### PR TITLE
Refactor interface metadata

### DIFF
--- a/nwb_conversion_tools/basedatainterface.py
+++ b/nwb_conversion_tools/basedatainterface.py
@@ -17,7 +17,7 @@ class BaseDataInterface:
         pass
 
     @abstractmethod
-    def get_metadata(self, metadata):
+    def get_metadata(self):
         pass
 
     @abstractmethod

--- a/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
@@ -27,7 +27,7 @@ class NeuroscopeRecordingInterface(BaseRecordingExtractorInterface):
         all_shank_channels = np.concatenate(shank_channels)
         all_shank_channels.sort()
         shank_electrode_number = [x for channels in shank_channels for x, _ in enumerate(channels)]
-        shank_group_name = ["shank{}".format(n+1) for n, channels in enumerate(shank_channels) for _ in channels]
+        shank_group_name = [f"shank{n+1}" for n, channels in enumerate(shank_channels) for _ in channels]
 
         re_metadata = dict(
             Ecephys=dict(

--- a/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
@@ -73,3 +73,8 @@ class NeuroscopeSortingInterface(BaseSortingExtractorInterface):
     """Primary data interface class for converting a NeuroscopeSortingExtractor."""
 
     SX = se.NeuroscopeMultiSortingExtractor
+
+    def get_metadata():
+        """Retrieve UnitProperties metadata specific to the Neuroscope format."""
+        # TODO
+        raise NotImplementedError

--- a/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
@@ -14,12 +14,13 @@ class NeuroscopeRecordingInterface(BaseRecordingExtractorInterface):
 
     RX = se.NeuroscopeRecordingExtractor
 
-    def get_metadata(self, metadata):
+    def get_metadata(self):
         """Retrieve Ecephys metadata specific to the Neuroscope format."""
-        session_path = Path(self.input_args['file_path'])
+        file_path = Path(self.input_args['file_path'])
+        session_path = file_path.parent
         session_id = session_path.stem
         xml_filepath = session_path / f"{session_id}.xml"
-        root = et.parse(xml_filepath).getroot()
+        root = et.parse(str(xml_filepath.absolute())).getroot()
         shank_channels = [[int(channel.text)
                           for channel in group.find('channels')]
                           for group in root.find('spikeDetection').find('channelGroups').findall('group')]
@@ -66,7 +67,7 @@ class NeuroscopeRecordingInterface(BaseRecordingExtractorInterface):
                 )
             )
         )
-        dict_deep_update(metadata, re_metadata)
+        return re_metadata
 
 
 class NeuroscopeSortingInterface(BaseSortingExtractorInterface):
@@ -74,7 +75,7 @@ class NeuroscopeSortingInterface(BaseSortingExtractorInterface):
 
     SX = se.NeuroscopeMultiSortingExtractor
 
-    def get_metadata():
+    def get_metadata(self):
         """Retrieve UnitProperties metadata specific to the Neuroscope format."""
         # TODO
-        raise NotImplementedError
+        return dict()

--- a/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
@@ -78,4 +78,4 @@ class NeuroscopeSortingInterface(BaseSortingExtractorInterface):
     def get_metadata(self):
         """Retrieve UnitProperties metadata specific to the Neuroscope format."""
         # TODO
-        return dict()
+        raise NotImplementedError

--- a/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
@@ -1,13 +1,76 @@
 """Authors: Cody Baker and Ben Dichter."""
 import spikeextractors as se
+from lxml import etree as et
+from pathlib import Path
+from itertools import compress
+import numpy as np
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
+from ..utils import dict_deep_update
 
 
 class NeuroscopeRecordingInterface(BaseRecordingExtractorInterface):
+    """Primary data interface class for converting a NeuroscopeRecordingExtractor."""
+
     RX = se.NeuroscopeRecordingExtractor
+
+    def get_metadata(self, metadata):
+        """Retrieve Ecephys metadata specific to the Neuroscope format."""
+        session_path = Path(self.input_args['file_path'])
+        session_id = session_path.stem
+        xml_filepath = session_path / f"{session_id}.xml"
+        root = et.parse(xml_filepath).getroot()
+        shank_channels = [[int(channel.text)
+                          for channel in group.find('channels')]
+                          for group in root.find('spikeDetection').find('channelGroups').findall('group')]
+        all_shank_channels = np.concatenate(shank_channels)
+        all_shank_channels.sort()
+        shank_electrode_number = [x for channels in shank_channels for x, _ in enumerate(channels)]
+        shank_group_name = ["shank{}".format(n+1) for n, channels in enumerate(shank_channels) for _ in channels]
+
+        re_metadata = dict(
+            Ecephys=dict(
+                subset_channels=all_shank_channels,
+                Device=[
+                    dict(
+                        description=session_id + '.xml'
+                    )
+                ],
+                ElectrodeGroup=[
+                    dict(
+                        name=f'shank{n+1}',
+                        description=f"shank{n+1} electrodes"
+                    )
+                    for n, _ in enumerate(shank_channels)
+                ],
+                Electrodes=[
+                    dict(
+                        name='shank_electrode_number',
+                        description="0-indexed channel within a shank.",
+                        data=shank_electrode_number
+                    ),
+                    dict(
+                        name='group',
+                        description="A reference to the ElectrodeGroup this electrode is a part of.",
+                        data=shank_group_name
+                    ),
+                    dict(
+                        name='group_name',
+                        description="The name of the ElectrodeGroup this electrode is a part of.",
+                        data=shank_group_name
+                    )
+                ],
+                ElectricalSeries=dict(
+                    name='ElectricalSeries',
+                    description="raw acquisition traces"
+                )
+            )
+        )
+        dict_deep_update(metadata, re_metadata)
 
 
 class NeuroscopeSortingInterface(BaseSortingExtractorInterface):
+    """Primary data interface class for converting a NeuroscopeSortingExtractor."""
+
     SX = se.NeuroscopeMultiSortingExtractor

--- a/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
@@ -2,7 +2,6 @@
 import spikeextractors as se
 from lxml import etree as et
 from pathlib import Path
-from itertools import compress
 import numpy as np
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface

--- a/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
@@ -5,4 +5,11 @@ from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 
 
 class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
+    """Primary data interface class for converting a NeuroscopeRecordingExtractor."""
+
     RX = SpikeGLXRecordingExtractor
+
+    def get_metadata():
+        """Retrieve Ecephys metadata specific to the SpikeGLX format."""
+        # TODO
+        raise NotImplementedError

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -5,22 +5,6 @@ from pynwb import NWBHDF5IO, NWBFile
 from pynwb.file import Subject
 from datetime import datetime
 import uuid
-import collections.abc
-import numpy as np
-
-
-def dict_deep_update(d, u):
-    for k, v in u.items():
-        if isinstance(v, collections.abc.Mapping):
-            d[k] = dict_deep_update(d.get(k, {}), v)
-        elif isinstance(v, list):
-            d[k] = d.get(k, []) + v
-            # Remove repeated items if they exist
-            if len(v) > 0 and not isinstance(v[0], dict):
-                d[k] = list(np.unique(d[k]))
-        else:
-            d[k] = v
-    return d
 
 
 class NWBConverter:
@@ -80,7 +64,6 @@ class NWBConverter:
 
     def run_conversion(self, metadata_dict, nwbfile_path=None, save_to_file=True, stub_test=False):
         """Build nwbfile object, auto-populate with minimal values if missing."""
-
         nwbfile_kwargs = dict(
                 session_description="no description",
                 identifier=str(uuid.uuid4()),
@@ -97,7 +80,7 @@ class NWBConverter:
 
         # Run data interfaces data conversion
         for name, data_interface in self.data_interface_objects.items():
-            data_interface.convert_data(nwbfile, metadata_dict[name], stub_test)
+            data_interface.convert_data(nwbfile, metadata_dict, stub_test)
 
         if save_to_file:
             if nwbfile_path is None:

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -1,6 +1,6 @@
 """Authors: Cody Baker and Ben Dichter."""
 from .utils import (get_schema_from_hdmf_class, get_root_schema, get_input_schema,
-                    get_schema_for_NWBFile)
+                    get_schema_for_NWBFile, dict_deep_update)
 from pynwb import NWBHDF5IO, NWBFile
 from pynwb.file import Subject
 from datetime import datetime

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -56,8 +56,8 @@ class NWBConverter:
         """Auto-fill as much of the metadata as possible. Must comply with metadata schema."""
         metadata = dict()
         for interface in self.data_interface_objects.values():
-            interface_metadada = interface.get_metadata()
-            metadata = dict_deep_update(metadata, interface_metadada)
+            interface_metadata = interface.get_metadata()
+            metadata = dict_deep_update(metadata, interface_metadata)
         return metadata
 
     def run_conversion(self, metadata_dict, nwbfile_path=None, save_to_file=True, stub_test=False):

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -50,16 +50,14 @@ class NWBConverter:
         for name, data_interface in self.data_interface_objects.items():
             interface_schema = data_interface.get_metadata_schema()
             metadata_schema = dict_deep_update(metadata_schema, interface_schema)
-
         return metadata_schema
 
     def get_metadata(self):
         """Auto-fill as much of the metadata as possible. Must comply with metadata schema."""
         metadata = dict()
-        for interface_name, interface in self.data_interface_objects.items():
-            interface_metadada = interface.get_metadata(metadata=metadata)
+        for interface in self.data_interface_objects.values():
+            interface_metadada = interface.get_metadata()
             metadata = dict_deep_update(metadata, interface_metadada)
-
         return metadata
 
     def run_conversion(self, metadata_dict, nwbfile_path=None, save_to_file=True, stub_test=False):

--- a/nwb_conversion_tools/utils.py
+++ b/nwb_conversion_tools/utils.py
@@ -1,9 +1,25 @@
 """Authors: Cody Baker, Ben Dichter and Luiz Tauffer."""
 import inspect
 from datetime import datetime
+import collections.abc
 
 import numpy as np
 import pynwb
+
+
+def dict_deep_update(d, u):
+    """Perform an update to all nested keys of dictionary d from dictionary u."""
+    for k, v in u.items():
+        if isinstance(v, collections.abc.Mapping):
+            d[k] = dict_deep_update(d.get(k, {}), v)
+        elif isinstance(v, list):
+            d[k] = d.get(k, []) + v
+            # Remove repeated items if they exist
+            if len(v) > 0 and not isinstance(v[0], dict):
+                d[k] = list(np.unique(d[k]))
+        else:
+            d[k] = v
+    return d
 
 
 def get_base_schema(tag=None):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='nwb-conversion-tools',
-    version='0.3.4',
+    version='0.4.0',
     description='Convert data to nwb',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
@bendichter The first of the major metadata handling changes is included in this PR. Subsequent ones will include the `NeuroscopeSorting` and `SpikeGLXRecording`.

Overall changes are built to reflect the structural shift of metadata auto-population away from specific `NWBConverter`s into the individual `DataInterfaces`.

This will render several past conversion scripts in other repositories incompatible with the current design; I have locally saved a branch of the current pre-metadata patch on my end for quick side-reversion, if that is ever needed for those conversions.

@luiztauffer I will also be uploading an example `RecordingExtractor` template tomorrow that uses this structure and showcases how, per our discussion, it ought to flow to keep an eye out for that. Also let me know if this PR breaks anything else on your end currently.

I also moved the `deep_dict_update` function to the `utils` as it is very useful for interacting with the new metadata structure (that is no longer nested by data interface name).