### PR TITLE
Gui fix3

### DIFF
--- a/nwb_conversion_tools/gui/classes/forms_basic.py
+++ b/nwb_conversion_tools/gui/classes/forms_basic.py
@@ -50,7 +50,7 @@ class BasicFormCollapsible(CollapsibleBox):
             # Required fields get a red star in their label
             if 'default' not in field:
                 required = True
-                default = 'required: '+ str(field['type'])
+                default = ''
             # Optional fields
             else:
                 required = False
@@ -64,6 +64,8 @@ class BasicFormCollapsible(CollapsibleBox):
                 continue
             # String types
             if field['type'] is str:
+                if not default:
+                    default = 'unfilled field value'
                 self.fields_info.append({
                     'name': field['name'],
                     'type': 'str',
@@ -74,6 +76,8 @@ class BasicFormCollapsible(CollapsibleBox):
                 })
             # Float types
             elif field['type'] in ('float', float):
+                if not default:
+                    default = float('NaN')
                 self.fields_info.append({
                     'name': field['name'],
                     'type': 'float',
@@ -105,20 +109,11 @@ class BasicFormCollapsible(CollapsibleBox):
             # String types
             if field['type'] == 'str':
                 form = QLineEdit('')
-                if field['required']:
-                    form.setPlaceholderText(field['default'])
-                else:
-                    form.setText(field['default'])
+                form.setText(field['default'])
             # Float types
             elif field['type'] == 'float':
-                if field['default'] is not None:
-                    form = QLineEdit('')
-                    if field['required']:
-                        form.setPlaceholderText(str(field['default']))
-                    else:
-                        form.setText(str(field['default']))
-                else:
-                    form = QLineEdit(None)
+                form = QLineEdit('')
+                form.setText(str(field['default']))
                 form.setValidator(validator_float)
             # Link types
             elif field['type'] == 'link':
@@ -247,7 +242,7 @@ class BasicFormFixed(QGroupBox):
             # Required fields get a red star in their label
             if 'default' not in field:
                 required = True
-                default = 'required: '+ str(field['type'])
+                default = ''
             # Optional fields
             else:
                 required = False
@@ -261,6 +256,8 @@ class BasicFormFixed(QGroupBox):
                 continue
             # String types
             if field['type'] is str:
+                if not default:
+                    default = 'unfilled field value'
                 self.fields_info.append({
                     'name': field['name'],
                     'type': 'str',
@@ -271,6 +268,8 @@ class BasicFormFixed(QGroupBox):
                 })
             # Float types
             elif field['type'] in ('float', float):
+                if not default:
+                    default = float('NaN')
                 self.fields_info.append({
                     'name': field['name'],
                     'type': 'float',
@@ -302,20 +301,11 @@ class BasicFormFixed(QGroupBox):
             # String types
             if field['type'] == 'str':
                 form = QLineEdit('')
-                if field['required']:
-                    form.setPlaceholderText(field['default'])
-                else:
-                    form.setText(field['default'])
+                form.setText(field['default'])
             # Float types
             elif field['type'] == 'float':
-                if field['default'] is not None:
-                    form = QLineEdit('')
-                    if field['required']:
-                        form.setPlaceholderText(str(field['default']))
-                    else:
-                        form.setText(str(field['default']))
-                else:
-                    form = QLineEdit(None)
+                form = QLineEdit('')
+                form.setText(str(field['default']))
                 form.setValidator(validator_float)
             # Link types
             elif field['type'] == 'link':

--- a/nwb_conversion_tools/gui/classes/forms_basic.py
+++ b/nwb_conversion_tools/gui/classes/forms_basic.py
@@ -50,7 +50,7 @@ class BasicFormCollapsible(CollapsibleBox):
             # Required fields get a red star in their label
             if 'default' not in field:
                 required = True
-                default = ''
+                default = 'required: '+ str(field['type'])
             # Optional fields
             else:
                 required = False
@@ -105,11 +105,20 @@ class BasicFormCollapsible(CollapsibleBox):
             # String types
             if field['type'] == 'str':
                 form = QLineEdit('')
-                form.setText(field['default'])
+                if field['required']:
+                    form.setPlaceholderText(field['default'])
+                else:
+                    form.setText(field['default'])
             # Float types
             elif field['type'] == 'float':
-                form = QLineEdit('')
-                form.setText(str(field['default']))
+                if field['default'] is not None:
+                    form = QLineEdit('')
+                    if field['required']:
+                        form.setPlaceholderText(str(field['default']))
+                    else:
+                        form.setText(str(field['default']))
+                else:
+                    form = QLineEdit(None)
                 form.setValidator(validator_float)
             # Link types
             elif field['type'] == 'link':
@@ -234,7 +243,7 @@ class BasicFormFixed(QGroupBox):
             # Required fields get a red star in their label
             if 'default' not in field:
                 required = True
-                default = ''
+                default = 'required: '+ str(field['type'])
             # Optional fields
             else:
                 required = False
@@ -289,11 +298,20 @@ class BasicFormFixed(QGroupBox):
             # String types
             if field['type'] == 'str':
                 form = QLineEdit('')
-                form.setText(field['default'])
+                if field['required']:
+                    form.setPlaceholderText(field['default'])
+                else:
+                    form.setText(field['default'])
             # Float types
             elif field['type'] == 'float':
-                form = QLineEdit('')
-                form.setText(str(field['default']))
+                if field['default'] is not None:
+                    form = QLineEdit('')
+                    if field['required']:
+                        form.setPlaceholderText(str(field['default']))
+                    else:
+                        form.setText(str(field['default']))
+                else:
+                    form = QLineEdit(None)
                 form.setValidator(validator_float)
             # Link types
             elif field['type'] == 'link':

--- a/nwb_conversion_tools/gui/classes/forms_basic.py
+++ b/nwb_conversion_tools/gui/classes/forms_basic.py
@@ -50,7 +50,7 @@ class BasicFormCollapsible(CollapsibleBox):
             # Required fields get a red star in their label
             if 'default' not in field:
                 required = True
-                default = ''
+                default = 'required: '+ str(field['type'])
             # Optional fields
             else:
                 required = False
@@ -64,8 +64,6 @@ class BasicFormCollapsible(CollapsibleBox):
                 continue
             # String types
             if field['type'] is str:
-                if not default:
-                    default = 'unfilled field value'
                 self.fields_info.append({
                     'name': field['name'],
                     'type': 'str',
@@ -76,8 +74,6 @@ class BasicFormCollapsible(CollapsibleBox):
                 })
             # Float types
             elif field['type'] in ('float', float):
-                if not default:
-                    default = float('NaN')
                 self.fields_info.append({
                     'name': field['name'],
                     'type': 'float',
@@ -109,11 +105,20 @@ class BasicFormCollapsible(CollapsibleBox):
             # String types
             if field['type'] == 'str':
                 form = QLineEdit('')
-                form.setText(field['default'])
+                if field['required']:
+                    form.setPlaceholderText(field['default'])
+                else:
+                    form.setText(field['default'])
             # Float types
             elif field['type'] == 'float':
-                form = QLineEdit('')
-                form.setText(str(field['default']))
+                if field['default'] is not None:
+                    form = QLineEdit('')
+                    if field['required']:
+                        form.setPlaceholderText(str(field['default']))
+                    else:
+                        form.setText(str(field['default']))
+                else:
+                    form = QLineEdit(None)
                 form.setValidator(validator_float)
             # Link types
             elif field['type'] == 'link':
@@ -242,7 +247,7 @@ class BasicFormFixed(QGroupBox):
             # Required fields get a red star in their label
             if 'default' not in field:
                 required = True
-                default = ''
+                default = 'required: '+ str(field['type'])
             # Optional fields
             else:
                 required = False
@@ -256,8 +261,6 @@ class BasicFormFixed(QGroupBox):
                 continue
             # String types
             if field['type'] is str:
-                if not default:
-                    default = 'unfilled field value'
                 self.fields_info.append({
                     'name': field['name'],
                     'type': 'str',
@@ -268,8 +271,6 @@ class BasicFormFixed(QGroupBox):
                 })
             # Float types
             elif field['type'] in ('float', float):
-                if not default:
-                    default = float('NaN')
                 self.fields_info.append({
                     'name': field['name'],
                     'type': 'float',
@@ -301,11 +302,20 @@ class BasicFormFixed(QGroupBox):
             # String types
             if field['type'] == 'str':
                 form = QLineEdit('')
-                form.setText(field['default'])
+                if field['required']:
+                    form.setPlaceholderText(field['default'])
+                else:
+                    form.setText(field['default'])
             # Float types
             elif field['type'] == 'float':
-                form = QLineEdit('')
-                form.setText(str(field['default']))
+                if field['default'] is not None:
+                    form = QLineEdit('')
+                    if field['required']:
+                        form.setPlaceholderText(str(field['default']))
+                    else:
+                        form.setText(str(field['default']))
+                else:
+                    form = QLineEdit(None)
                 form.setValidator(validator_float)
             # Link types
             elif field['type'] == 'link':

--- a/nwb_conversion_tools/gui/classes/forms_basic.py
+++ b/nwb_conversion_tools/gui/classes/forms_basic.py
@@ -180,7 +180,11 @@ class BasicFormCollapsible(CollapsibleBox):
                 try:
                     metadata[name] = float(group.text())
                 except:
-                    metadata[name] = group.text()
+                    if group.text() == '':
+                        # metadata[name] = None
+                        continue
+                    else:
+                        metadata[name] = group.text()
             if isinstance(group, QComboBox):
                 metadata[name] = str(group.currentText())
             if isinstance(group, QGroupBox):
@@ -374,7 +378,11 @@ class BasicFormFixed(QGroupBox):
                 try:
                     metadata[name] = float(group.text())
                 except:
-                    metadata[name] = group.text()
+                    if group.text()=='':
+                        # metadata[name] = None
+                        continue
+                    else:
+                        metadata[name] = group.text()
             if isinstance(group, QComboBox):
                 metadata[name] = str(group.currentText())
             if isinstance(group, QGroupBox):


### PR DESCRIPTION
There are two fixes in this: (could not further break them into two seperate PRs without undoing some changes):
1. Required fields: if unfilled, will have a placeholder. This is in addition to the red asterisk. Just thought this might grab user attention more while filling up form. 
2. Not required fields: these have default values (defined in pynwb); but those that have a NoneType default, the form field now remains empty instead of filling with a text 'None'. This was necessary, since prior to this, while reading the form to write to the dict, it read it as a string instead of NoneType. 