### PR TITLE
get_metadata() for SpikeGLX

### DIFF
--- a/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
@@ -51,11 +51,6 @@ class NeuroscopeRecordingInterface(BaseRecordingExtractorInterface):
                         data=shank_electrode_number
                     ),
                     dict(
-                        name='group',
-                        description="A reference to the ElectrodeGroup this electrode is a part of.",
-                        data=shank_group_name
-                    ),
-                    dict(
                         name='group_name',
                         description="The name of the ElectrodeGroup this electrode is a part of.",
                         data=shank_group_name

--- a/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
@@ -6,12 +6,12 @@ from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 
 
 class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
-    """Primary data interface class for converting the SpikeGLX format."""
+    """Primary data interface class for converting the high-pass (ap) SpikeGLX format."""
 
     RX = SpikeGLXRecordingExtractor
 
     def get_metadata(self):
-        """Auto-populate as much metadata as possible from the SpikeGLX format."""
+        """Auto-populate as much metadata as possible from the high-pass (ap) SpikeGLX format."""
         file_path = Path(self.input_args['file_path'])
         session_id = file_path.parent.stem
 
@@ -27,7 +27,7 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
             Ecephys=dict(
                 Device=[
                     dict(
-                        description=session_id + '.ap.meta'
+                        description=f"More details for the high-pass (ap) data found in {session_id}.ap.meta!"
                     )
                 ],
                 ElectrodeGroup=[
@@ -51,7 +51,7 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
                 ],
                 ElectricalSeries=dict(
                     name='ElectricalSeries',
-                    description="Raw acquisition traces."
+                    description="Raw acquisition traces for the high-pass (ap) SpikeGLX data."
                 )
             )
         )

--- a/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
@@ -1,15 +1,63 @@
 """Authors: Cody Baker and Ben Dichter."""
+from pathlib import Path
 from spikeextractors import SpikeGLXRecordingExtractor
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 
 
 class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
-    """Primary data interface class for converting a NeuroscopeRecordingExtractor."""
+    """Primary data interface class for converting the SpikeGLX format."""
 
     RX = SpikeGLXRecordingExtractor
 
-    def get_metadata():
-        """Retrieve Ecephys metadata specific to the SpikeGLX format."""
-        # TODO
-        raise NotImplementedError
+    def get_metadata(self):
+        """Auto-populate as much metadata as possible from the SpikeGLX format."""
+        file_path = Path(self.input_args['file_path'])
+        session_id = file_path.parent.stem
+
+        n_shanks = int(self.recording_extractor._meta['snsShankMap'][1])
+        if n_shanks > 1:
+            raise NotImplementedError("SpikeGLX metadata for more than a single shank is not yet supported.")
+
+        channels = self.recording_extractor.get_channel_ids()
+        shank_electrode_number = channels
+        shank_group_name = ["Shank1" for x in channels]
+
+        re_metadata = dict(
+            Ecephys=dict(
+                Device=[
+                    dict(
+                        description=session_id + '.ap.meta'
+                    )
+                ],
+                ElectrodeGroup=[
+                    dict(
+                        name='Shank1',
+                        description="Shank1 electrodes."
+                    )
+                    for n in range(n_shanks)
+                ],
+                Electrodes=[
+                    dict(
+                        name='shank_electrode_number',
+                        description="0-indexed channel within a shank.",
+                        data=shank_electrode_number
+                    ),
+                    dict(
+                        name='group',
+                        description="A reference to the ElectrodeGroup this electrode is a part of.",
+                        data=shank_group_name
+                    ),
+                    dict(
+                        name='group_name',
+                        description="The name of the ElectrodeGroup this electrode is a part of.",
+                        data=shank_group_name
+                    )
+                ],
+                ElectricalSeries=dict(
+                    name='ElectricalSeries',
+                    description="Raw acquisition traces."
+                )
+            )
+        )
+        return re_metadata

--- a/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
@@ -44,11 +44,6 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
                         data=shank_electrode_number
                     ),
                     dict(
-                        name='group',
-                        description="A reference to the ElectrodeGroup this electrode is a part of.",
-                        data=shank_group_name
-                    ),
-                    dict(
                         name='group_name',
                         description="The name of the ElectrodeGroup this electrode is a part of.",
                         data=shank_group_name


### PR DESCRIPTION
Though in principle, it appears as if the [SpikeGLX can have multiple shanks](https://github.com/billkarsh/SpikeGLX/blob/master/Markdown/UserManual.md#shank-map), the exact formatting of the channel mapping and extraction thereof would be unreliable without a good prototype file to test on.

The current implementation uses the default maps of single shanks.