### PR TITLE
updated data interface import structure to be similar to roi

### DIFF
--- a/nwb_conversion_tools/datainterfaces/__init__.py
+++ b/nwb_conversion_tools/datainterfaces/__init__.py
@@ -1,6 +1,6 @@
-from .neuroscopedatainterface import NeuroscopeRecordingInterface, NeuroscopeSortingInterface
+from .neuroscopedatainterface import *
 from .spikeglxdatainterface import SpikeGLXRecordingInterface
-from .sipickledatainterfaces import SIPickleRecordingExtractorInterface, SIPickleSortingExtractorInterface
+from .sipickledatainterfaces import *
 from .intandatainterface import IntanRecordingInterface
 from .ceddatainterface import CEDRecordingInterface
 from .roiextractordatainterface import *


### PR DESCRIPTION
@bendichter For the spikeextractor data interfaces with more than one class within them, changing the `__init__` imports to `*` to reduce code and mimic roiextractors