### PR TITLE
enhanced add_electrical_series

### DIFF
--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -973,7 +973,9 @@ def write_recording(
                 use_times=use_times,
                 write_as=write_as,
                 es_key=es_key,
-                write_scaled=write_scaled
+                write_scaled=write_scaled,
+                compression=compression,
+                iterate=iterate
             )
 
             # Write to file
@@ -987,7 +989,9 @@ def write_recording(
             metadata=metadata,
             write_as=write_as,
             es_key=es_key,
-            write_scaled=write_scaled
+            write_scaled=write_scaled,
+            compression=compression,
+            iterate=iterate
         )
 
 def get_nspikes(units_table, unit_id):

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -5,6 +5,8 @@ import numpy as np
 import distutils.version
 from pathlib import Path
 from typing import Union, Optional, List
+from warnings import warn
+import psutil
 
 import spikeextractors as se
 import pynwb
@@ -461,7 +463,9 @@ def add_electrical_series(
     write_as: str = 'raw',
     es_key: str = None,
     write_scaled: bool = False,
-    compression: Optional[str] = "gzip"
+    compression: Optional[str] = "gzip",
+    compression_opts: Optional[int] = None,
+    iterate: bool = True
 ):
     """
     Auxiliary static method for nwbextractor.
@@ -485,7 +489,7 @@ def add_electrical_series(
         If True, the times are saved to the nwb file using recording.frame_to_time(). If False (defualut),
         the sampling rate is used.
     write_as: str (optional, defaults to 'raw')
-        How to save the traces data in the nwb file. Options: 
+        How to save the traces data in the nwb file. Options:
         - 'raw' will save it in acquisition
         - 'processed' will save it as FilteredEphys, in a processing module
         - 'lfp' will save it as LFP, in a processing module
@@ -493,20 +497,38 @@ def add_electrical_series(
         Key in metadata dictionary containing metadata info for the specific electrical series
     write_scaled: bool (optional, defaults to True)
         If True, writes the scaled traces (return_scaled=True)
+    compression: str (optional, defaults to "gzip")
+        Type of compression to use. Valid types are "gzip" and "lzf".
+        Set to None to disable all compression.
+    compression_opts: int (optional, defaults to 4)
+        Only applies to compression="gzip". Controls the level of the GZIP.
+    iterate: bool (optional, defaults to True)
+        Whether or not to use DataChunkIteration. Highly recommended for large (16+ GB) recordings.
 
     Missing keys in an element of metadata['Ecephys']['ElectrodeGroup'] will be auto-populated with defaults
     whenever possible.
     """
     if nwbfile is not None:
         assert isinstance(nwbfile, pynwb.NWBFile), "'nwbfile' should be of type pynwb.NWBFile!"
-
     assert buffer_mb > 10, "'buffer_mb' should be at least 10MB to ensure data can be chunked!"
+    assert compression is None or compression in ["gzip", "lzf"], \
+        "Invalid compression type ({compression})! Choose one of 'gzip', 'lzf', or None."
 
     if not nwbfile.electrodes:
         add_electrodes(recording, nwbfile, metadata)
 
     assert write_as in ['raw', 'processed', 'lfp'], \
-        f"'write_as' should be 'raw', 'processed' or 'lfp', but intead received value {write_as}"
+        f"'write_as' should be 'raw', 'processed' or 'lfp', but instead received value {write_as}"
+
+    if compression == "gzip":
+        if compression_opts is None:
+            compression_opts = 4
+        else:
+            assert compression_opts in range(10), \
+                "compression type is 'gzip', but specified compression_opts is not an integer between 0 and 9!"
+    elif compression == "lzf" and compression_opts is not None:
+        warn(f"compression_opts ({compression_opts}) were passed, but compression type is 'lzf'! Ignoring options.")
+        compression_opts = None
 
     if write_as == 'raw':
         eseries_kwargs = dict(
@@ -594,37 +616,45 @@ def add_electrical_series(
             eseries_kwargs.update(conversion=1e-6)
             eseries_kwargs.update(channel_conversion=channel_conversion)
 
-    if isinstance(recording.get_traces(end_frame=5, return_scaled=write_scaled), np.memmap) \
-            and np.all(channel_offset == 0):
-        n_bytes = np.dtype(recording.get_dtype()).itemsize
-        buffer_size = int(buffer_mb * 1e6) // (recording.get_num_channels() * n_bytes)
-        ephys_data = DataChunkIterator(
-            data=recording.get_traces(return_scaled=write_scaled).T,  # nwb standard is time as zero axis
-            buffer_size=buffer_size
-        )
+    trace_dtype = recording.get_traces(channel_ids=[0], end_frame=1).dtype
+    estimated_memory = trace_dtype.itemsize * recording.get_num_channels() * recording.get_num_frames()
+    if not iterate and psutil.virtual_memory().available <= estimated_memory:
+        warn("iteration was disabled, but not enough memory to load traces! Forcing iterate=True.")
+        iterate = True
+    if iterate:
+        if isinstance(recording.get_traces(end_frame=5, return_scaled=write_scaled), np.memmap) \
+                and np.all(channel_offset == 0):
+            n_bytes = np.dtype(recording.get_dtype()).itemsize
+            buffer_size = int(buffer_mb * 1e6) // (recording.get_num_channels() * n_bytes)
+            ephys_data = DataChunkIterator(
+                data=recording.get_traces(return_scaled=write_scaled).T,  # nwb standard is time as zero axis
+                buffer_size=buffer_size
+            )
+        else:
+            def data_generator(recording, channels_ids, unsigned_coercion, write_scaled):
+                for i, ch in enumerate(channels_ids):
+                    data = recording.get_traces(channel_ids=[ch], return_scaled=write_scaled)
+                    if not write_scaled:
+                        data_dtype_name = data.dtype.name
+                        if data_dtype_name.startswith("uint"):
+                            data_dtype_name = data_dtype_name[1:]  # Retain memory of signed data type
+                        data = data + unsigned_coercion[i]
+                        data = data.astype(data_dtype_name)
+                    yield data.flatten()
+            ephys_data = DataChunkIterator(
+                data=data_generator(
+                    recording=recording,
+                    channels_ids=channel_ids,
+                    unsigned_coercion=unsigned_coercion,
+                    write_scaled=write_scaled
+                ),
+                iter_axis=1,  # nwb standard is time as zero axis
+                maxshape=(recording.get_num_frames(), recording.get_num_channels())
+            )
     else:
-        def data_generator(recording, channels_ids, unsigned_coercion, write_scaled):
-            for i, ch in enumerate(channels_ids):
-                data = recording.get_traces(channel_ids=[ch], return_scaled=write_scaled)
-                if not write_scaled:
-                    data_dtype_name = data.dtype.name
-                    if data_dtype_name.startswith("uint"):
-                        data_dtype_name = data_dtype_name[1:]  # Retain memory of signed data type
-                    data = data + unsigned_coercion[i]
-                    data = data.astype(data_dtype_name)
-                yield data.flatten()
-        ephys_data = DataChunkIterator(
-            data=data_generator(
-                recording=recording,
-                channels_ids=channel_ids,
-                unsigned_coercion=unsigned_coercion,
-                write_scaled=write_scaled
-            ),
-            iter_axis=1,  # nwb standard is time as zero axis
-            maxshape=(recording.get_num_frames(), recording.get_num_channels())
-        )
+        ephys_data = recording.get_traces(return_scaled=write_scaled).T
 
-    eseries_kwargs.update(data=H5DataIO(ephys_data, compression="gzip"))
+    eseries_kwargs.update(data=H5DataIO(ephys_data, compression=compression, compression_opts=compression_opts))
     if not use_times:
         eseries_kwargs.update(
             starting_time=recording.frame_to_time(0),
@@ -634,7 +664,8 @@ def add_electrical_series(
         eseries_kwargs.update(
             timestamps=H5DataIO(
                 recording.frame_to_time(np.arange(recording.get_num_frames())),
-                compression="gzip"
+                compression=compression,
+                compression_opts=compression_opts
             )
         )
 
@@ -646,15 +677,16 @@ def add_electrical_series(
         ecephys_mod.data_interfaces['Processed'].add_electrical_series(es)
     elif write_as == 'lfp':
         ecephys_mod.data_interfaces['LFP'].add_electrical_series(es)
-        
+
 
 def add_epochs(
-    recording: se.RecordingExtractor, 
+    recording: se.RecordingExtractor,
     nwbfile=None,
     metadata: dict = None
 ):
     """
     Auxiliary static method for nwbextractor.
+
     Adds epochs from recording object to nwbfile object.
 
     Parameters
@@ -698,7 +730,9 @@ def add_all_to_nwbfile(
     metadata: dict = None,
     write_as: str = 'raw',
     es_key: str = None,
-    write_scaled: bool = False
+    write_scaled: bool = False,
+    compression: Optional[str] = "gzip",
+    iterate: bool = True
 ):
     """
     Auxiliary static method for nwbextractor.
@@ -721,7 +755,7 @@ def add_all_to_nwbfile(
         Check the auxiliary function docstrings for more information
         about metadata format.
     write_as: str (optional, defaults to 'raw')
-        How to save the traces data in the nwb file. Options: 
+        How to save the traces data in the nwb file. Options:
         - 'raw' will save it in acquisition
         - 'processed' will save it as FilteredEphys, in a processing module
         - 'lfp' will save it as LFP, in a processing module
@@ -744,14 +778,14 @@ def add_all_to_nwbfile(
         nwbfile=nwbfile,
         metadata=metadata
     )
-    
+
     add_electrodes(
         recording=recording,
         nwbfile=nwbfile,
         metadata=metadata,
         write_scaled=write_scaled
     )
-    
+
     add_electrical_series(
         recording=recording,
         nwbfile=nwbfile,
@@ -760,7 +794,9 @@ def add_all_to_nwbfile(
         metadata=metadata,
         write_as=write_as,
         es_key=es_key,
-        write_scaled=write_scaled
+        write_scaled=write_scaled,
+        compression=compression,
+        iterate=iterate
     )
 
     add_epochs(
@@ -780,7 +816,9 @@ def write_recording(
     metadata: dict = None,
     write_as: str = 'raw',
     es_key: str = None,
-    write_scaled: bool = False
+    write_scaled: bool = False,
+    compression: Optional[str] = "gzip",
+    iterate: bool = True
 ):
     """
     Primary method for writing a RecordingExtractor object to an NWBFile.
@@ -823,7 +861,7 @@ def write_recording(
             metadata['Ecephys']['ElectricalSeries'] = {'name': my_name,
                                                         'description': my_description}
     write_as: str (optional, defaults to 'raw')
-        How to save the traces data in the nwb file. Options: 
+        How to save the traces data in the nwb file. Options:
         - 'raw' will save it in acquisition
         - 'processed' will save it as FilteredEphys, in a processing module
         - 'lfp' will save it as LFP, in a processing module
@@ -832,7 +870,6 @@ def write_recording(
     write_scaled: bool (optional, defaults to True)
         If True, writes the scaled traces (return_scaled=True)
     """
-
     if nwbfile is not None:
         assert isinstance(nwbfile, pynwb.NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
 

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -461,7 +461,7 @@ def add_electrical_series(
     write_as: str = 'raw',
     es_key: str = None,
     write_scaled: bool = False,
-    use_compression: bool = True
+    compression: Optional[str] = "gzip"
 ):
     """
     Auxiliary static method for nwbextractor.

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -809,6 +809,13 @@ def add_all_to_nwbfile(
         Key in metadata dictionary containing metadata info for the specific electrical series
     write_scaled: bool (optional, defaults to True)
         If True, writes the scaled traces (return_scaled=True)
+    compression: str (optional, defaults to "gzip")
+        Type of compression to use. Valid types are "gzip" and "lzf".
+        Set to None to disable all compression.
+    compression_opts: int (optional, defaults to 4)
+        Only applies to compression="gzip". Controls the level of the GZIP.
+    iterate: bool (optional, defaults to True)
+        Whether or not to use DataChunkIteration. Highly recommended for large (16+ GB) recordings.
     """
     if nwbfile is not None:
         assert isinstance(nwbfile, pynwb.NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
@@ -914,6 +921,13 @@ def write_recording(
         Key in metadata dictionary containing metadata info for the specific electrical series
     write_scaled: bool (optional, defaults to True)
         If True, writes the scaled traces (return_scaled=True)
+    compression: str (optional, defaults to "gzip")
+        Type of compression to use. Valid types are "gzip" and "lzf".
+        Set to None to disable all compression.
+    compression_opts: int (optional, defaults to 4)
+        Only applies to compression="gzip". Controls the level of the GZIP.
+    iterate: bool (optional, defaults to True)
+        Whether or not to use DataChunkIteration. Highly recommended for large (16+ GB) recordings.
     """
     if nwbfile is not None:
         assert isinstance(nwbfile, pynwb.NWBFile), "'nwbfile' should be of type pynwb.NWBFile"

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -460,7 +460,8 @@ def add_electrical_series(
     use_times: bool = False,
     write_as: str = 'raw',
     es_key: str = None,
-    write_scaled: bool = False
+    write_scaled: bool = False,
+    use_compression: bool = True
 ):
     """
     Auxiliary static method for nwbextractor.

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -303,7 +303,6 @@ class TestExtractors(unittest.TestCase):
             compression,
             f"Intended compression type does not match what was written! (Out: {compression_out}, should be: {compression})"
         )
-        self.assertN
         RX_nwb = se.NwbRecordingExtractor(path)
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 from datetime import datetime
 import time
+from warnings import warn
 
 import spikeextractors as se
 from spikeextractors.testing import (
@@ -246,7 +247,7 @@ class TestExtractors(unittest.TestCase):
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
         del RX_nwb
-        print(f"Time to write traces to NWB with default options: {round(time.perf_counter() - start, 2)}s")
+        warn(f"Time to write traces to NWB with default options: {round(time.perf_counter() - start, 2)}s")
 
         start = time.perf_counter()
         write_recording(recording=self.RX, save_path=path, overwrite=True, compression="lzf")
@@ -255,7 +256,7 @@ class TestExtractors(unittest.TestCase):
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
         del RX_nwb
-        print(f"Time to write traces to NWB with 'lzf' compression: {round(time.perf_counter() - start, 2)}s")
+        warn(f"Time to write traces to NWB with 'lzf' compression: {round(time.perf_counter() - start, 2)}s")
 
         start = time.perf_counter()
         write_recording(recording=self.RX, save_path=path, overwrite=True, compression=None)
@@ -264,7 +265,7 @@ class TestExtractors(unittest.TestCase):
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
         del RX_nwb
-        print(f"Time to write traces to NWB with no compression: {round(time.perf_counter() - start, 2)}s")
+        warn(f"Time to write traces to NWB with no compression: {round(time.perf_counter() - start, 2)}s")
 
         start = time.perf_counter()
         write_recording(recording=self.RX, save_path=path, overwrite=True, compression=None, iterate=False)
@@ -273,7 +274,7 @@ class TestExtractors(unittest.TestCase):
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
         del RX_nwb
-        print(f"Time to write traces to NWB with no compression or iteration: {round(time.perf_counter() - start, 2)}s")
+        warn(f"Time to write traces to NWB with no compression or iteration: {round(time.perf_counter() - start, 2)}s")
 
     def test_write_sorting(self):
         path = self.test_dir + '/test.nwb'

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -251,7 +251,7 @@ class TestExtractors(unittest.TestCase):
         del RX_nwb
         warn(
             "Time to write float traces to NWB with default options: "
-            f"{round(trace_size_mb / (time.perf_counter() - start), 2)}MB/s"
+            f"{round(trace_size_mb / (time.perf_counter() - start), 5)}MB/s"
         )
 
         write_recording(recording=self.RX, save_path=path, overwrite=True, compression="lzf")
@@ -277,7 +277,7 @@ class TestExtractors(unittest.TestCase):
         del RX_nwb
         warn(
             "Time to write float traces to NWB with no compression or iteration: "
-            f"{round(trace_size_mb / (time.perf_counter() - start), 2)}MB/s"
+            f"{round(trace_size_mb / (time.perf_counter() - start), 5)}MB/s"
         )
 
     def test_write_sorting(self):

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -241,31 +241,32 @@ class TestExtractors(unittest.TestCase):
             es_key='ElectricalSeries_lfp',
         )
 
+        trace_dtype = self.RX.get_traces(channel_ids=[0], end_frame=1).dtype
+        trace_size_mb = trace_dtype.itemsize * self.RX.get_num_channels() * self.RX.get_num_frames() * 1e-6
         start = time.perf_counter()
         RX_nwb = se.NwbRecordingExtractor(file_path=path_multi, electrical_series_name='raw_traces')
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
         del RX_nwb
-        warn(f"Time to write traces to NWB with default options: {round(time.perf_counter() - start, 2)}s")
+        warn(
+            "Time to write float traces to NWB with default options: "
+            f"{round(trace_size_mb / (time.perf_counter() - start), 2)}MB/s"
+        )
 
-        start = time.perf_counter()
         write_recording(recording=self.RX, save_path=path, overwrite=True, compression="lzf")
         RX_nwb = se.NwbRecordingExtractor(path)
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
         del RX_nwb
-        warn(f"Time to write traces to NWB with 'lzf' compression: {round(time.perf_counter() - start, 2)}s")
 
-        start = time.perf_counter()
         write_recording(recording=self.RX, save_path=path, overwrite=True, compression=None)
         RX_nwb = se.NwbRecordingExtractor(path)
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
         del RX_nwb
-        warn(f"Time to write traces to NWB with no compression: {round(time.perf_counter() - start, 2)}s")
 
         start = time.perf_counter()
         write_recording(recording=self.RX, save_path=path, overwrite=True, compression=None, iterate=False)
@@ -274,7 +275,10 @@ class TestExtractors(unittest.TestCase):
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
         del RX_nwb
-        warn(f"Time to write traces to NWB with no compression or iteration: {round(time.perf_counter() - start, 2)}s")
+        warn(
+            "Time to write float traces to NWB with no compression or iteration: "
+            f"{round(trace_size_mb / (time.perf_counter() - start), 2)}MB/s"
+        )
 
     def test_write_sorting(self):
         path = self.test_dir + '/test.nwb'

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -246,21 +246,79 @@ class TestExtractors(unittest.TestCase):
         check_dumping(RX_nwb)
         del RX_nwb
 
-        write_recording(recording=self.RX, save_path=path, overwrite=True, compression="lzf")
+        write_recording(recording=self.RX, save_path=path, overwrite=True)  # Testing default compression, should be "gzip"
+        compression = "gzip"
+        with NWBHDF5IO(path=path, mode="r") as io:
+            nwbfile = io.read()
+            compression_out = nwbfile.acquisition["ElectricalSeries_raw"].data.compression
+        self.assertEqual(
+            compression_out,
+            compression,
+            f"Intended compression type does not match what was written! (Out: {compression_out}, should be: {compression})"
+        )
         RX_nwb = se.NwbRecordingExtractor(path)
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
         del RX_nwb
 
-        write_recording(recording=self.RX, save_path=path, overwrite=True, compression=None)
+        write_recording(recording=self.RX, save_path=path, overwrite=True, compression=compression)
+        with NWBHDF5IO(path=path, mode="r") as io:
+            nwbfile = io.read()
+            compression_out = nwbfile.acquisition["ElectricalSeries_raw"].data.compression
+        self.assertEqual(
+            compression_out,
+            compression,
+            f"Intended compression type does not match what was written! (Out: {compression_out}, should be: {compression})"
+        )
         RX_nwb = se.NwbRecordingExtractor(path)
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
         del RX_nwb
 
-        write_recording(recording=self.RX, save_path=path, overwrite=True, compression=None, iterate=False)
+        compression = "lzf"
+        write_recording(recording=self.RX, save_path=path, overwrite=True, compression=compression)
+        with NWBHDF5IO(path=path, mode="r") as io:
+            nwbfile = io.read()
+            compression_out = nwbfile.acquisition["ElectricalSeries_raw"].data.compression
+        self.assertEqual(
+            compression_out,
+            compression,
+            f"Intended compression type does not match what was written! (Out: {compression_out}, should be: {compression})"
+        )
+        RX_nwb = se.NwbRecordingExtractor(path)
+        check_recording_return_types(RX_nwb)
+        check_recordings_equal(self.RX, RX_nwb)
+        check_dumping(RX_nwb)
+        del RX_nwb
+
+        compression = None
+        write_recording(recording=self.RX, save_path=path, overwrite=True, compression=compression)
+        with NWBHDF5IO(path=path, mode="r") as io:
+            nwbfile = io.read()
+            compression_out = nwbfile.acquisition["ElectricalSeries_raw"].data.compression
+        self.assertEqual(
+            compression_out,
+            compression,
+            f"Intended compression type does not match what was written! (Out: {compression_out}, should be: {compression})"
+        )
+        self.assertN
+        RX_nwb = se.NwbRecordingExtractor(path)
+        check_recording_return_types(RX_nwb)
+        check_recordings_equal(self.RX, RX_nwb)
+        check_dumping(RX_nwb)
+        del RX_nwb
+
+        write_recording(recording=self.RX, save_path=path, overwrite=True, compression=compression, iterate=False)
+        with NWBHDF5IO(path=path, mode="r") as io:
+            nwbfile = io.read()
+            compression_out = nwbfile.acquisition["ElectricalSeries_raw"].data.compression
+        self.assertEqual(
+            compression_out,
+            compression,
+            f"Intended compression type does not match what was written! (Out: {compression_out}, should be: {compression})"
+        )
         RX_nwb = se.NwbRecordingExtractor(path)
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -111,7 +111,6 @@ class TestExtractors(unittest.TestCase):
 
         return (RX, RX2, RX3, SX, SX2, SX3, example_info)
 
-
     def test_write_recording(self):
         path = self.test_dir + '/test.nwb'
 
@@ -154,6 +153,20 @@ class TestExtractors(unittest.TestCase):
         )
 
         RX_nwb = se.NwbRecordingExtractor(file_path=path_multi, electrical_series_name='raw_traces')
+        check_recording_return_types(RX_nwb)
+        check_recordings_equal(self.RX, RX_nwb)
+        check_dumping(RX_nwb)
+        del RX_nwb
+
+        write_recording(recording=self.RX, save_path=path, overwrite=True, commpression="lzf")
+        RX_nwb = se.NwbRecordingExtractor(path)
+        check_recording_return_types(RX_nwb)
+        check_recordings_equal(self.RX, RX_nwb)
+        check_dumping(RX_nwb)
+        del RX_nwb
+
+        write_recording(recording=self.RX, save_path=path, overwrite=True, iterate=False)
+        RX_nwb = se.NwbRecordingExtractor(path)
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -4,7 +4,6 @@ import unittest
 from pathlib import Path
 import numpy as np
 from datetime import datetime
-import time
 from warnings import warn
 
 import spikeextractors as se
@@ -241,18 +240,11 @@ class TestExtractors(unittest.TestCase):
             es_key='ElectricalSeries_lfp',
         )
 
-        trace_dtype = self.RX.get_traces(channel_ids=[0], end_frame=1).dtype
-        trace_size_mb = trace_dtype.itemsize * self.RX.get_num_channels() * self.RX.get_num_frames() * 1e-6
-        start = time.perf_counter()
         RX_nwb = se.NwbRecordingExtractor(file_path=path_multi, electrical_series_name='raw_traces')
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
         del RX_nwb
-        warn(
-            "Time to write float traces to NWB with default options: "
-            f"{round(trace_size_mb / (time.perf_counter() - start), 5)}MB/s"
-        )
 
         write_recording(recording=self.RX, save_path=path, overwrite=True, compression="lzf")
         RX_nwb = se.NwbRecordingExtractor(path)
@@ -268,17 +260,12 @@ class TestExtractors(unittest.TestCase):
         check_dumping(RX_nwb)
         del RX_nwb
 
-        start = time.perf_counter()
         write_recording(recording=self.RX, save_path=path, overwrite=True, compression=None, iterate=False)
         RX_nwb = se.NwbRecordingExtractor(path)
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
         del RX_nwb
-        warn(
-            "Time to write float traces to NWB with no compression or iteration: "
-            f"{round(trace_size_mb / (time.perf_counter() - start), 5)}MB/s"
-        )
 
     def test_write_sorting(self):
         path = self.test_dir + '/test.nwb'


### PR DESCRIPTION
[fix #196](https://github.com/catalystneuro/nwb-conversion-tools/issues/196) 

## Motivation

Allowing user control over write options for `ecephys` electrical series in order to speed the process in certain cases.

## How to test the behavior?
New tests have been added for each option, as well as time reporting for write speed comparison.
```
!pytest
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Is your contribution compliant with our coding style? Read about [PEP8](https://www.python.org/dev/peps/pep-0008/) and [black](https://black.readthedocs.io/en/stable/the_black_code_style.html).
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
