### PR TITLE
get_float_type_in_docval

### DIFF
--- a/nwb_conversion_tools/utils.py
+++ b/nwb_conversion_tools/utils.py
@@ -21,7 +21,7 @@ def get_schema_from_hdmf_class(hdmf_class):
         # type float
         if docval_arg['type'] == 'float' \
             or (isinstance(docval_arg['type'], tuple)
-                and 'float' in docval_arg['type']):
+                and any([it in docval_arg['type'] for it in [float, 'float']])):
             schema_arg[docval_arg['name']].update(type='number')
 
         # type string

--- a/nwb_conversion_tools/utils.py
+++ b/nwb_conversion_tools/utils.py
@@ -55,9 +55,8 @@ def get_schema_from_hdmf_class(hdmf_class):
                 docval_arg_type = docval_arg['type']
 
             # if another nwb object (or list of nwb objects)
-            if any([t.__module__.split('.')[0] == 'pynwb' for t in docval_arg_type if hasattr(t, '__module__')]):
-                is_nwb = [t.__module__.split('.')[0] == 'pynwb' for t in list(docval_arg_type) if
-                          hasattr(t, '__module__')]
+            if any([hasattr(t, '__nwbfields__') for t in docval_arg_type]):
+                is_nwb = [hasattr(t, '__nwbfields__') for t in docval_arg_type]
                 item = docval_arg_type[np.where(is_nwb)[0][0]]
                 # if it is child
                 if docval_arg['name'] in pynwb_children_fields:


### PR DESCRIPTION
Changes on `get_schema_from_hdmf_class()`:

- [x] we were testing for the string `'float'`, but not for the type `float` when looping through docval args. This fixes it
- [x] we were testing for `pynwb` module name, but extensions might have e.g. `abc`. Testing for `__nwbfields__` attribute should solve this