### PR TITLE
Fixes for SpikeGLX

### DIFF
--- a/nwb_conversion_tools/baselfpextractorinterface.py
+++ b/nwb_conversion_tools/baselfpextractorinterface.py
@@ -23,7 +23,6 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
                 )
             )
         )
-
         return metadata
 
     def run_conversion(
@@ -69,8 +68,8 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
             nwbfile=nwbfile,
             metadata=metadata,
             use_times=use_times,
-            write_as='lfp',
-            es_key='LFPElectricalSeries',
+            write_as="lfp",
+            es_key="ElectricalSeries_lfp",
             save_path=save_path,
             overwrite=overwrite,
             buffer_mb=buffer_mb

--- a/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/neuroscopedatainterface.py
@@ -169,7 +169,7 @@ class NeuroscopeLFPInterface(BaseLFPExtractorInterface):
             xml_file_path=get_xml_file_path(data_file_path=self.source_data['file_path'])
         )
         metadata['Ecephys'].update(
-            LFPElectricalSeries=dict(
+            ElectricalSeries_lfp=dict(
                 name="LFP",
                 description="Local field potential signal."
             )

--- a/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/spikeglxdatainterface.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from pathlib import Path
 from typing import Union, Optional
-from spikeextractors import SpikeGLXRecordingExtractor, SubRecordingExtractor
+from spikeextractors import SpikeGLXRecordingExtractor, SubRecordingExtractor, RecordingExtractor
 from pynwb.ecephys import ElectricalSeries
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
@@ -10,6 +10,58 @@ from ..baselfpextractorinterface import BaseLFPExtractorInterface
 from ..utils.json_schema import get_schema_from_method_signature, get_schema_from_hdmf_class
 
 PathType = Union[str, Path, None]
+
+
+def fetch_spikeglx_metadata(file_path: str, recording: RecordingExtractor, metadata: dict):
+    # file_path = Path(self.source_data['file_path'])
+    file_path = Path(file_path)
+    session_id = file_path.parent.stem
+
+    if isinstance(recording, SubRecordingExtractor):
+        n_shanks = int(recording._parent_recording._meta.get('snsShankMap', [1, 1])[1])
+        session_start_time = datetime.fromisoformat(
+            recording._parent_recording._meta['fileCreateTime']
+        ).astimezone()
+    else:
+        n_shanks = int(recording._meta.get('snsShankMap', [1, 1])[1])
+        session_start_time = datetime.fromisoformat(recording._meta['fileCreateTime']).astimezone()
+    if n_shanks > 1:
+        raise NotImplementedError("SpikeGLX metadata for more than a single shank is not yet supported.")
+
+    channels = recording.get_channel_ids()
+    shank_electrode_number = channels
+    shank_group_name = ["Shank1" for x in channels]
+
+    metadata['NWBFile'] = dict(session_start_time=session_start_time.strftime('%Y-%m-%dT%H:%M:%S'))
+
+    metadata['Ecephys'] = dict(
+        Device=[
+            dict(
+                name='Device_ecephys',
+                description=f"More details for the high-pass (ap) data found in {session_id}.ap.meta!"
+            )
+        ],
+        ElectrodeGroup=[
+            dict(
+                name='Shank1',
+                description="Shank1 electrodes.",
+                location='no description',
+                device='Device_ecephys'
+            )
+        ],
+        Electrodes=[
+            dict(
+                name='shank_electrode_number',
+                description="0-indexed channel within a shank.",
+                data=shank_electrode_number
+            ),
+            dict(
+                name='group_name',
+                description="The name of the ElectrodeGroup this electrode is a part of.",
+                data=shank_group_name
+            )
+        ]
+    )
 
 
 class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
@@ -22,11 +74,11 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
         """Compile input schema for the RecordingExtractor."""
         metadata_schema = get_schema_from_method_signature(
             class_method=cls.RX.__init__,
-            exclude=['x_pitch', 'y_pitch']
+            exclude=["x_pitch", "y_pitch"]
         )
-        metadata_schema['additionalProperties'] = True
-        metadata_schema['properties']['file_path']['format'] = 'file'
-        metadata_schema['properties']['file_path']['description'] = 'Path to SpikeGLX file.'
+        metadata_schema["additionalProperties"] = True
+        metadata_schema["properties"]["file_path"]["format"] = "file"
+        metadata_schema["properties"]["file_path"]["description"] = "Path to SpikeGLX file."
         return metadata_schema
 
     def __init__(self, file_path: PathType, stub_test: Optional[bool] = False):
@@ -35,96 +87,32 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
             self.subset_channels = [0, 1]
 
     def get_metadata_schema(self):
-        """Compile metadata schema for the RecordingExtractor."""
         metadata_schema = super().get_metadata_schema()
-        metadata_schema['properties']['Ecephys']['properties'].update(
+        metadata_schema["properties"]["Ecephys"]["properties"].update(
             ElectricalSeries_raw=get_schema_from_hdmf_class(ElectricalSeries),
             ElectricalSeries_lfp=get_schema_from_hdmf_class(ElectricalSeries)
         )
         return metadata_schema
 
     def get_metadata(self):
-        """Auto-fill as much of the metadata as possible. Must comply with metadata schema."""
         metadata = super().get_metadata()
-
-        file_path = Path(self.source_data['file_path'])
-        session_id = file_path.parent.stem
-
-        if isinstance(self.recording_extractor, SubRecordingExtractor):
-            n_shanks = int(self.recording_extractor._parent_recording._meta.get('snsShankMap', [1, 1])[1])
-            session_start_time = datetime.fromisoformat(
-                self.recording_extractor._parent_recording._meta['fileCreateTime']
-            ).astimezone()
-        else:
-            n_shanks = int(self.recording_extractor._meta.get('snsShankMap', [1, 1])[1])
-            session_start_time = datetime.fromisoformat(self.recording_extractor._meta['fileCreateTime']).astimezone()
-        if n_shanks > 1:
-            raise NotImplementedError("SpikeGLX metadata for more than a single shank is not yet supported.")
-
-        channels = self.recording_extractor.get_channel_ids()
-        shank_electrode_number = channels
-        shank_group_name = ["Shank1" for x in channels]
-
-        metadata['NWBFile'] = dict(
-            session_start_time=session_start_time.strftime('%Y-%m-%dT%H:%M:%S'),
+        fetch_spikeglx_metadata(
+            file_path=self.source_data["file_path"],
+            recording=self.recording_extractor,
+            metadata=metadata
         )
-
-        metadata['Ecephys'] = dict(
-            Device=[
-                dict(
-                    name='Device_ecephys',
-                    description=f"More details for the high-pass (ap) data found in {session_id}.ap.meta!"
-                )
-            ],
-            ElectrodeGroup=[
-                dict(
-                    name='Shank1',
-                    description="Shank1 electrodes.",
-                    location='no description', 
-                    device='Device_ecephys'
-                )
-            ],
-            Electrodes=[
-                dict(
-                    name='shank_electrode_number',
-                    description="0-indexed channel within a shank.",
-                    data=shank_electrode_number
-                ),
-                dict(
-                    name='group_name',
-                    description="The name of the ElectrodeGroup this electrode is a part of.",
-                    data=shank_group_name
-                )
-            ]
+        metadata["Ecephys"]["ElectricalSeries_raw"] = dict(
+            name="ElectricalSeries_raw",
+            description="Raw acquisition traces for the high-pass (ap) SpikeGLX data."
         )
-
-        if self.source_data['file_path'].split('.')[-2] == 'ap':
-            metadata['Ecephys']['ElectricalSeries_raw'] = dict(
-                name='ElectricalSeries_raw',
-                description="Raw acquisition traces for the high-pass (ap) SpikeGLX data."
-            )
-        elif self.source_data['file_path'].split('.')[-2] == 'lf':
-            metadata['Ecephys']['ElectricalSeries_lfp'] = dict(
-                name='ElectricalSeries_lfp',
-                description="LFP traces for the processed (lf) SpikeGLX data."
-            )
-
         return metadata
 
     def get_conversion_options(self):
-        conversion_options = dict()
-        if self.source_data['file_path'].split('.')[-2] == 'ap':
-            conversion_options = dict(
-                write_as='raw', 
-                es_key='ElectricalSeries_raw', 
-                stub_test=False
-            )
-        elif self.source_data['file_path'].split('.')[-2] == 'lf':
-            conversion_options = dict(
-                write_as='lfp', 
-                es_key='ElectricalSeries_lfp', 
-                stub_test=False
-            )  
+        conversion_options = dict(
+            write_as="raw",
+            es_key="ElectricalSeries_raw",
+            stub_test=False
+        )
         return conversion_options
 
 
@@ -132,3 +120,24 @@ class SpikeGLXLFPInterface(BaseLFPExtractorInterface):
     """Primary data interface class for converting the low-pass (ap) SpikeGLX format."""
 
     RX = SpikeGLXRecordingExtractor
+
+    def get_metadata(self):
+        metadata = super().get_metadata()
+        fetch_spikeglx_metadata(
+            file_path=self.source_data["file_path"],
+            recording=self.recording_extractor,
+            metadata=metadata
+        )
+        metadata["Ecephys"]["ElectricalSeries_lfp"] = dict(
+            name="ElectricalSeries_lfp",
+            description="LFP traces for the processed (lf) SpikeGLX data."
+        )
+        return metadata
+
+    def get_conversion_options(self):
+        conversion_options = dict(
+            write_as="lfp",
+            es_key="ElectricalSeries_lfp",
+            stub_test=False
+        )
+        return conversion_options


### PR DESCRIPTION
Accommodate the possibility of writing spikeglx traces as raw (`ap` extension) or lfp (`lf` extension). 

@CodyCBakerPhD I think this will be important for Brody lab [here](https://github.com/catalystneuro/brody-lab-to-nwb/pull/5).
I tested on MovshonSpikeGLXConverter and it is working over [there](https://github.com/catalystneuro/movshon-lab-to-nwb/blob/main/tutorials/spikeglx_nwb_conversion_simple.ipynb).
