### PR TITLE
debugging for nwb-conversion-tools v0.6.0

### DIFF
--- a/nwb_conversion_tools/basedatainterface.py
+++ b/nwb_conversion_tools/basedatainterface.py
@@ -12,6 +12,10 @@ class BaseDataInterface:
     def get_source_schema(cls):
         return get_base_schema()
 
+    @classmethod
+    def get_conversion_options_schema(cls):
+        return get_schema_from_method_signature(cls.run_conversion, exclude=['nwbfile', 'metadata'])
+
     def __init__(self, **source_data):
         self.source_data = source_data
 
@@ -21,12 +25,8 @@ class BaseDataInterface:
     def get_metadata(self):
         return dict()
 
-    @classmethod
-    def get_conversion_options_schema(cls):
-        return get_schema_from_method_signature(cls.run_conversion, exclude=['nwbfile', 'metadata'])
-
     @abstractmethod
-    def run_conversion(self, nwbfile_path, metadata, **conversion_options):
+    def run_conversion(self, nwbfile_path: str, metadata: dict, **conversion_options):
         pass
 
     @abstractmethod

--- a/nwb_conversion_tools/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/baserecordingextractorinterface.py
@@ -2,6 +2,7 @@
 from abc import ABC
 
 import spikeextractors as se
+from pynwb import NWBFile
 from pynwb.device import Device
 from pynwb.ecephys import ElectrodeGroup, ElectricalSeries
 
@@ -11,10 +12,13 @@ from .json_schema_utils import get_schema_from_method_signature, fill_defaults
 
 
 class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
+    """Primary class for all RecordingExtractorInterfaces."""
+
     RX = None
 
     @classmethod
     def get_source_schema(cls):
+        """Compile input schema for the RecordingExtractor."""
         return get_schema_from_method_signature(cls.RX.__init__)
 
     def __init__(self, **source_data):
@@ -23,6 +27,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         self.subset_channels = None
 
     def get_metadata_schema(self):
+        """Compile metadata schema for the RecordingExtractor."""
         metadata_schema = super().get_metadata_schema()
 
         # Initiate Ecephys metadata
@@ -36,6 +41,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         return metadata_schema
 
     def get_metadata(self):
+        """Auto-fill as much of the metadata as possible. Must comply with metadata schema."""
         out = super().get_metadata()
         out['properties'].update(
             Ecephys=dict(
@@ -51,7 +57,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         )
         return out
 
-    def run_conversion(self, nwbfile, metadata: None, stub_test=False):
+    def run_conversion(self, nwbfile: NWBFile, metadata: dict = None, stub_test: bool = False):
         """
         Primary function for converting recording extractor data to nwb.
 
@@ -62,7 +68,6 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         stub_test: bool, optional (default False)
             If True, will truncate the data to run the conversion faster and take up less memory.
         """
-
         recording_extractor = self.recording_extractor
         if stub_test or self.subset_channels is not None:
             kwargs = dict()

--- a/nwb_conversion_tools/datainterfaces/intandatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/intandatainterface.py
@@ -12,7 +12,7 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
 
     def get_metadata(self):
         """Retrieve Ecephys metadata specific to the Intan format."""
-        intan_file_metadata = read_rhd(self.input_args['file_path'])[1]
+        intan_file_metadata = read_rhd(self.source_data['file_path'])[1]
         exclude_chan_types = ['AUX', 'ADC', 'VDD']
 
         group_names = [x['native_channel_name'].split('-')[0] for x in intan_file_metadata

--- a/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
@@ -13,7 +13,7 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
 
     def get_metadata(self):
         """Auto-populate as much metadata as possible from the high-pass (ap) SpikeGLX format."""
-        file_path = Path(self.input_args['file_path'])
+        file_path = Path(self.source_data['file_path'])
         session_id = file_path.parent.stem
 
         n_shanks = int(self.recording_extractor._meta['snsShankMap'][1])

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -1,3 +1,4 @@
+"""Authors: Luiz Tauffer, Cody Baker, and Ben Dichter."""
 import collections.abc
 import inspect
 
@@ -18,6 +19,7 @@ def dict_deep_update(d, u):
 
 
 def get_base_schema(tag=None, root=False, id_=None, **kwargs):
+    """Return the base schema used for all other schemas."""
     base_schema = dict(
         required=[],
         properties={},
@@ -26,23 +28,19 @@ def get_base_schema(tag=None, root=False, id_=None, **kwargs):
     )
     if tag is not None:
         base_schema.update(tag=tag)
-
     if root:
         base_schema.update({
             "$schema": "http://json-schema.org/draft-07/schema#"
         })
-
     if id_:
         base_schema.update({"$id": id_})
-
     base_schema.update(**kwargs)
-
     return base_schema
 
 
 def get_schema_from_method_signature(class_method, exclude=None):
     """
-    Take a class method and return a jsonschema of the input args
+    Take a class method and return a jsonschema of the input args.
 
     Parameters
     ----------
@@ -59,9 +57,17 @@ def get_schema_from_method_signature(class_method, exclude=None):
     input_schema = get_base_schema()
     for param in inspect.signature(class_method).parameters.values():
         if param.name not in exclude + ['self']:
+            if param.name != 'self' and param.annotation:
+                if param.annotation is bool:
+                    param_type = "boolean"
+                if param.annotation is str:
+                    param_type = "string"
+            else:
+                raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "
+                                          "is not assigned! Please implement.")
             arg_spec = {
                 param.name: dict(
-                    type='string'
+                    type=param_type
                 )
             }
             if param.default is param.empty:
@@ -70,14 +76,12 @@ def get_schema_from_method_signature(class_method, exclude=None):
                 arg_spec[param.name].update(default=param.default)
             input_schema['properties'].update(arg_spec)
         input_schema['additionalProperties'] = param.kind == inspect.Parameter.VAR_KEYWORD
-
     return input_schema
 
 
 def fill_defaults(schema: dict, defaults: dict, overwrite: bool = True):
     """
-    Insert the values of the defaults dict as default values in the schema
-    in place.
+    Insert the values of the defaults dict as default values in the schema in place.
 
     Parameters
     ----------

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -66,7 +66,7 @@ def get_schema_from_method_signature(class_method, exclude=None):
 
     for param in inspect.signature(class_method).parameters.values():
         if param.name not in exclude + ['self']:
-            if param.name != 'self' and param.annotation:
+            if param.annotation:
                 param_type = annotation_json_type_map[str(param.annotation).split("'")[1]]
             else:
                 raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -59,7 +59,9 @@ def get_schema_from_method_signature(class_method, exclude=None):
         bool="boolean",
         str="string",
         int="number",
-        float="number"
+        float="number",
+        dict="object",
+        list="array"
     )
 
     for param in inspect.signature(class_method).parameters.values():

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -55,13 +55,17 @@ def get_schema_from_method_signature(class_method, exclude=None):
     if exclude is None:
         exclude = []
     input_schema = get_base_schema()
+    annotation_json_type_map = dict(
+        bool="boolean",
+        str="string",
+        int="number",
+        float="number"
+    )
+
     for param in inspect.signature(class_method).parameters.values():
         if param.name not in exclude + ['self']:
             if param.name != 'self' and param.annotation:
-                if param.annotation is bool:
-                    param_type = "boolean"
-                if param.annotation is str:
-                    param_type = "string"
+                param_type = annotation_json_type_map[str(param.annotation).split("'")[1]]
             else:
                 raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "
                                           "is not assigned! Please implement.")

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -111,9 +111,7 @@ class NWBConverter:
 
         # If conversion_options is valid, procede to run conversions for DataInterfaces
         for interface_name, data_interface in self.data_interface_objects.items():
-            if interface_name not in conversion_options:
-                conversion_options.update({interface_name: dict()})
-            data_interface.run_conversion(nwbfile, metadata, **conversion_options[interface_name])
+            data_interface.run_conversion(nwbfile, metadata, **conversion_options.get(interface_name, dict()))
 
         # Save result to file or return object
         if save_to_file:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='nwb-conversion-tools',
-    version='0.6.0',
+    version='0.6.1',
     description='Convert data to nwb',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
@bendichter @luiztauffer The new json schema validation, while very nice and general, produced a number of errors that I've begun to correct here and in the Tank repo first.

The biggest changes are related to the now very heavy usage of `get_schema_from_method_signature` coupled  with the fact that not all downstream `properties` are of type `string`, as was previously hard-coded. Extended this to at least include type `bool` and throw an error if not either of those types to let us know to implement it.

While the actual `param_type` checking is the biggest direct change, there are a number of indirect changes required across the repo as well as coding practices for downstream inheritances. This is due to the usage derived from `param.annotation` which requires much better specification of value types across downstream functions. If this is undesired, I suppose we could just change the error I mentioned to a soft warning and simply default to a `string` type as before, but who knows what issues this might cause in more complicated future situations.

Otherwise, added some other docstrings and styling corrections.