### PR TITLE
Debugging for petersen; add timestamp regularity check

### DIFF
--- a/nwb_conversion_tools/conversion_tools.py
+++ b/nwb_conversion_tools/conversion_tools.py
@@ -9,12 +9,7 @@ def check_regular_timestamps(ts):
     """Check whether rate should be used instead of timestamps."""
     time_tol_decimals = 9
     uniq_diff_ts = np.unique(np.diff(ts).round(decimals=time_tol_decimals))
-    if len(uniq_diff_ts) == 1:
-        error_code = "A101"
-        print(
-            "- %s: '%s' %s has a constant sampling rate. Consider using starting_time %f and rate %f instead of using "
-            "the timestamps array." % (error_code, ts.name, type(ts).__name__, ts.timestamps[0], uniq_diff_ts[0])
-        )
+    return len(uniq_diff_ts) == 1
 
 
 def save_si_object(object_name: str, si_object, output_folder,

--- a/nwb_conversion_tools/conversion_tools.py
+++ b/nwb_conversion_tools/conversion_tools.py
@@ -1,6 +1,20 @@
 """Authors: Cody Baker, Alessio Buccino."""
 from pathlib import Path
+import numpy as np
+
 import spikeextractors as se
+
+
+def check_regular_timestamps(ts):
+    """Check whether rate should be used instead of timestamps."""
+    time_tol_decimals = 9
+    uniq_diff_ts = np.unique(np.diff(ts.timestamps).round(decimals=time_tol_decimals))
+    if len(uniq_diff_ts) == 1:
+        error_code = "A101"
+        print(
+            "- %s: '%s' %s has a constant sampling rate. Consider using starting_time %f and rate %f instead of using "
+            "the timestamps array." % (error_code, ts.name, type(ts).__name__, ts.timestamps[0], uniq_diff_ts[0])
+        )
 
 
 def save_si_object(object_name: str, si_object, output_folder,

--- a/nwb_conversion_tools/conversion_tools.py
+++ b/nwb_conversion_tools/conversion_tools.py
@@ -8,7 +8,7 @@ import spikeextractors as se
 def check_regular_timestamps(ts):
     """Check whether rate should be used instead of timestamps."""
     time_tol_decimals = 9
-    uniq_diff_ts = np.unique(np.diff(ts.timestamps).round(decimals=time_tol_decimals))
+    uniq_diff_ts = np.unique(np.diff(ts).round(decimals=time_tol_decimals))
     if len(uniq_diff_ts) == 1:
         error_code = "A101"
         print(

--- a/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
@@ -35,12 +35,23 @@ def get_xml(xml_file_path: str):
 
 
 def get_shank_channels(xml_file_path: str, sort: bool = False):
-    """Auxiliary function for retrieving the list of structured shank-only channels."""
+    """
+    Auxiliary function for retrieving the list of structured shank-only channels.
+
+    Attempts to retrieve these first from the spikeDetection sub-field in the event that spike sorting was performed on
+    the raw data. In the event that spike sorting was not performed, it then retrieves only the anatomicalDescription.
+    """
     root = get_xml(xml_file_path)
-    shank_channels = [
-        [int(channel.text) for channel in group.find('channels')]
-        for group in root.find('spikeDetection').find('channelGroups').findall('group')
-    ]
+    try:
+        shank_channels = [
+            [int(channel.text) for channel in group.find('channels')]
+            for group in root.find('spikeDetection').find('channelGroups').findall('group')
+        ]
+    except AttributeError:
+        shank_channels = [
+            [int(channel.text) for channel in group.find('channels')]
+            for group in root.find('anatomicalDescription').find('channelGroups').findall('group')
+        ]
 
     if sort:
         shank_channels = sorted(np.concatenate(shank_channels))

--- a/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
@@ -49,7 +49,7 @@ def get_shank_channels(xml_file_path: str, sort: bool = False):
         ]
     except (TypeError, AttributeError):
         shank_channels = [
-            [int(channel.text) for channel in group.find('channels')]
+            [int(channel.text) for channel in group.findall('channel')]
             for group in root.find('anatomicalDescription').find('channelGroups').findall('group')
         ]
 

--- a/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
@@ -47,7 +47,7 @@ def get_shank_channels(xml_file_path: str, sort: bool = False):
             [int(channel.text) for channel in group.find('channels')]
             for group in root.find('spikeDetection').find('channelGroups').findall('group')
         ]
-    except AttributeError:
+    except (TypeError, AttributeError):
         shank_channels = [
             [int(channel.text) for channel in group.find('channels')]
             for group in root.find('anatomicalDescription').find('channelGroups').findall('group')

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,6 @@
+from nwb_conversion_tools.conversion_tools import check_regular_timestamps
+
+
+def test_check_regular_timestamps():
+    assert check_regular_timestamps([1,2,3])
+    assert not check_regular_timestamps([1,2,4])


### PR DESCRIPTION
@bendichter Small debugs for Petersen

1) For those sessions of Petersen that did not have spike sorted data, there apparently is no `.xml` field for isolating the channel groups used for `spikeDetection`, which is necessary for LFP/DAT extraction due to the channel subsetting. This adjusts the subsetting in this case to occur at the anatomical level.

2) Added that timestamp regularity check we talked about [here](https://github.com/catalystneuro/buzsaki-lab-to-nwb/pull/25).