### PR TITLE
improved the stubbing of the BaseSortingExtractor

### DIFF
--- a/nwb_conversion_tools/basesortingextractorinterface.py
+++ b/nwb_conversion_tools/basesortingextractorinterface.py
@@ -36,12 +36,15 @@ class BaseSortingExtractorInterface(BaseDataInterface):
 
         property_descriptions = {}
         if stub_test:
-            # No easy way to lazily figure out upper bound on frames for SortingExtractor?
-            end_frame = 100
-            stub_sorting_extractor = se.SubSortingExtractor(self.sorting_extractor,
-                                                            unit_ids=self.sorting_extractor.get_unit_ids(),
-                                                            start_frame=0,
-                                                            end_frame=end_frame)
+            max_min_spike_time = max([min(x) for y in self.sorting_extractor.get_unit_ids()
+                                      for x in [self.sorting_extractor.get_unit_spike_train(y)] if any(x)])
+            end_frame = 1.1 * max_min_spike_time
+            stub_sorting_extractor = se.SubSortingExtractor(
+                self.sorting_extractor,
+                unit_ids=self.sorting_extractor.get_unit_ids(),
+                start_frame=0,
+                end_frame=end_frame
+            )
             sorting_extractor = stub_sorting_extractor
         else:
             sorting_extractor = self.sorting_extractor
@@ -55,6 +58,8 @@ class BaseSortingExtractorInterface(BaseDataInterface):
                     data = metadata_column['data'][unit_id]
                 sorting_extractor.set_unit_property(unit_id, metadata_column['name'], data)
 
-        se.NwbSortingExtractor.write_sorting(sorting_extractor,
-                                             property_descriptions=property_descriptions,
-                                             nwbfile=nwbfile)
+        se.NwbSortingExtractor.write_sorting(
+            sorting_extractor,
+            property_descriptions=property_descriptions,
+            nwbfile=nwbfile
+        )

--- a/nwb_conversion_tools/basesortingextractorinterface.py
+++ b/nwb_conversion_tools/basesortingextractorinterface.py
@@ -38,12 +38,11 @@ class BaseSortingExtractorInterface(BaseDataInterface):
         if stub_test:
             max_min_spike_time = max([min(x) for y in self.sorting_extractor.get_unit_ids()
                                       for x in [self.sorting_extractor.get_unit_spike_train(y)] if any(x)])
-            end_frame = 1.1 * max_min_spike_time
             stub_sorting_extractor = se.SubSortingExtractor(
                 self.sorting_extractor,
                 unit_ids=self.sorting_extractor.get_unit_ids(),
                 start_frame=0,
-                end_frame=end_frame
+                end_frame=1.1*max_min_spike_time
             )
             sorting_extractor = stub_sorting_extractor
         else:


### PR DESCRIPTION
This fix resolves some very odd issues caused by any sorting extractor that doesn't contain spikes in what was previously the first 100 seconds of the experiment; also more holistically generalized the `end_frame` for stubbing that will now include at least one spike (and very slightly more) for every unit.

Also adjusted indenting style.