### PR TITLE
define type of arrays for ecephys schema

### DIFF
--- a/nwb_conversion_tools/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/baserecordingextractorinterface.py
@@ -37,13 +37,24 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
 
         # Initiate Ecephys metadata
         metadata_schema['properties']['Ecephys'] = get_base_schema(tag='Ecephys')
+        metadata_schema['properties']['Ecephys']['required'] = ['Device', 'ElectrodeGroup']
         metadata_schema['properties']['Ecephys']['properties'] = dict(
-            Device=get_schema_from_hdmf_class(Device),
-            ElectrodeGroup=get_schema_from_hdmf_class(ElectrodeGroup),
+            Device=dict(
+                type="array",
+                items={"$ref": "#/properties/Ecephys/properties/definitions/Device"}
+            ),
+            ElectrodeGroup=dict(
+                type="array",
+                items={"$ref": "#/properties/Ecephys/properties/definitions/ElectrodeGroup"}
+            ),
             ElectricalSeries=get_schema_from_hdmf_class(ElectricalSeries)
         )
-        metadata_schema['properties']['Ecephys']['required'] = ['Device', 'ElectrodeGroup', 'ElectricalSeries']
-        fill_defaults(metadata_schema, self.get_metadata())
+        # Schema definition for arrays
+        metadata_schema['properties']['Ecephys']['properties']["definitions"] = dict(
+            Device=get_schema_from_hdmf_class(Device),
+            ElectrodeGroup=get_schema_from_hdmf_class(ElectrodeGroup),
+        )
+        #fill_defaults(metadata_schema, self.get_metadata())
         return metadata_schema
 
     def subset_recording(self, stub_test: bool = False):

--- a/nwb_conversion_tools/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/baserecordingextractorinterface.py
@@ -41,10 +41,12 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         metadata_schema['properties']['Ecephys']['properties'] = dict(
             Device=dict(
                 type="array",
+                minItems=1,
                 items={"$ref": "#/properties/Ecephys/properties/definitions/Device"}
             ),
             ElectrodeGroup=dict(
                 type="array",
+                minItems=1,
                 items={"$ref": "#/properties/Ecephys/properties/definitions/ElectrodeGroup"}
             ),
             ElectricalSeries=get_schema_from_hdmf_class(ElectricalSeries)

--- a/nwb_conversion_tools/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/baserecordingextractorinterface.py
@@ -48,8 +48,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
                 type="array",
                 minItems=1,
                 items={"$ref": "#/properties/Ecephys/properties/definitions/ElectrodeGroup"}
-            ),
-            ElectricalSeries=get_schema_from_hdmf_class(ElectricalSeries)
+            )
         )
         # Schema definition for arrays
         metadata_schema['properties']['Ecephys']['properties']["definitions"] = dict(

--- a/nwb_conversion_tools/basesortingextractorinterface.py
+++ b/nwb_conversion_tools/basesortingextractorinterface.py
@@ -24,7 +24,7 @@ class BaseSortingExtractorInterface(BaseDataInterface, ABC):
 
     def get_metadata_schema(self):
         metadata_schema = get_base_schema(
-            required=['SpikeEventSeries'],
+            # required=['SpikeEventSeries'],
             properties=dict(
                 SpikeEventSeries=get_schema_from_hdmf_class(SpikeEventSeries)
             )

--- a/nwb_conversion_tools/basesortingextractorinterface.py
+++ b/nwb_conversion_tools/basesortingextractorinterface.py
@@ -24,7 +24,6 @@ class BaseSortingExtractorInterface(BaseDataInterface, ABC):
 
     def get_metadata_schema(self):
         metadata_schema = get_base_schema(
-            # required=['SpikeEventSeries'],
             properties=dict(
                 SpikeEventSeries=get_schema_from_hdmf_class(SpikeEventSeries)
             )

--- a/nwb_conversion_tools/conversion_tools.py
+++ b/nwb_conversion_tools/conversion_tools.py
@@ -40,7 +40,7 @@ def get_default_nwbfile_metadata():
     metadata = dict(
         NWBFile=dict(
             session_description="no description",
-            session_start_time=datetime(1970, 1, 1),
+            session_start_time=datetime(1970, 1, 1).isoformat(),
             identifier=str(uuid.uuid4())
         )
     )

--- a/nwb_conversion_tools/datainterfaces/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/blackrockdatainterface.py
@@ -2,7 +2,6 @@
 import random
 import string
 import pytz
-import uuid
 from typing import Union, Optional
 from pathlib import Path
 import spikeextractors as se

--- a/nwb_conversion_tools/datainterfaces/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/blackrockdatainterface.py
@@ -2,6 +2,7 @@
 import random
 import string
 import pytz
+import uuid
 from typing import Union, Optional
 from pathlib import Path
 import spikeextractors as se
@@ -46,9 +47,9 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         comment = nsx_file.basic_header['Comment']
 
         metadata['NWBFile'] = dict(
-            session_start_time=session_start_time_tzaware,
+            session_start_time=session_start_time_tzaware.strftime('%Y-%m-%dT%H:%M:%S'),
             session_description=comment,
-            identifier=''.join(random.choices(string.ascii_uppercase + string.digits, k=12))
+            identifier=str(uuid.uuid4())
         )
 
         metadata['Ecephys'] = dict(

--- a/nwb_conversion_tools/datainterfaces/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/blackrockdatainterface.py
@@ -49,7 +49,6 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         metadata['NWBFile'] = dict(
             session_start_time=session_start_time_tzaware.strftime('%Y-%m-%dT%H:%M:%S'),
             session_description=comment,
-            identifier=str(uuid.uuid4())
         )
 
         metadata['Ecephys'] = dict(

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -28,7 +28,7 @@ def get_base_schema(tag=None, root=False, id_=None, **kwargs) -> dict:
         required=[],
         properties={},
         type='object',
-        additionalProperties=False
+        additionalProperties=True
     )
     if tag is not None:
         base_schema.update(tag=tag)

--- a/nwb_conversion_tools/json_schema_utils.py
+++ b/nwb_conversion_tools/json_schema_utils.py
@@ -28,7 +28,7 @@ def get_base_schema(tag=None, root=False, id_=None, **kwargs) -> dict:
         required=[],
         properties={},
         type='object',
-        additionalProperties=True
+        additionalProperties=False
     )
     if tag is not None:
         base_schema.update(tag=tag)

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -48,10 +48,16 @@ class NWBConverter:
             })
         return conversion_options_schema
 
+    @classmethod
+    def validate_source(cls, source_data):
+        """Validate source_data against Converter source_schema."""
+        validate(instance=source_data, schema=cls.get_source_schema())
+        print('Source data is valid!')
+
     def __init__(self, source_data):
         """Validate source_data against source_schema and initialize all data interfaces."""
         # Validate source_data against source_schema
-        validate(instance=source_data, schema=self.get_source_schema())
+        self.validate_source(source_data=source_data)
 
         # If data is valid, proceed to instantiate DataInterface objects
         self.data_interface_objects = {
@@ -89,14 +95,24 @@ class NWBConverter:
             metadata = dict_deep_update(metadata, interface_metadata)
         return metadata
 
+    def validate_metadata(self, metadata):
+        """Validate metadata against Converter metadata_schema."""
+        validate(instance=metadata, schema=self.get_metadata_schema())
+        print('Metadata is valid!')
+
+    def validate_conversion_options(self, conversion_options):
+        """Validate conversion_options against Converter conversion_options_schema."""
+        validate(instance=conversion_options, schema=self.get_conversion_options_schema())
+        print('conversion_options is valid!')
+
     def run_conversion(
-            self,
-            metadata: dict,
-            save_to_file: Optional[bool] = True,
-            nwbfile_path: Optional[str] = None,
-            overwrite: Optional[bool] = False,
-            nwbfile: Optional[NWBFile] = None,
-            conversion_options: Optional[dict] = None
+        self,
+        metadata: dict,
+        save_to_file: Optional[bool] = True,
+        nwbfile_path: Optional[str] = None,
+        overwrite: Optional[bool] = False,
+        nwbfile: Optional[NWBFile] = None,
+        conversion_options: Optional[dict] = None
     ):
         """
         Run the NWB conversion over all the instantiated data interfaces.
@@ -125,10 +141,10 @@ class NWBConverter:
         if conversion_options is None:
             conversion_options = dict()
         else:
-            validate(instance=conversion_options, schema=self.get_conversion_options_schema())
+            self.validate_conversion_options(conversion_options=conversion_options)
 
         # Validate metadata
-        validate(instance=metadata, schema=self.get_metadata_schema())
+        self.validate_metadata(metadata=metadata)
 
         if save_to_file:
             if nwbfile_path is None:

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -144,7 +144,7 @@ class NWBConverter:
             self.validate_conversion_options(conversion_options=conversion_options)
 
         # Validate metadata
-        self.validate_metadata(metadata=metadata)
+        # self.validate_metadata(metadata=metadata)
 
         if save_to_file:
             if nwbfile_path is None:

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -121,10 +121,14 @@ class NWBConverter:
         assert (not save_to_file and nwbfile_path is None) or nwbfile is None, \
             "Either pass a nwbfile_path location with save_to_file=True, or a nwbfile object, but not both!"
 
+        # Validate conversion options
         if conversion_options is None:
             conversion_options = dict()
         else:
             validate(instance=conversion_options, schema=self.get_conversion_options_schema())
+
+        # Validate metadata
+        validate(instance=metadata, schema=self.get_metadata_schema())
 
         if save_to_file:
             if nwbfile_path is None:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='nwb-conversion-tools',
-    version='0.7.3',
+    version='0.7.4',
     description='Convert data to nwb',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Motivation

@sbuergers [found out](https://github.com/catalystneuro/nwb-conversion-tools/pull/166#discussion_r610653741) we were not defining `Device` and `ElectrodeGorup` as arrays on the base schema.

## How to test the behavior?
```python
from jsonschema import validate
#import any Converter using BaseRecordingExtractorInterfaces
converter = MyNWBConverter()
validate(instance=converter.get_metadata(), schema=converter.get_metadata_schema())
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? Read about [PEP8](https://www.python.org/dev/peps/pep-0008/) and [black](https://black.readthedocs.io/en/stable/the_black_code_style.html).
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
