### PR TITLE
Extend annotation checking to union

### DIFF
--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -71,8 +71,8 @@ def get_schema_from_method_signature(class_method, exclude=None):
         if param_name not in exclude:
             if param.annotation:
                 param_type = [
-                    annotation_json_type_map[y] for x in param.annotation.__args__
-                    for y in [str(x).split("'")[1]] if y in annotation_json_type_map
+                    annotation_json_type_map[anno] for arg_types in param.annotation.__args__
+                    for anno in [str(arg_types).split("'")[1]] if anno in annotation_json_type_map
                 ]
                 assert len(param_type) == 1, \
                     f"There must be only one valid annotation type that maps to json! {len(param_type)} found."

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -83,7 +83,8 @@ def get_schema_from_method_signature(class_method, exclude=None):
             else:
                 raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "
                                           "is not implemented! Please request it to be added at github.com/"
-                                          "catalystneuro/nwb-conversion-tools/issues.")
+                                          "catalystneuro/nwb-conversion-tools/issues or create the json-schema"
+                                          "for this method manually.")
             arg_spec = {
                 param_name: dict(
                     type=param_type[0]

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -79,7 +79,7 @@ def get_schema_from_method_signature(class_method, exclude=None):
                 elif "'" in anno:
                     param_type = annotation_json_type_map[anno.split("'")[1]]
                 else:
-                    raise NotImplementedError("The annotation format of '{param}' in function '{class_method}' "
+                    raise NotImplementedError(f"The annotation format of '{param}' in function '{class_method}' "
                                               "is unrecognized!")
             else:
                 raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -79,12 +79,13 @@ def get_schema_from_method_signature(class_method, exclude=None):
                 elif "'" in anno:
                     param_type = annotation_json_type_map[anno.split("'")[1]]
                 else:
-                    raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "
-                                              "is not implemented! Please request it to be added at github.com/"
-                                              "catalystneuro/nwb-conversion-tools/issues.")
+                    raise NotImplementedError("The annotation format of '{param}' in function '{class_method}' "
+                                              "is unrecognized!")
             else:
                 raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "
-                                          "is not assigned! Please implement.")
+                                          "is not implemented! Please request it to be added at github.com/"
+                                          "catalystneuro/nwb-conversion-tools/issues.")
+
             arg_spec = {
                 param.name: dict(
                     type=param_type

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -58,21 +58,21 @@ def get_schema_from_method_signature(class_method, exclude=None):
     else:
         exclude = exclude + ['self']
     input_schema = get_base_schema()
-    annotation_json_type_map = dict(
-        bool="boolean",
-        str="string",
-        int="number",
-        float="number",
-        dict="object",
-        list="array"
-    )
+    annotation_json_type_map = {
+        bool: "boolean",
+        str: "string",
+        int: "number",
+        float: "number",
+        dict: "object",
+        list: "array"
+    }
 
     for param_name, param in inspect.signature(class_method).parameters.items():
         if param_name not in exclude:
             if param.annotation:
                 param_type = [
-                    annotation_json_type_map[arg_type.__name__] for arg_type in param.annotation.__args__
-                    if arg_type.__name__ in annotation_json_type_map
+                    annotation_json_type_map[arg_type] for arg_type in param.annotation.__args__
+                    if arg_type in annotation_json_type_map
                 ]
                 assert len(param_type) == 1, \
                     f"There must be only one valid annotation type that maps to json! {len(param_type)} found."

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -69,7 +69,7 @@ def get_schema_from_method_signature(class_method, exclude=None):
         if param.name not in exclude + ['self']:
             if param.annotation:
                 anno = str(param.annotation)
-                if "Union" in anno:
+                if "typing.Union" in anno:
                     types = re.search("typing.Union\[(.*)\]", anno).group(1).split(",")
                     intersect_valid_keys = list(set(annotation_json_type_map.keys()).intersection(types))
                     assert len(intersect_valid_keys) == 1, \

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -70,12 +70,12 @@ def get_schema_from_method_signature(class_method, exclude=None):
     for param_name, param in inspect.signature(class_method).parameters.items():
         if param_name not in exclude:
             if param.annotation:
-                types = [str(x).split("'")[1] for x in param.annotation.__args__]
-                intersect_valid_keys = list(set(annotation_json_type_map).intersection(types))
-                assert len(intersect_valid_keys) == 1, \
-                    "There must be only one valid annotation type that maps to json! " \
-                    f"{len(intersect_valid_keys)} found."
-                param_type = annotation_json_type_map[intersect_valid_keys[0]]
+                param_type = [
+                    annotation_json_type_map[y] for x in param.annotation.__args__
+                    for y in [str(x).split("'")[1]] if y in annotation_json_type_map
+                ]
+                assert len(param_type) == 1, \
+                    f"There must be only one valid annotation type that maps to json! {len(param_type)} found."
             else:
                 raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "
                                           "is not implemented! Please request it to be added at github.com/"
@@ -83,7 +83,7 @@ def get_schema_from_method_signature(class_method, exclude=None):
 
             arg_spec = {
                 param_name: dict(
-                    type=param_type
+                    type=param_type[0]
                 )
             }
             if param.default is param.empty:

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -70,19 +70,12 @@ def get_schema_from_method_signature(class_method, exclude=None):
     for param_name, param in inspect.signature(class_method).parameters.items():
         if param_name not in exclude:
             if param.annotation:
-                anno = str(param.annotation)
-                if "typing.Union" in anno:
-                    types = re.search("typing.Union\[(.*)\]", anno).group(1).split(",")
-                    intersect_valid_keys = list(set(annotation_json_type_map).intersection(types))
-                    assert len(intersect_valid_keys) == 1, \
-                        "There must be only one valid annotation type that maps to json! " \
-                        f"{len(intersect_valid_keys)} found."
-                    param_type = annotation_json_type_map[intersect_valid_keys[0]]
-                elif "'" in anno:
-                    param_type = annotation_json_type_map[anno.split("'")[1]]
-                else:
-                    raise NotImplementedError(f"The annotation format of '{param}' in function '{class_method}' "
-                                              "is unrecognized!")
+                types = [str(x).split("'")[1] for x in param.annotation.__args__]
+                intersect_valid_keys = list(set(annotation_json_type_map).intersection(types))
+                assert len(intersect_valid_keys) == 1, \
+                    "There must be only one valid annotation type that maps to json! " \
+                    f"{len(intersect_valid_keys)} found."
+                param_type = annotation_json_type_map[intersect_valid_keys[0]]
             else:
                 raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "
                                           "is not implemented! Please request it to be added at github.com/"

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -1,6 +1,7 @@
 """Authors: Luiz Tauffer, Cody Baker, and Ben Dichter."""
 import collections.abc
 import inspect
+import re
 
 
 def dict_deep_update(d, u):
@@ -67,7 +68,20 @@ def get_schema_from_method_signature(class_method, exclude=None):
     for param in inspect.signature(class_method).parameters.values():
         if param.name not in exclude + ['self']:
             if param.annotation:
-                param_type = annotation_json_type_map[str(param.annotation).split("'")[1]]
+                anno = str(param.annotation)
+                if "Union" in anno:
+                    types = re.search("typing.Union\[(.*)\]", anno).group(1).split(",")
+                    intersect_valid_keys = list(set(annotation_json_type_map.keys()).intersection(types))
+                    assert len(intersect_valid_keys) == 1, \
+                        "There must be only one valid annotation type that maps to json! " \
+                        f"{len(intersect_valid_keys)} found."
+                    param_type = annotation_json_type_map[intersect_valid_keys[0]]
+                elif "'" in anno:
+                    param_type = annotation_json_type_map[anno.split("'")[1]]
+                else:
+                    raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "
+                                              "is not implemented! Please request it to be added at github.com/"
+                                              "catalystneuro/nwb-conversion-tools/issues.")
             else:
                 raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "
                                           "is not assigned! Please implement.")

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -54,7 +54,9 @@ def get_schema_from_method_signature(class_method, exclude=None):
 
     """
     if exclude is None:
-        exclude = []
+        exclude = ['self']
+    else:
+        exclude = exclude + ['self']
     input_schema = get_base_schema()
     annotation_json_type_map = dict(
         bool="boolean",
@@ -66,12 +68,12 @@ def get_schema_from_method_signature(class_method, exclude=None):
     )
 
     for param in inspect.signature(class_method).parameters.values():
-        if param.name not in exclude + ['self']:
+        if param.name not in exclude:
             if param.annotation:
                 anno = str(param.annotation)
                 if "typing.Union" in anno:
                     types = re.search("typing.Union\[(.*)\]", anno).group(1).split(",")
-                    intersect_valid_keys = list(set(annotation_json_type_map.keys()).intersection(types))
+                    intersect_valid_keys = list(set(annotation_json_type_map).intersection(types))
                     assert len(intersect_valid_keys) == 1, \
                         "There must be only one valid annotation type that maps to json! " \
                         f"{len(intersect_valid_keys)} found."

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -71,8 +71,8 @@ def get_schema_from_method_signature(class_method, exclude=None):
         if param_name not in exclude:
             if param.annotation:
                 param_type = [
-                    annotation_json_type_map[anno] for arg_types in param.annotation.__args__
-                    for anno in [str(arg_types).split("'")[1]] if anno in annotation_json_type_map
+                    annotation_json_type_map[arg_type.__name__] for arg_type in param.annotation.__args__
+                    if arg_type.__name__ in annotation_json_type_map
                 ]
                 assert len(param_type) == 1, \
                     f"There must be only one valid annotation type that maps to json! {len(param_type)} found."

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -1,7 +1,6 @@
 """Authors: Luiz Tauffer, Cody Baker, and Ben Dichter."""
 import collections.abc
 import inspect
-import re
 
 
 def dict_deep_update(d, u):
@@ -80,7 +79,6 @@ def get_schema_from_method_signature(class_method, exclude=None):
                 raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "
                                           "is not implemented! Please request it to be added at github.com/"
                                           "catalystneuro/nwb-conversion-tools/issues.")
-
             arg_spec = {
                 param_name: dict(
                     type=param_type[0]


### PR DESCRIPTION
@bendichter Some of the annotation types in `spikeextractors` are fancier in their extensions using `typing.Union` to include things like `Path`, `None`, etc., in addition to something obvious like a `str`. This threw off the original annotation type checking, of course, so this fixes it in a _fairly_ general manner by finding the common base data type and validating against that (assuming there is one and only one match with the base data type).

One interesting case that would break this, which we _may_ run into in the future with the method attached here is an `ArrayLike` annotation, which can include more than one of the allowable json types (`int`, `float`, `list`) but could still be valid in that mapping as a json `array`. Depends on how the A`rrayLike` call is implemented as well, which also depends on the version of python in question.

But anyway, this works for now.