### PR TITLE
Sorting interface to write electrode metadata without recording

### DIFF
--- a/nwb_conversion_tools/basesortingextractorinterface.py
+++ b/nwb_conversion_tools/basesortingextractorinterface.py
@@ -1,5 +1,6 @@
 """Authors: Cody Baker and Ben Dichter."""
 import spikeextractors as se
+import numpy as np
 from pynwb import NWBFile
 from pynwb.ecephys import SpikeEventSeries
 
@@ -30,11 +31,30 @@ class BaseSortingExtractorInterface(BaseDataInterface):
 
         return metadata_schema
 
-    def convert_data(self, nwbfile: NWBFile, metadata_dict: dict, stub_test: bool = False):
+    def convert_data(self, nwbfile: NWBFile, metadata_dict: dict, stub_test: bool = False,
+                     write_ecephys_metadata: bool = False):
         if 'UnitProperties' not in metadata_dict:
             metadata_dict['UnitProperties'] = []
+        if write_ecephys_metadata and 'Ecephys' in metadata_dict:
+            n_channels = max([len(x['data']) for x in metadata_dict['Ecephys']['Electrodes']])
+            recording = se.NumpyRecordingExtractor(timeseries=np.array(range(n_channels)), sampling_frequency=1)
+            se.NwbRecordingExtractor.add_devices(
+                recording=recording,
+                nwbfile=nwbfile,
+                metadata=metadata_dict
+            )
+            se.NwbRecordingExtractor.add_electrode_groups(
+                recording=recording,
+                nwbfile=nwbfile,
+                metadata=metadata_dict
+            )
+            se.NwbRecordingExtractor.add_electrodes(
+                recording=recording,
+                nwbfile=nwbfile,
+                metadata=metadata_dict
+            )
 
-        property_descriptions = {}
+        property_descriptions = dict()
         if stub_test:
             max_min_spike_time = max([min(x) for y in self.sorting_extractor.get_unit_ids()
                                       for x in [self.sorting_extractor.get_unit_spike_train(y)] if any(x)])


### PR DESCRIPTION
@bendichter Extended sorting interface to include capability of writing electrode metadata in the absence of a true recording extractor. This removes the need for a NoRecording interface on the conversions that currently make use of it.

I did begin this approach by attempting to refactor the NwbRecordingExtractor.add_* methods into a general, non-class specific form so that they could be used in both that and the NwbSortingExtractor, and it worked well up until add_electrodes, which is intertwined with its recording extractor object at nearly every update to the keyword arguments for nwbfile.add_electrode, so was unable to generalize it on that repo.

I believe this current interface specific approach is far simpler, however, and even has the same capabilities for filling missing data as would be had by a true RecordingExtractor.