### PR TITLE
Add SortingExtractor object directly to NWBConverter object

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='nwb-conversion-tools',
-    version='0.6.3',
+    version='0.6.4',
     description='Convert data to nwb',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,6 +1,9 @@
 from jsonschema import Draft7Validator
 
-from nwb_conversion_tools import interface_list
+import spikeextractors as se
+from spikeextractors.tests.utils import check_sortings_equal
+
+from nwb_conversion_tools import NWBConverter, interface_list
 
 
 def test_interface_schemas():
@@ -12,3 +15,19 @@ def test_interface_schemas():
         # check validity of conversion options schema
         schema = data_interface.get_conversion_options_schema()
         Draft7Validator.check_schema(schema)
+
+
+def test_add_sorting_extractor():
+    sorting_extractor = se.example_datasets.toy_example()[1]
+    converter = NWBConverter(source_data=dict())
+    converter.add_sorting_extractor(sorting_extractor=sorting_extractor)
+
+    interface_name = 'NumpySorting'
+    interface_class_name = 'NumpySortingExtractorDataInterface'
+    extractor_name = 'NumpySortingExtractor'
+    assert interface_name in converter.data_interface_classes
+    assert interface_name in converter.data_interface_objects
+    assert interface_class_name == converter.data_interface_classes[interface_name]
+    assert interface_class_name == converter.data_interface_objects[interface_name].__name__
+    assert extractor_name == converter.data_interface_objects[interface_name].SX
+    check_sortings_equal(sorting_extractor, converter.data_interface_objects[interface_name].sorting_extractor)


### PR DESCRIPTION
@bendichter Finalized functionality and testing of the method where we take a SortingExtractor object that has already been instantiated, and add it into the internal interface classes and lists via the metaprogramming strategy.

One thing to discuss would be how `data_interface_classes` defaults to `None`, but it is now possible for someone to make a NWBConverter without any `source_data` with the intention of simply adding a SortingExtractor object to it. I've resolved this here with a bunch of `if` checks on the `None` status, but it might take less code to simply set the default `data_interface_classes` to an empty dictionary.