### PR TITLE
directly call run_conversion

### DIFF
--- a/nwb_conversion_tools/converter.py
+++ b/nwb_conversion_tools/converter.py
@@ -23,13 +23,9 @@ class NWBConverter:
         """
         self.metadata = metadata
         self.source_paths = source_paths
-        self.nwbfile_saveloc = None
         # create self.nwbfile object
         if nwbfile is None:
             self.create_nwbfile(metadata['NWBFile'])
-        elif isinstance(nwbfile,str):
-            self.create_nwbfile(metadata['NWBFile'])
-            self.nwbfile_saveloc = nwbfile
         else:
             self.nwbfile = nwbfile
 
@@ -261,7 +257,7 @@ class NWBConverter:
                 index=index
             )
 
-    def save(self, to_path=None, read_check=True):
+    def save(self, to_path, read_check=True):
         """
         This method should not be overridden.
         Saves object self.nwbfile.
@@ -272,10 +268,6 @@ class NWBConverter:
         read_check: bool
             If True, try to read the file after writing
         """
-        if to_path is None:
-            to_path = self.nwbfile_saveloc
-        if to_path is None:
-            raise Exception('provice nwb save location as argument')
         with NWBHDF5IO(to_path, 'w') as io:
             io.write(self.nwbfile)
 

--- a/nwb_conversion_tools/converter.py
+++ b/nwb_conversion_tools/converter.py
@@ -23,10 +23,13 @@ class NWBConverter:
         """
         self.metadata = metadata
         self.source_paths = source_paths
-
+        self.nwbfile_saveloc = None
         # create self.nwbfile object
         if nwbfile is None:
             self.create_nwbfile(metadata['NWBFile'])
+        elif isinstance(nwbfile,str):
+            self.create_nwbfile(metadata['NWBFile'])
+            self.nwbfile_saveloc = nwbfile
         else:
             self.nwbfile = nwbfile
 
@@ -258,7 +261,7 @@ class NWBConverter:
                 index=index
             )
 
-    def save(self, to_path, read_check=True):
+    def save(self, to_path=None, read_check=True):
         """
         This method should not be overridden.
         Saves object self.nwbfile.
@@ -269,7 +272,10 @@ class NWBConverter:
         read_check: bool
             If True, try to read the file after writing
         """
-
+        if to_path is None:
+            to_path = self.nwbfile_saveloc
+        if to_path is None:
+            raise Exception('provice nwb save location as argument')
         with NWBHDF5IO(to_path, 'w') as io:
             io.write(self.nwbfile)
 

--- a/nwb_conversion_tools/gui/nwb_conversion_gui.py
+++ b/nwb_conversion_tools/gui/nwb_conversion_gui.py
@@ -30,8 +30,8 @@ import inspect
 #   -check kwargs
 
 class Application(QMainWindow):
-    def __init__(self, metafile=None, conversion_module=None, source_paths={},
-                 kwargs_fields={}, extension_modules={}, extension_forms={},
+    def __init__(self, metafile=None, conversion_module=None, source_paths=None,
+                 kwargs_fields=None, extension_modules=None, extension_forms=None,
                  show_add_del=False, nwbfile_loc=None, conversion_class=None):
         super().__init__()
         # Dictionary storing source files paths
@@ -46,7 +46,8 @@ class Application(QMainWindow):
         self.extension_modules = extension_modules
         # Updates name_to_gui_class with extension classes
         self.name_to_gui_class = name_to_gui_class
-        self.name_to_gui_class.update(extension_forms)
+        if extension_forms:
+            self.name_to_gui_class.update(extension_forms)
         # Temporary folder path
         self.temp_dir = tempfile.mkdtemp()
         # default nwbfile save location:
@@ -119,7 +120,7 @@ class Application(QMainWindow):
         l_grid1.addWidget(self.btn_nwb_file, 1, 4, 1, 1)
 
         # Adds custom files/dir paths fields
-        if len(self.source_paths.keys()) == 0:
+        if self.source_paths is None:
             self.lbl_source_file = QLabel('source files:')
             self.lin_source_file = QLineEdit('')
             self.btn_source_file = QPushButton()
@@ -153,7 +154,7 @@ class Application(QMainWindow):
             l_grid1.addWidget(self.group_source_paths, 3, 0, 1, 6)
 
         # Adds custom kwargs checkboxes
-        if len(self.kwargs_fields.keys()) > 0:
+        if self.kwargs_fields:
             self.group_kwargs = QGroupBox('KWARGS')
             self.grid_kwargs = QGridLayout()
             self.grid_kwargs.setColumnStretch(4, 1)
@@ -432,8 +433,9 @@ class Application(QMainWindow):
         """Loads NWB file on Ipython console"""
         # Imports extension modules
         imports_text = ""
-        for k, v in self.extension_modules.items():
-            imports_text += "\nfrom " + k + " import " + ", ".join(v)
+        if self.extension_modules:
+            for k, v in self.extension_modules.items():
+                imports_text += "\nfrom " + k + " import " + ", ".join(v)
         code = """
             import pynwb
             import os
@@ -692,8 +694,8 @@ if __name__ == '__main__':
 
 
 # If it is imported as a module
-def nwb_conversion_gui(metafile=None, conversion_module=None, source_paths={},
-                       kwargs_fields={}, extension_modules={}, extension_forms={},
+def nwb_conversion_gui(metafile=None, conversion_module=None, source_paths=None,
+                       kwargs_fields=None, extension_modules=None, extension_forms=None,
                        show_add_del=False, nwbfile_loc=None, conversion_class=None):
     """Sets up QT application."""
     if conversion_module:

--- a/nwb_conversion_tools/gui/nwb_conversion_gui.py
+++ b/nwb_conversion_tools/gui/nwb_conversion_gui.py
@@ -103,7 +103,9 @@ class Application(QMainWindow):
 
         self.lbl_nwb_file = QLabel('Output nwb file:')
         self.lbl_nwb_file.setToolTip("Path to the NWB file that will be created.")
-        self.lin_nwb_file = QLineEdit(self.nwbfile_loc)
+        self.lin_nwb_file = QLineEdit('')
+        if self.nwbfile_loc is not None:
+            self.lin_nwb_file = QLineEdit(self.nwbfile_loc)
         self.btn_nwb_file = QPushButton()
         self.btn_nwb_file.setIcon(self.style().standardIcon(QStyle.SP_DialogOpenButton))
         self.btn_nwb_file.clicked.connect(self.load_nwb_file)
@@ -657,6 +659,8 @@ class ConversionFunctionThread(QtCore.QThread):
 
     def run(self):
         #try:
+        if not self.parent.lin_nwb_file.text():
+            raise ValueError('select a save location for nwbfile')
         if self.parent.conversion_module_path:# if not an empty string (if value was selected from gui)
             mod_file = self.parent.conversion_module_path
             spec = importlib.util.spec_from_file_location(os.path.basename(mod_file).strip('.py'), mod_file)
@@ -704,8 +708,6 @@ def nwb_conversion_gui(metafile=None, conversion_module=None, source_paths=None,
     app = QtCore.QCoreApplication.instance()
     if conversion_class is None and conversion_module is None:
         raise Exception('provide one of conversion_module:str or conversion_class:class')
-    if nwbfile_loc is None:
-        nwbfile_loc = os.path.join(os.getcwd(),conversion_class.__name__ + '_nwbfile_gui.nwb')
     if app is None:
         app = QApplication(sys.argv)  # instantiate a QtGui (holder for the app)
     Application(

--- a/nwb_conversion_tools/gui/nwb_conversion_gui.py
+++ b/nwb_conversion_tools/gui/nwb_conversion_gui.py
@@ -32,7 +32,7 @@ import inspect
 class Application(QMainWindow):
     def __init__(self, metafile=None, conversion_module='', source_paths={},
                  kwargs_fields={}, extension_modules={}, extension_forms={},
-                 show_add_del=False, nwb_file=None, conversion_class=None):
+                 show_add_del=False, nwbfile_loc=None, conversion_class=None):
         super().__init__()
         # Dictionary storing source files paths
         self.source_paths = source_paths
@@ -50,7 +50,7 @@ class Application(QMainWindow):
         # Temporary folder path
         self.temp_dir = tempfile.mkdtemp()
         # default nwbfile save location:
-        self.nwb_file = nwb_file
+        self.nwbfile_loc = nwbfile_loc
         # conversion_class:
         self.conversion_class = conversion_class
 
@@ -666,9 +666,9 @@ class ConversionFunctionThread(QtCore.QThread):
                     break
         metadata = self.parent.read_metadata_from_form()
         fileloc = list(self.parent.source_paths.values())[0]['path']
-        conversion_obj = self.parent.conversion_class(fileloc, self.parent.lin_nwb_file.text(), metadata)
+        conversion_obj = self.parent.conversion_class(fileloc, None, metadata)
         conversion_obj.run_conversion()
-        conversion_obj.save()
+        conversion_obj.save(self.parent.lin_nwb_file.text())
         #    self.error = None
         #except Exception as error:
         #    self.error = error
@@ -692,13 +692,13 @@ if __name__ == '__main__':
 # If it is imported as a module
 def nwb_conversion_gui(metafile=None, conversion_module='', source_paths={},
                        kwargs_fields={}, extension_modules={}, extension_forms={},
-                       show_add_del=False, nwbfile=None, conversion_class=None):
+                       show_add_del=False, nwbfile_loc=None, conversion_class=None):
     """Sets up QT application."""
     app = QtCore.QCoreApplication.instance()
     if conversion_class is None and conversion_module=='':
         raise Exception('provide one of conversion_module:str or conversion_class:class')
-    if nwbfile is None:
-        nwbfile = os.path.join(os.getcwd(),conversion_class.__name__ + '_nwbfile_gui.nwb')
+    if nwbfile_loc is None:
+        nwbfile_loc = os.path.join(os.getcwd(),conversion_class.__name__ + '_nwbfile_gui.nwb')
     if app is None:
         app = QApplication(sys.argv)  # instantiate a QtGui (holder for the app)
     Application(
@@ -709,7 +709,7 @@ def nwb_conversion_gui(metafile=None, conversion_module='', source_paths={},
         extension_modules=extension_modules,
         extension_forms=extension_forms,
         show_add_del=show_add_del,
-        nwb_file=nwbfile,
+        nwbfile_loc=nwbfile_loc,
         conversion_class=conversion_class
     )
     sys.exit(app.exec_())

--- a/nwb_conversion_tools/ophys/schnitzerlab/cnmfeconverter.py
+++ b/nwb_conversion_tools/ophys/schnitzerlab/cnmfeconverter.py
@@ -16,15 +16,3 @@ class Cnmfe2NWB(SegmentationExtractor2NWBConverter):
             raise Exception('provide a *cnmfe*.mat file source')
         self.segext_obj = CnmfeSegmentationExtractor(source_path[0])  # source_path=['*\folder.sima']
         super(Cnmfe2NWB, self).__init__(source_path, nwbfile, metadata)
-
-def conversion_function(source_paths=None, f_nwb=None, metadata=None):
-    if isinstance(f_nwb, str):
-        f_nwb = None
-    nwbloc =  r'C:\Users\Saksham\Google Drive (sxs1790@case.edu)\NWB\nwb-conversion-tools\tests\Ophys\datasets\test_nwb_cnmfe_gui.nwb'
-    fileloc = list(source_paths.values())[0]['path']
-    obj = Cnmfe2NWB(fileloc, None, metadata)
-
-    obj.run_conversion()
-
-    obj.save(nwbloc)
-    return obj.nwbfile

--- a/nwb_conversion_tools/ophys/schnitzerlab/extractconverter.py
+++ b/nwb_conversion_tools/ophys/schnitzerlab/extractconverter.py
@@ -15,16 +15,3 @@ class Extract2NWB(SegmentationExtractor2NWBConverter):
             raise Exception('provide a .mat file source')
         self.segext_obj = ExtractSegmentationExtractor(source_path[0])  # source_path=['*\folder.sima']
         super(Extract2NWB, self).__init__(source_path, nwbfile, metadata)
-
-
-def conversion_function(source_paths=None, f_nwb=None, metadata=None):
-    if isinstance(f_nwb, str):
-        f_nwb = None
-    nwbloc =  r'C:\Users\Saksham\Google Drive (sxs1790@case.edu)\NWB\nwb-conversion-tools\tests\Ophys\datasets\test_nwb_extract_gui.nwb'
-    fileloc = list(source_paths.values())[0]['path']
-    obj = Extract2NWB(fileloc, None, metadata)
-
-    obj.run_conversion()
-
-    obj.save(nwbloc)
-    return obj.nwbfile

--- a/nwb_conversion_tools/ophys/sima/simaconverter.py
+++ b/nwb_conversion_tools/ophys/sima/simaconverter.py
@@ -15,19 +15,3 @@ class Sima2NWB(SegmentationExtractor2NWBConverter):
         self.segext_obj = SimaSegmentationExtractor(source_path[0])  # source_path=['*\folder.sima']
         super(Sima2NWB, self).__init__(source_path, nwbfile, metadata)
 
-
-def conversion_function(source_paths=None, f_nwb=None, metadata=None):
-    # print(source_paths)
-    # print(type(f_nwb))
-    # print(len(f_nwb))
-    # print(type(metadata))
-    print(type(metadata['Ophys']['DfOverF']['roi_response_series'][0]['rate']))
-    with open(
-            r'C:\Users\Saksham\Google Drive (sxs1790@case.edu)\NWB\nwb-conversion-tools\tests\Ophys\datasets\nct_gui_in.yaml',
-            'w') as f:
-        yaml.dump(metadata, f)
-    if isinstance(f_nwb, str):
-        f_nwb = None
-    print(list(source_paths.values())[0]['path'], f_nwb, sep='\n\n')
-
-    # Sima2NWB(list(source_paths.values())[0]['path'], f_nwb, metadata).run_conversion()

--- a/nwb_conversion_tools/ophys/suite2p/suite2pconverter.py
+++ b/nwb_conversion_tools/ophys/suite2p/suite2pconverter.py
@@ -19,15 +19,3 @@ class Suite2p2NWB(SegmentationExtractor2NWBConverter):
             roi_resp_dict[i]=self.segext_obj.get_traces(name=i)
         self.segext_obj.roi_response = roi_resp_dict
         super(Suite2p2NWB, self).__init__(source_path, nwbfile, metadata)
-
-def conversion_function(source_paths=None, f_nwb=None, metadata=None):
-    if isinstance(f_nwb, str):
-        f_nwb = None
-    nwbloc =  r'C:\Users\Saksham\Google Drive (sxs1790@case.edu)\NWB\nwb-conversion-tools\tests\Ophys\datasets\test_nwb_suite2p_gui.nwb'
-    fileloc = list(source_paths.values())[0]['path']
-    obj = Suite2p2NWB(fileloc, None, metadata)
-
-    obj.run_conversion()
-
-    obj.save(nwbloc)
-    return obj.nwbfile


### PR DESCRIPTION
use the class to call the run_conversion function within. 
However, i've still kept the older conversion_path, which is redundant, but will only be useful if the user selects another conversion script path from file drop down menu in the gui. 