### PR TITLE
Annotation refactor; remove intan naming; fix default session start time

### DIFF
--- a/nwb_conversion_tools/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/baserecordingextractorinterface.py
@@ -80,7 +80,8 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
             )
         return recording_extractor
 
-    def run_conversion(self, nwbfile: NWBFile, metadata: dict = None, stub_test: bool = False):
+    def run_conversion(self, nwbfile: NWBFile, metadata: dict = None, stub_test: bool = False,
+                       use_timestamps: bool = False):
         """
         Primary function for converting recording extractor data to nwb.
 
@@ -95,5 +96,6 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         se.NwbRecordingExtractor.write_recording(
             recording_extractor,
             nwbfile=nwbfile,
-            metadata=metadata
+            metadata=metadata,
+            use_timestamps=use_timestamps
         )

--- a/nwb_conversion_tools/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/baserecordingextractorinterface.py
@@ -80,8 +80,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
             )
         return recording_extractor
 
-    def run_conversion(self, nwbfile: NWBFile, metadata: dict = None, stub_test: bool = False,
-                       use_timestamps: bool = False):
+    def run_conversion(self, nwbfile: NWBFile, metadata: dict = None, stub_test: bool = False):
         """
         Primary function for converting recording extractor data to nwb.
 
@@ -96,6 +95,5 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         se.NwbRecordingExtractor.write_recording(
             recording_extractor,
             nwbfile=nwbfile,
-            metadata=metadata,
-            use_timestamps=use_timestamps
+            metadata=metadata
         )

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -80,8 +80,7 @@ def get_schema_from_method_signature(class_method: classmethod, exclude: list = 
                 if any(valid_args):
                     param_type = [annotation_json_type_map[x] for x in np.array(args)[valid_args]]
                 else:
-                    raise ValueError("There must be only one valid annotation type that maps to json! "
-                                     f"{param.annotation.__args__} found.")
+                    raise ValueError("No valid arguments were found in the json type mapping!")
 
                 if len(set(param_type)) > 1:
                     raise ValueError("Conflicting json parameter types were detected from the annotation! "

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -73,18 +73,21 @@ def get_schema_from_method_signature(class_method: classmethod, exclude: list = 
             if param.annotation:
                 if hasattr(param.annotation, "__args__"):
                     args = param.annotation.__args__
+                    valid_args = [x in annotation_json_type_map for x in args]
+                    if any(valid_args):
+                        param_types = [annotation_json_type_map[x] for x in np.array(args)[valid_args]]
+                    else:
+                        raise ValueError("No valid arguments were found in the json type mapping!")
+                    if len(set(param_types)) > 1:
+                        raise ValueError("Conflicting json parameter types were detected from the annotation! "
+                                         f"{param.annotation.__args__} found.")
+                    param_type = param_types[0]
                 else:
-                    args = [param.annotation]
-
-                valid_args = [x in annotation_json_type_map for x in args]
-                if any(valid_args):
-                    param_type = [annotation_json_type_map[x] for x in np.array(args)[valid_args]]
-                else:
-                    raise ValueError("No valid arguments were found in the json type mapping!")
-
-                if len(set(param_type)) > 1:
-                    raise ValueError("Conflicting json parameter types were detected from the annotation! "
-                                     f"{param.annotation.__args__} found.")
+                    arg = param.annotation
+                    if arg in annotation_json_type_map:
+                        param_type = annotation_json_type_map[arg]
+                    else:
+                        raise ValueError("No valid arguments were found in the json type mapping!")
             else:
                 raise NotImplementedError(f"The annotation type of '{param}' in function '{class_method}' "
                                           "is not implemented! Please request it to be added at github.com/"
@@ -92,7 +95,7 @@ def get_schema_from_method_signature(class_method: classmethod, exclude: list = 
                                           "for this method manually.")
             arg_spec = {
                 param_name: dict(
-                    type=param_type[0]
+                    type=param_type
                 )
             }
             if param.default is param.empty:

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -86,7 +86,7 @@ class NWBConverter:
             NWBFile=dict(
                 session_description="no description",
                 identifier=str(uuid.uuid4()),
-                session_start_time=datetime(2000, 1, 1)
+                session_start_time=datetime(1970, 1, 1)
             )
         )
         for interface in self.data_interface_objects.values():

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -86,7 +86,7 @@ class NWBConverter:
             NWBFile=dict(
                 session_description="no description",
                 identifier=str(uuid.uuid4()),
-                session_start_time=datetime(1900, 1, 1)
+                session_start_time=datetime(2000, 1, 1)
             )
         )
         for interface in self.data_interface_objects.values():


### PR DESCRIPTION
@bendichter This PR adds some stuff relevant to Syntalos

1. Allow timestamps arguments to be passed to recording extractor
2. Refactored that part of the new annotations fix you didn't like
3. Small bug fix to the default `session_start_time`; apparently if it's `datetime(1900,1,1)` you get really weird, hard to debug errors during the final `io.write` because the associated timestamp becomes negative. Updating this to `datetime(2000,1,1)` fixes that bug.