### PR TITLE
alternative option for adding a recording extractor to an existing NWBConverter object

### DIFF
--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import uuid
 
 
-def recording_extractor_to_data_interface_class(RX):
+def recording_extractor_class_to_data_interface_class(RX):
     """Auxilliary function for automatically generating interface class from RecordingExtractor class."""
 
     def __init__(self, extractor):
@@ -113,7 +113,7 @@ class NWBConverter:
     def add_extractor(self, extractor):
         """Add a SpikeExtractor object into the converter; called after initialization but before run_conversion."""
         if isinstance(extractor, se.RecordingExtractor):
-            interface_class = recording_extractor_to_data_interface_class(type(extractor))
+            interface_class = recording_extractor_class_to_data_interface_class(type(extractor))
             interface_name = interface_class.__name__.replace("ExtractorDataInterface", "")
             self.data_interface_objects.update({interface_name: interface_class(extractor)})
             # Add to data_interface_classes as well? Wouldn't be necessary for running the conversion


### PR DESCRIPTION
@alejoe91 @bendichter This illustrates the structure of another idea I had for adding an extractor object within a local environment directly into an instance of a specific inheritor of the `NWBConverter` class prior to run_conversion; this is an alternative to the dumping (pickle) method which had its own interface.

It's not fully debugged but still shows the idea; also uses the metaprograming approach Ben suggested on [this PR](https://github.com/catalystneuro/nwb-conversion-tools/pull/70).

A further (and necessary) improvement would be to check if the given interface exists in this repo and if so, just specify that class instead of making our own through type: this would be very important for inheriting `get_metadata` functions which correspond to a specific `RecordingExtractor`. (Just not sure what the best way to do that would be, will keep thinking about it)