### PR TITLE
get_conversion_options() method and some datainterface updates

### DIFF
--- a/nwb_conversion_tools/basedatainterface.py
+++ b/nwb_conversion_tools/basedatainterface.py
@@ -30,6 +30,11 @@ class BaseDataInterface(ABC):
         return metadata_schema
 
     def get_metadata(self):
+        """Child DataInterface classes should override this to match their metadata"""
+        return dict()
+
+    def get_conversion_options(self):
+        """Child DataInterface classes should override this to match their conversion options"""
         return dict()
 
     @abstractmethod

--- a/nwb_conversion_tools/datainterfaces/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/blackrockdatainterface.py
@@ -26,7 +26,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
     def get_source_schema(cls):
         """Compile input schema for the RecordingExtractor."""
         metadata_schema = get_schema_from_method_signature(
-            class_method=cls.RX.__init__,
+            class_method=cls.__init__,
             exclude=['block_index', 'seg_index']
         )
         metadata_schema['additionalProperties'] = True

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -94,6 +94,13 @@ class NWBConverter:
             metadata = dict_deep_update(metadata, interface_metadata)
         return metadata
 
+    def get_conversion_options(self):
+        """Auto-fill as much of the conversion options as possible. Must comply with conversion_options_schema."""
+        conversion_options = dict()
+        for interface_name, interface in self.data_interface_objects.items():
+            conversion_options[interface_name] = interface_name=interface.get_conversion_options()
+        return conversion_options
+
     def validate_metadata(self, metadata):
         """Validate metadata against Converter metadata_schema."""
         validate(instance=metadata, schema=self.get_metadata_schema())

--- a/nwb_conversion_tools/nwbconverter.py
+++ b/nwb_conversion_tools/nwbconverter.py
@@ -145,7 +145,7 @@ class NWBConverter:
 
         # Validate conversion options
         if conversion_options is None:
-            conversion_options = dict()
+            conversion_options = self.get_conversion_options()
         else:
             self.validate_conversion_options(conversion_options=conversion_options)
 


### PR DESCRIPTION
- [x] Method `get_conversion_options()` added for base datainterfaces and converter classes. This will allow us to generate the default `conversion_options` for each data interface that complies with `conversion_options_schema`

updates on data interfaces: 
- [x] blackrock