### PR TITLE
quick fix to importing under the new data interface file structure

### DIFF
--- a/nwb_conversion_tools/__init__.py
+++ b/nwb_conversion_tools/__init__.py
@@ -1,1 +1,2 @@
 from .nwbconverter import NWBConverter
+from .datainterfaces import *


### PR DESCRIPTION
@bendichter Not quite as sophisticated as the way SpikeExtractors initializes the extensive list of specialized extractors, but something like this is still necessary for the current file structure.