### PR TITLE
unroot schema

### DIFF
--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -102,3 +102,16 @@ def fill_defaults(schema: dict, defaults: dict, overwrite: bool = True):
             else:
                 if overwrite or ('default' not in val):
                     val['default'] = defaults[key]
+
+
+def unroot_schema(schema: dict):
+    """Modifies a json-schema dictionary to make it not root
+
+    Parameters
+    ----------
+    schema: dict
+    """
+
+    terms = ('required', 'properties', 'type', 'additionalProperties',
+             'title', 'description')
+    return {k: v for k, v in schema.items() if k in terms}

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -27,7 +27,8 @@ class NWBConverter:
             version='0.1.0'
         )
         for interface_name, data_interface in cls.data_interface_classes.items():
-            source_schema['properties'].update({interface_name: data_interface.get_source_schema()})
+            source_schema['properties'].update(
+                {interface_name: unroot_schema(data_interface.get_source_schema())})
         return source_schema
 
     @classmethod
@@ -88,7 +89,7 @@ class NWBConverter:
             )
         )
         for interface in self.data_interface_objects.values():
-            interface_metadata = unroot_schema(interface.get_metadata())
+            interface_metadata = interface.get_metadata()
             metadata = dict_deep_update(metadata, interface_metadata)
         return metadata
 

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -7,7 +7,8 @@ from pynwb import NWBHDF5IO, NWBFile
 from pynwb.file import Subject
 
 from .utils import get_schema_from_hdmf_class, get_schema_for_NWBFile
-from .json_schema_utils import dict_deep_update, get_base_schema, fill_defaults
+from .json_schema_utils import dict_deep_update, get_base_schema, fill_defaults, \
+    unroot_schema
 
 
 class NWBConverter:
@@ -41,7 +42,7 @@ class NWBConverter:
         )
         for interface_name, data_interface in cls.data_interface_classes.items():
             conversion_options_schema['properties'].update({
-                interface_name: data_interface.get_conversion_options_schema()
+                interface_name: unroot_schema(data_interface.get_conversion_options_schema())
             })
         return conversion_options_schema
 
@@ -71,7 +72,7 @@ class NWBConverter:
             )
         )
         for data_interface in self.data_interface_objects.values():
-            interface_schema = data_interface.get_metadata_schema()
+            interface_schema = unroot_schema(data_interface.get_metadata_schema())
             metadata_schema = dict_deep_update(metadata_schema, interface_schema)
 
         fill_defaults(metadata_schema, self.get_metadata())
@@ -87,7 +88,7 @@ class NWBConverter:
             )
         )
         for interface in self.data_interface_objects.values():
-            interface_metadata = interface.get_metadata()
+            interface_metadata = unroot_schema(interface.get_metadata())
             metadata = dict_deep_update(metadata, interface_metadata)
         return metadata
 


### PR DESCRIPTION
@luiztauffer when a `DataInterface.get_metadata_schema` returns values like `$shema` and `id_`, these values should only be on the root level of a json-schema object. When it gets merged with other schemas, it should lose these identifiers. Would this PR work for you?