### PR TITLE
fixed issue with reading annotations without __args__ attr

### DIFF
--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -19,7 +19,7 @@ def dict_deep_update(d, u):
     return d
 
 
-def get_base_schema(tag=None, root=False, id_=None, **kwargs):
+def get_base_schema(tag=None, root=False, id_=None, **kwargs) -> dict:
     """Return the base schema used for all other schemas."""
     base_schema = dict(
         required=[],
@@ -39,9 +39,9 @@ def get_base_schema(tag=None, root=False, id_=None, **kwargs):
     return base_schema
 
 
-def get_schema_from_method_signature(class_method, exclude=None):
+def get_schema_from_method_signature(class_method: classmethod, exclude: list = None) -> dict:
     """
-    Take a class method and return a jsonschema of the input args.
+    Take a class method and return a json-schema of the input args.
 
     Parameters
     ----------

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -70,9 +70,14 @@ def get_schema_from_method_signature(class_method, exclude=None):
     for param_name, param in inspect.signature(class_method).parameters.items():
         if param_name not in exclude:
             if param.annotation:
-                valid_args = [x in annotation_json_type_map for x in param.annotation.__args__]
+                if hasattr(param.annotation, "__args__"):
+                    args = param.annotation.__args__
+                else:
+                    args = [param.annotation]
+
+                valid_args = [x in annotation_json_type_map for x in args]
                 if any(valid_args):
-                    param_type = [annotation_json_type_map[x] for x in np.array(param.annotation.__args__)[valid_args]]
+                    param_type = [annotation_json_type_map[x] for x in np.array(args)[valid_args]]
                 else:
                     raise ValueError("There must be only one valid annotation type that maps to json! "
                                      f"{param.annotation.__args__} found.")

--- a/tests/test_json_schema_utils.py
+++ b/tests/test_json_schema_utils.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+from typing import Union
+
+from nwb_conversion_tools.json_schema_utils import get_schema_from_method_signature
+
+
+def test_get_schema_from_method_signature():
+    class A:
+        def __init__(self, a: int, b: float, c: Union[Path, str], d: bool, e: str = 'hi'):
+            pass
+
+    schema = get_schema_from_method_signature(A.__init__)
+
+    correct_schema = dict(
+        additionalProperties=False,
+        properties=dict(
+            a=dict(type="number"),
+            b=dict(type="number"),
+            c=dict(type="string"),
+            d=dict(type="boolean"),
+            e=dict(
+                default="hi",
+                type="string"
+            )
+        ),
+        required=[
+            "a",
+            "b",
+            "c",
+            "d",
+        ],
+        type="object"
+    )
+
+    assert json.dumps(schema, sort_keys=True, indent=2) == json.dumps(correct_schema, sort_keys=True, indent=2)


### PR DESCRIPTION
@bendichter @weiglszonja Quick hotfix needed for running nwb-conversion-tools when the annotation types don't have internal __args__ attribute.