### PR TITLE
Spikeglx metadata fix

### DIFF
--- a/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
@@ -19,16 +19,20 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
 
         if isinstance(self.recording_extractor, SubRecordingExtractor):
             n_shanks = int(self.recording_extractor._parent_recording._meta['snsShankMap'][1])
+            session_start_time = datetime.fromisoformat(
+                self.recording_extractor._parent_recording._meta['fileCreateTime']
+            ).astimezone()
         else:
             n_shanks = int(self.recording_extractor._meta['snsShankMap'][1])
+            session_start_time = datetime.fromisoformat(
+                self.recording_extractor._meta['fileCreateTime']
+            ).astimezone()
         if n_shanks > 1:
             raise NotImplementedError("SpikeGLX metadata for more than a single shank is not yet supported.")
 
         channels = self.recording_extractor.get_channel_ids()
         shank_electrode_number = channels
         shank_group_name = ["Shank1" for x in channels]
-        session_start_time = datetime.fromisoformat(
-            self.recording_extractor._meta['fileCreateTime']).astimezone()
 
         ecephys_metadata = dict(
             Ecephys=dict(

--- a/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
@@ -24,9 +24,7 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
             ).astimezone()
         else:
             n_shanks = int(self.recording_extractor._meta['snsShankMap'][1])
-            session_start_time = datetime.fromisoformat(
-                self.recording_extractor._meta['fileCreateTime']
-            ).astimezone()
+            session_start_time = datetime.fromisoformat(self.recording_extractor._meta['fileCreateTime']).astimezone()
         if n_shanks > 1:
             raise NotImplementedError("SpikeGLX metadata for more than a single shank is not yet supported.")
 


### PR DESCRIPTION
@bendichter Small fix required for Manuel's use of the pipeline.

It appears as if, when the fileCreateTime field was added for the session_start_time extraction, it was not checked against the possibility of a SubRecording being the extractor type.