### PR TITLE
Using lazy imports to avoid having to append strict requirements

### DIFF
--- a/nwb_conversion_tools/datainterfaces/intandatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/intandatainterface.py
@@ -1,14 +1,23 @@
 """Authors: Cody Baker and Ben Dichter."""
 import spikeextractors as se
-from pyintan.intan import read_rhd
-
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
+
+try:
+    from pyintan.intan import read_rhd
+    HAVE_PYINTAN = True
+except ImportError:
+    HAVE_PYINTAN = False
+INSTALL_MESSAGE = "Please install pyintan to use this extractor!"
 
 
 class IntanRecordingInterface(BaseRecordingExtractorInterface):
     """Primary data interface class for converting a IntanRecordingExtractor."""
 
     RX = se.IntanRecordingExtractor
+
+    def __init__(self, *args, **kwargs):
+        assert HAVE_PYINTAN, INSTALL_MESSAGE
+        super().__init__(*args, **kwargs)
 
     def get_metadata(self):
         """Retrieve Ecephys metadata specific to the Intan format."""

--- a/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
@@ -3,10 +3,16 @@ from pathlib import Path
 
 import numpy as np
 import spikeextractors as se
-from lxml import etree as et
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
+
+try:
+    from lxml import etree as et
+    HAVE_LXML = True
+except ImportError:
+    HAVE_LXML = False
+INSTALL_MESSAGE = "Please install lxml to use this extractor!"
 
 
 class NeuroscopeRecordingInterface(BaseRecordingExtractorInterface):
@@ -15,10 +21,11 @@ class NeuroscopeRecordingInterface(BaseRecordingExtractorInterface):
     RX = se.NeuroscopeRecordingExtractor
 
     def __init__(self, *args, **kwargs):
+        assert HAVE_LXML, INSTALL_MESSAGE
+
         super().__init__(*args, **kwargs)
 
         root = self.get_xml()
-
         shank_channels = [[int(channel.text)
                            for channel in group.find('channels')]
                           for group in root.find('spikeDetection').find('channelGroups').findall('group')]


### PR DESCRIPTION
@bendichter Using a similar strategy to spikeextractors, this allows the format specific interfaces that use specific outside packages to import them without having to add the packages to the main requirements.

Currently the only two interfaces that do this are intan and neuroscope, but it sets the precedent early on do always use this strategy to avoid bloating the nwb-conversion-tools `setup`.