### PR TITLE
adding spikeextractors tests for nwb, including new metadata

### DIFF
--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -844,8 +844,7 @@ def write_recording(
         metadata = dict_deep_update(recording.nwb_metadata, metadata)
     elif metadata is None:
         # If not NWBRecording, make metadata from information available on Recording
-        metadata_0 = get_nwb_metadata(recording=recording)
-        metadata = dict_deep_update(metadata_0, metadata)
+        metadata = get_nwb_metadata(recording=recording)
 
     if nwbfile is None:
         if Path(save_path).is_file() and not overwrite:

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -5,8 +5,10 @@ import numpy as np
 import distutils.version
 from pathlib import Path
 from typing import Union
+
 import spikeextractors as se
 import pynwb
+
 from hdmf.data_utils import DataChunkIterator
 from hdmf.backends.hdf5.h5_utils import H5DataIO
 from .json_schema import dict_deep_update

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -16,13 +16,10 @@ class TestExtractors(unittest.TestCase):
     def setUp(self):
         self.RX, self.RX2, self.RX3, self.SX, self.SX2, self.SX3, self.example_info = self._create_example(seed=0)
         self.test_dir = tempfile.mkdtemp()
-        # self.test_dir = '.'
 
     def tearDown(self):
-        # Remove the directory after the test
         del self.RX, self.RX2, self.RX3, self.SX, self.SX2, self.SX3
         shutil.rmtree(self.test_dir)
-        # pass
 
     def _create_example(self, seed):
         channel_ids = [0, 1, 2, 3]

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -1,0 +1,322 @@
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+import numpy as np
+
+import spikeextractors as se
+from spikeextractors.testing import (
+    check_sortings_equal, check_recordings_equal, check_dumping, check_recording_return_types,
+    get_default_nwbfile_metadata
+)
+from pynwb import NWBHDF5IO
+
+
+class TestExtractors(unittest.TestCase):
+    def setUp(self):
+        self.RX, self.RX2, self.RX3, self.SX, self.SX2, self.SX3, self.example_info = self._create_example(seed=0)
+        self.test_dir = tempfile.mkdtemp()
+        # self.test_dir = '.'
+
+    def tearDown(self):
+        # Remove the directory after the test
+        del self.RX, self.RX2, self.RX3, self.SX, self.SX2, self.SX3
+        shutil.rmtree(self.test_dir)
+        # pass
+
+    def _create_example(self, seed):
+        channel_ids = [0, 1, 2, 3]
+        num_channels = 4
+        num_frames = 10000
+        num_ttls = 30
+        sampling_frequency = 30000
+        X = np.random.RandomState(seed=seed).normal(0, 1, (num_channels, num_frames))
+        geom = np.random.RandomState(seed=seed).normal(0, 1, (num_channels, 2))
+        X = (X * 100).astype(int)
+        ttls = np.sort(np.random.permutation(num_frames)[:num_ttls])
+
+        RX = se.NumpyRecordingExtractor(timeseries=X, sampling_frequency=sampling_frequency, geom=geom)
+        RX.set_ttls(ttls)
+        RX.set_channel_locations([0, 0], channel_ids=0)
+        RX.add_epoch("epoch1", 0, 10)
+        RX.add_epoch("epoch2", 10, 20)
+        for i, channel_id in enumerate(RX.get_channel_ids()):
+            RX.set_channel_property(channel_id=channel_id, property_name='shared_channel_prop', value=i)
+
+        RX2 = se.NumpyRecordingExtractor(timeseries=X, sampling_frequency=sampling_frequency, geom=geom)
+        RX2.copy_epochs(RX)
+        times = np.arange(RX.get_num_frames()) / RX.get_sampling_frequency() + 5
+        RX2.set_times(times)
+
+        RX3 = se.NumpyRecordingExtractor(timeseries=X, sampling_frequency=sampling_frequency, geom=geom)
+
+        SX = se.NumpySortingExtractor()
+        SX.set_sampling_frequency(sampling_frequency)
+        spike_times = [200, 300, 400]
+        train1 = np.sort(np.rint(np.random.RandomState(seed=seed).uniform(0, num_frames, spike_times[0])).astype(int))
+        SX.add_unit(unit_id=1, times=train1)
+        SX.add_unit(unit_id=2, times=np.sort(np.random.RandomState(seed=seed).uniform(0, num_frames, spike_times[1])))
+        SX.add_unit(unit_id=3, times=np.sort(np.random.RandomState(seed=seed).uniform(0, num_frames, spike_times[2])))
+        SX.set_unit_property(unit_id=1, property_name='stability', value=80)
+        SX.add_epoch("epoch1", 0, 10)
+        SX.add_epoch("epoch2", 10, 20)
+
+        SX2 = se.NumpySortingExtractor()
+        SX2.set_sampling_frequency(sampling_frequency)
+        spike_times2 = [100, 150, 450]
+        train2 = np.rint(np.random.RandomState(seed=seed).uniform(0, num_frames, spike_times2[0])).astype(int)
+        SX2.add_unit(unit_id=3, times=train2)
+        SX2.add_unit(unit_id=4, times=np.random.RandomState(seed=seed).uniform(0, num_frames, spike_times2[1]))
+        SX2.add_unit(unit_id=5, times=np.random.RandomState(seed=seed).uniform(0, num_frames, spike_times2[2]))
+        SX2.set_unit_property(unit_id=4, property_name='stability', value=80)
+        SX2.set_unit_spike_features(unit_id=3, feature_name='widths', value=np.asarray([3] * spike_times2[0]))
+        SX2.copy_epochs(SX)
+        SX2.copy_times(RX2)
+        for i, unit_id in enumerate(SX2.get_unit_ids()):
+            SX2.set_unit_property(unit_id=unit_id, property_name='shared_unit_prop', value=i)
+            SX2.set_unit_spike_features(
+                unit_id=unit_id,
+                feature_name='shared_unit_feature',
+                value=np.asarray([i] * spike_times2[i])
+            )
+
+        SX3 = se.NumpySortingExtractor()
+        train3 = np.asarray([1, 20, 21, 35, 38, 45, 46, 47])
+        SX3.add_unit(unit_id=0, times=train3)
+        features3 = np.asarray([0, 5, 10, 15, 20, 25, 30, 35])
+        features4 = np.asarray([0, 10, 20, 30])
+        feature4_idx = np.asarray([0, 2, 4, 6])
+        SX3.set_unit_spike_features(unit_id=0, feature_name='dummy', value=features3)
+        SX3.set_unit_spike_features(unit_id=0, feature_name='dummy2', value=features4, indexes=feature4_idx)
+
+        example_info = dict(
+            channel_ids=channel_ids,
+            num_channels=num_channels,
+            num_frames=num_frames,
+            sampling_frequency=sampling_frequency,
+            unit_ids=[1, 2, 3],
+            train1=train1,
+            train2=train2,
+            train3=train3,
+            features3=features3,
+            unit_prop=80,
+            channel_prop=(0, 0),
+            ttls=ttls,
+            epochs_info=((0, 10), (10, 20)),
+            geom=geom,
+            times=times
+        )
+
+        return (RX, RX2, RX3, SX, SX2, SX3, example_info)
+
+
+    def test_nwb_extractor(self):
+        path1 = self.test_dir + '/test.nwb'
+        se.NwbRecordingExtractor.write_recording(self.RX, path1)
+        RX_nwb = se.NwbRecordingExtractor(path1)
+        check_recording_return_types(RX_nwb)
+        check_recordings_equal(self.RX, RX_nwb)
+        check_dumping(RX_nwb)
+
+        del RX_nwb
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path1, overwrite=True)
+        RX_nwb = se.NwbRecordingExtractor(path1)
+        check_recording_return_types(RX_nwb)
+        check_recordings_equal(self.RX, RX_nwb)
+        check_dumping(RX_nwb)
+
+        # append sorting to existing file
+        se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path1, overwrite=False)
+
+        path2 = self.test_dir + "/firings_true.nwb"
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path2)
+        se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path2)
+        SX_nwb = se.NwbSortingExtractor(path2)
+        check_sortings_equal(self.SX, SX_nwb)
+        check_dumping(SX_nwb)
+
+        # Test for handling unit property descriptions argument
+        property_descriptions = dict(stability="This is a description of stability.")
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path1, overwrite=True)
+        se.NwbSortingExtractor.write_sorting(
+            sorting=self.SX,
+            save_path=path1,
+            property_descriptions=property_descriptions
+        )
+        SX_nwb = se.NwbSortingExtractor(path1)
+        check_sortings_equal(self.SX, SX_nwb)
+        check_dumping(SX_nwb)
+
+        # Test for handling skip_properties argument
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path1, overwrite=True)
+        se.NwbSortingExtractor.write_sorting(
+            sorting=self.SX,
+            save_path=path1,
+            skip_properties=['stability']
+        )
+        SX_nwb = se.NwbSortingExtractor(path1)
+        assert 'stability' not in SX_nwb.get_shared_unit_property_names()
+        check_sortings_equal(self.SX, SX_nwb)
+        check_dumping(SX_nwb)
+
+        # Test for handling skip_features argument
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path1, overwrite=True)
+        # SX2 has timestamps, so loading it back from Nwb will not recover the same spike frames. USe use_times=False
+        se.NwbSortingExtractor.write_sorting(
+            sorting=self.SX2,
+            save_path=path1,
+            skip_features=['widths'],
+            use_times=False
+        )
+        SX_nwb = se.NwbSortingExtractor(path1)
+        assert 'widths' not in SX_nwb.get_shared_unit_spike_feature_names()
+        check_sortings_equal(self.SX2, SX_nwb)
+        check_dumping(SX_nwb)
+
+        # Test writting multiple recordings using metadata
+        metadata = get_default_nwbfile_metadata()
+        path_nwb = self.test_dir + '/test_multiple.nwb'
+        se.NwbRecordingExtractor.write_recording(
+            recording=self.RX,
+            save_path=path_nwb,
+            metadata=metadata,
+            write_as='raw',
+            es_key='ElectricalSeries_raw',
+        )
+        se.NwbRecordingExtractor.write_recording(
+            recording=self.RX2,
+            save_path=path_nwb,
+            metadata=metadata,
+            write_as='processed',
+            es_key='ElectricalSeries_processed',
+        )
+        se.NwbRecordingExtractor.write_recording(
+            recording=self.RX3,
+            save_path=path_nwb,
+            metadata=metadata,
+            write_as='lfp',
+            es_key='ElectricalSeries_lfp',
+        )
+
+        RX_nwb = se.NwbRecordingExtractor(
+            file_path=path_nwb,
+            electrical_series_name='raw_traces'
+        )
+        check_recording_return_types(RX_nwb)
+        check_recordings_equal(self.RX, RX_nwb)
+        check_dumping(RX_nwb)
+        del RX_nwb
+
+    def check_metadata_write(self, metadata: dict, nwbfile_path: Path, recording: se.RecordingExtractor):
+        standard_metadata = se.NwbRecordingExtractor.get_nwb_metadata(recording=recording)
+        device_defaults = dict(  # from the individual add_devices function
+            name="Device",
+            description="no description"
+        )
+        electrode_group_defaults = dict(  # from the individual add_electrode_groups function
+            name="Electrode Group",
+            description="no description",
+            location="unknown",
+            device="Device"
+        )
+
+        with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
+            nwbfile = io.read()
+
+            device_source = metadata["Ecephys"].get("Device", standard_metadata["Ecephys"]["Device"])
+            self.assertEqual(len(device_source), len(nwbfile.devices))
+            for device in device_source:
+                device_name = device.get("name", device_defaults["name"])
+                self.assertIn(device_name, nwbfile.devices)
+                self.assertEqual(
+                    device.get("description", device_defaults["description"]), nwbfile.devices[device_name].description
+                )
+                self.assertEqual(device.get("manufacturer"), nwbfile.devices[device["name"]].manufacturer)
+
+            electrode_group_source = metadata["Ecephys"].get(
+                "ElectrodeGroup",
+                standard_metadata["Ecephys"]["ElectrodeGroup"]
+            )
+            self.assertEqual(len(electrode_group_source), len(nwbfile.electrode_groups))
+            for group in electrode_group_source:
+                group_name = group.get("name", electrode_group_defaults["name"])
+                self.assertIn(group_name, nwbfile.electrode_groups)
+                self.assertEqual(
+                    group.get("description", electrode_group_defaults["description"]),
+                    nwbfile.electrode_groups[group_name].description
+                )
+                self.assertEqual(
+                    group.get("location", electrode_group_defaults["location"]),
+                    nwbfile.electrode_groups[group_name].location
+                )
+                device_name = group.get("device", electrode_group_defaults["device"])
+                self.assertIn(device_name, nwbfile.devices)
+                self.assertEqual(nwbfile.electrode_groups[group_name].device, nwbfile.devices[device_name])
+
+            n_channels = len(recording.get_channel_ids())
+            electrode_source = metadata["Ecephys"].get("Electrodes", [])
+            self.assertEqual(n_channels, len(nwbfile.electrodes))
+            for column in electrode_source:
+                column_name = column["name"]
+                self.assertIn(column_name, nwbfile.electrodes)
+                self.assertEqual(column["description"], getattr(nwbfile.electrodes, column_name).description)
+                if column_name in ["x", "y", "z", "rel_x", "rel_y", "rel_z"]:
+                    for j in n_channels:
+                        self.assertEqual(column["data"][j], getattr(nwbfile.electrodes[j], column_name).values[0])
+                else:
+                    for j in n_channels:
+                        self.assertTrue(
+                            column["data"][j] == getattr(nwbfile.electrodes[j], column_name).values[0]
+                            or (
+                                np.isnan(column["data"][j])
+                                and np.isnan(getattr(nwbfile.electrodes[j], column_name).values[0])
+                            )
+                        )
+
+    def test_nwb_metadata(self):
+        path = self.test_dir + '/test_metadata.nwb'
+
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path, overwrite=True)
+        self.check_metadata_write(
+            metadata=se.NwbRecordingExtractor.get_nwb_metadata(recording=self.RX),
+            nwbfile_path=path,
+            recording=self.RX
+        )
+
+        # Manually adjusted device name - must properly adjust electrode_group reference
+        metadata2 = se.NwbRecordingExtractor.get_nwb_metadata(recording=self.RX)
+        metadata2["Ecephys"]["Device"] = [dict(name="TestDevice", description="A test device.", manufacturer="unknown")]
+        metadata2["Ecephys"]["ElectrodeGroup"][0]["device"] = "TestDevice"
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, metadata=metadata2, save_path=path, overwrite=True)
+        self.check_metadata_write(
+            metadata=metadata2,
+            nwbfile_path=path,
+            recording=self.RX
+        )
+
+        # Two devices in metadata
+        metadata3 = se.NwbRecordingExtractor.get_nwb_metadata(recording=self.RX)
+        metadata3["Ecephys"]["Device"].append(
+            dict(name="Device2", description="A second device.", manufacturer="unknown")
+        )
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, metadata=metadata3, save_path=path, overwrite=True)
+        self.check_metadata_write(
+            metadata=metadata3,
+            nwbfile_path=path,
+            recording=self.RX
+        )
+
+        # Forcing default auto-population from add_electrode_groups, and not get_nwb_metdata
+        metadata4 = se.NwbRecordingExtractor.get_nwb_metadata(recording=self.RX)
+        metadata4["Ecephys"]["Device"] = [dict(name="TestDevice", description="A test device.", manufacturer="unknown")]
+        metadata4["Ecephys"].pop("ElectrodeGroup")
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, metadata=metadata4, save_path=path, overwrite=True)
+        self.check_metadata_write(
+            metadata=metadata4,
+            nwbfile_path=path,
+            recording=self.RX
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Motivation

We recently moved the write_recording method from spikeextractors to nwb-conversion-tools, but lost that rich testing infrastructure that spikeinterface uses. This is the start of restoring that on our end.

## How to test the behavior?
```
!pytest  # from the working directory of the repository
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style? Read about [PEP8](https://www.python.org/dev/peps/pep-0008/) and [black](https://black.readthedocs.io/en/stable/the_black_code_style.html).
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
