### PR TITLE
No additonal properties

### DIFF
--- a/nwb_conversion_tools/datainterfaces/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/blackrockdatainterface.py
@@ -25,14 +25,13 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
     @classmethod
     def get_source_schema(cls):
         """Compile input schema for the RecordingExtractor."""
-        metadata_schema = get_schema_from_method_signature(
+        source_schema = get_schema_from_method_signature(
             class_method=cls.__init__,
             exclude=['block_index', 'seg_index']
         )
-        metadata_schema['additionalProperties'] = True
-        metadata_schema['properties']['filename']['format'] = 'file'
-        metadata_schema['properties']['filename']['description'] = 'Path to Blackrock file.'
-        return metadata_schema
+        source_schema['properties']['filename']['format'] = 'file'
+        source_schema['properties']['filename']['description'] = 'Path to Blackrock file.'
+        return source_schema
     
     def __init__(self, filename: PathType):
         nsx_to_load = int(str(filename).split('.')[-1][-1])

--- a/nwb_conversion_tools/datainterfaces/openephysdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/openephysdatainterface.py
@@ -24,14 +24,13 @@ class OpenEphysRecordingExtractorInterface(BaseRecordingExtractorInterface):
     @classmethod
     def get_source_schema(cls):
         """Compile input schema for the RecordingExtractor."""
-        metadata_schema = get_schema_from_method_signature(
+        source_schema = get_schema_from_method_signature(
             class_method=cls.__init__,
             exclude=['recording_id', 'experiment_id', 'stub_test']
         )
-        metadata_schema['properties']['folder_path']['format'] = 'directory'
-        metadata_schema['properties']['folder_path']['description'] = 'Path to directory containing OpenEphys files.'
-        metadata_schema['additionalProperties'] = True
-        return metadata_schema
+        source_schema['properties']['folder_path']['format'] = 'directory'
+        source_schema['properties']['folder_path']['description'] = 'Path to directory containing OpenEphys files.'
+        return source_schema
     
     def __init__(self, folder_path: PathType, experiment_id: Optional[int] = 0, 
                  recording_id: Optional[int] = 0, stub_test: Optional[bool] = False):

--- a/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
@@ -20,14 +20,13 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
     @classmethod
     def get_source_schema(cls):
         """Compile input schema for the RecordingExtractor."""
-        metadata_schema = get_schema_from_method_signature(
+        source_schema = get_schema_from_method_signature(
             class_method=cls.RX.__init__,
             exclude=['x_pitch', 'y_pitch']
         )
-        metadata_schema['additionalProperties'] = True
-        metadata_schema['properties']['file_path']['format'] = 'file'
-        metadata_schema['properties']['file_path']['description'] = 'Path to SpikeGLX file.'
-        return metadata_schema
+        source_schema['properties']['file_path']['format'] = 'file'
+        source_schema['properties']['file_path']['description'] = 'Path to SpikeGLX file.'
+        return source_schema
 
     def __init__(self, file_path: PathType, stub_test: Optional[bool] = False):
         super().__init__(file_path=str(file_path))


### PR DESCRIPTION
fix names of dictionaries and remove additionalProperties in `Converter.get_source_schema()` for Blackrock, Openephys and SpikeGLX
