### PR TITLE
propagate buffer_mb argument from spikeextractors

### DIFF
--- a/nwb_conversion_tools/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/baserecordingextractorinterface.py
@@ -77,7 +77,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         )
         return recording_extractor
 
-    def run_conversion(self, nwbfile: NWBFile, metadata: dict = None, stub_test: bool = False):
+    def run_conversion(self, nwbfile: NWBFile, metadata: dict = None, stub_test: bool = False, buffer_mb: int = 500):
         """
         Primary function for converting recording extractor data to nwb.
 
@@ -87,6 +87,9 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         metadata: dict
         stub_test: bool, optional (default False)
             If True, will truncate the data to run the conversion faster and take up less memory.
+        buffer_mb: int (optional, defaults to 500MB)
+            Maximum amount of memory (in MB) to use per iteration of the internal DataChunkIterator.
+            Requires trace data in the RecordingExtractor to be a memmap object.
         """
         if stub_test or self.subset_channels is not None:
             recording = self.subset_recording(stub_test=stub_test)
@@ -95,5 +98,6 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         se.NwbRecordingExtractor.write_recording(
             recording=recording,
             nwbfile=nwbfile,
-            metadata=metadata
+            metadata=metadata,
+            buffer_mb=buffer_mb
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,7 @@ pandas==1.0.3
 scipy==1.4.1
 h5py==2.10.0
 PyYAML==5.3.1
-# spikeextractors==0.9.3
-git+https://github.com/SpikeInterface/spikeextractors@return_scaled
+spikeextractors==0.9.5
 spikesorters==0.3.0
 spiketoolkit==0.6.1
 psutil==5.7.0


### PR DESCRIPTION
@alejoe91 @luiztauffer Depends on https://github.com/SpikeInterface/spikeextractors/pull/578

The `buffer_mb` argument has been available at the `add_electrical_series` level for quite a while, but was never able to be specified at the highest level of `write_recording`.

Now that we are running multiple large-scale raw data conversions in parallel, a facet unlikely to soon change, this argument will give us a much greater degree of control over the processing resource specification.