### PR TITLE
small fix to arguments for recording and lfp interfaces

### DIFF
--- a/nwb_conversion_tools/baselfpextractorinterface.py
+++ b/nwb_conversion_tools/baselfpextractorinterface.py
@@ -1,8 +1,13 @@
 """Authors: Cody Baker and Ben Dichter."""
+from typing import Optional, Union
+from pathlib import Path
+
 import spikeextractors as se
 from pynwb import NWBFile
 
 from .baserecordingextractorinterface import BaseRecordingExtractorInterface
+
+OptionalPathType = Optional[Union[str, Path]]
 
 
 class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
@@ -20,8 +25,41 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
 
         return metadata
 
+    def run_conversion(
+      self,
+      nwbfile: NWBFile,
+      metadata: dict = None,
+      stub_test: bool = False,
+      use_times: bool = False,
+      save_path: OptionalPathType = None,
+      overwrite: bool = False,
+      buffer_mb: int = 500
+    ):
+        """
+        Primary function for converting low-pass recording extractor data to nwb.
 
-    def run_conversion(self, nwbfile: NWBFile, metadata: dict = None, stub_test: bool = False):
+        Parameters
+        ----------
+        nwbfile: NWBFile
+            nwb file to which the recording information is to be added
+        metadata: dict
+            metadata info for constructing the nwb file (optional).
+            Should be of the format
+                metadata['Ecephys']['ElectricalSeries'] = dict(name=my_name, description=my_description)
+        use_times: bool
+            If True, the times are saved to the nwb file using recording.frame_to_time(). If False (default),
+            the sampling rate is used.
+        save_path: PathType
+            Required if an nwbfile is not passed. Must be the path to the nwbfile
+            being appended, otherwise one is created and written.
+        overwrite: bool
+            If using save_path, whether or not to overwrite the NWBFile if it already exists.
+        stub_test: bool, optional (default False)
+            If True, will truncate the data to run the conversion faster and take up less memory.
+        buffer_mb: int (optional, defaults to 500MB)
+            Maximum amount of memory (in MB) to use per iteration of the internal DataChunkIterator.
+            Requires trace data in the RecordingExtractor to be a memmap object.
+        """
         if stub_test or self.subset_channels is not None:
             recording = self.subset_recording(stub_test=stub_test)
         else:
@@ -30,5 +68,9 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
             recording=recording,
             nwbfile=nwbfile,
             metadata=metadata,
-            write_as_lfp=True
+            use_times=use_times,
+            write_as_lfp=True,
+            save_path=save_path,
+            overwrite=overwrite,
+            buffer_mb=buffer_mb
         )

--- a/nwb_conversion_tools/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/baserecordingextractorinterface.py
@@ -1,6 +1,6 @@
 """Authors: Cody Baker and Ben Dichter."""
 from abc import ABC
-from typing import Union
+from typing import Union, Optional
 from pathlib import Path
 
 import spikeextractors as se
@@ -12,7 +12,7 @@ from .basedatainterface import BaseDataInterface
 from .utils import get_schema_from_hdmf_class
 from .json_schema_utils import get_schema_from_method_signature, fill_defaults, get_base_schema
 
-PathType = Union[str, Path, None]
+OptionalPathType = Optional[Union[str, Path]]
 
 
 class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
@@ -75,14 +75,13 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
       nwbfile: NWBFile,
       metadata: dict = None,
       stub_test: bool = False,
-      use_times: bool = False, 
-      write_as_lfp: bool = False,
-      save_path: PathType = None, 
+      use_times: bool = False,
+      save_path: OptionalPathType = None,
       overwrite: bool = False,
       buffer_mb: int = 500
     ):
         """
-        Primary function for converting recording extractor data to nwb.
+        Primary function for converting high-pass recording extractor data to nwb.
 
         Parameters
         ----------
@@ -91,13 +90,10 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         metadata: dict
             metadata info for constructing the nwb file (optional).
             Should be of the format
-                metadata['Ecephys']['ElectricalSeries'] = {'name': my_name,
-                                                           'description': my_description}
+                metadata['Ecephys']['ElectricalSeries'] = dict(name=my_name, description=my_description)
         use_times: bool
             If True, the times are saved to the nwb file using recording.frame_to_time(). If False (default),
             the sampling rate is used.
-        write_as_lfp: bool (optional, defaults to False)
-            If True, writes the traces under a processing LFP module in the NWBFile instead of acquisition.
         save_path: PathType
             Required if an nwbfile is not passed. Must be the path to the nwbfile
             being appended, otherwise one is created and written.
@@ -119,7 +115,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
             nwbfile=nwbfile,
             metadata=metadata,
             use_times=use_times,
-            write_as_lfp=write_as_lfp,
+            write_as_lfp=False,
             save_path=save_path,
             overwrite=overwrite,
             buffer_mb=buffer_mb

--- a/nwb_conversion_tools/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/baserecordingextractorinterface.py
@@ -81,7 +81,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
       buffer_mb: int = 500
     ):
         """
-        Primary function for converting high-pass recording extractor data to nwb.
+        Primary function for converting raw (unprocessed) recording extractor data to nwb.
 
         Parameters
         ----------

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='nwb-conversion-tools',
-    version='0.7.0',
+    version='0.7.2',
     description='Convert data to nwb',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
@luiztauffer [When I propagated the `buffer_mb` option](https://github.com/catalystneuro/nwb-conversion-tools/pull/137) from spikeextractors to the recording class, I forgot to also propagate it to the LFP interfaces that inherit from it, but override that function in order to specify the lfp specific option.