### PR TITLE
fixes for write_electrodes for properties: group_name and location

### DIFF
--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -362,10 +362,8 @@ def add_electrodes(
         for i in recording.get_channel_property_names(channel_id=chan_id):
             property_names.add(i)
 
-    # property 'gain' should not be in the NWB electrodes_table
     # property 'brain_area' of RX channels corresponds to 'location' of NWB electrodes
-    # property 'offset' should not be in the NWB electrodes_table as not officially supported by schema v2.2.5
-    exclude_names = set(['gain', 'offset', 'location', 'name'] + list(exclude))
+    exclude_names = set(['location','group'] + list(exclude))
 
     channel_property_defaults = {
         list: [],
@@ -406,7 +404,6 @@ def add_electrodes(
             if not prop_skip:
                 index = found_property_types[prop] == ArrayType
                 prop_name_new = 'location' if prop == 'brain_area' else prop
-                prop_name_new = 'group_name' if prop == 'group' else prop
                 found_property_types[prop_name_new] = found_property_types.pop(prop)
                 elec_columns[prop_name_new].update(description=prop_name_new, data=data, index=index)
 
@@ -457,7 +454,7 @@ def add_electrodes(
 
             for name, desc in elec_columns.items():
                 if name == 'group_name':
-                    group_name = str(int(desc['data'][j]))
+                    group_name = str(desc['data'][j])
                     if group_name!='' and group_name not in nwbfile.electrode_groups:
                         warnings.warn(f"Electrode group {group_name} for electrode {channel_id} was not "
                                       "found in the nwbfile! Automatically adding.")

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -462,9 +462,6 @@ def add_electrodes(
                             Ecephys=dict(
                                 ElectrodeGroup=[dict(
                                     name=group_name,
-                                    description="no description",
-                                    location="unknown",
-                                    device="Device"
                                 )]
                             )
                         )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,6 @@ spikesorters==0.4.4
 spiketoolkit==0.7.4
 psutil==5.7.0
 roiextractors==0.3.1
-neo==0.9.0
+git+https://github.com/neuralensemble/python-neo@master
 opencv-python==4.5.1.48
 ndx-events==0.2.0

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -426,6 +426,10 @@ class TestWriteElectrodes(unittest.TestCase):
         for no, (chan_id1, chan_id2) in enumerate(zip(self.RX.get_channel_ids(), self.RX2.get_channel_ids())):
             self.RX2.set_channel_property(chan_id2, 'prop1', '10Hz')
             self.RX.set_channel_property(chan_id1, 'prop1', '10Hz')
+            self.RX2.set_channel_property(chan_id2, 'brain_area', 'M1')
+            self.RX.set_channel_property(chan_id1, 'brain_area', 'PMd')
+            self.RX2.set_channel_property(chan_id2, 'group_name', 'M1')
+            self.RX.set_channel_property(chan_id1, 'group_name', 'PMd')
             if no%2 == 0:
                 self.RX2.set_channel_property(chan_id2, 'prop2', chan_id2)
                 self.RX.set_channel_property(chan_id1, 'prop2', chan_id1)
@@ -443,6 +447,14 @@ class TestWriteElectrodes(unittest.TestCase):
             assert all([i in nwb.electrodes.colnames for i in ['prop1', 'prop2', 'prop3']])
             for i, chan_id in enumerate(nwb.electrodes.id.data):
                 assert nwb.electrodes['prop1'][i] == '10Hz'
+                if chan_id in self.RX.get_channel_ids():
+                    assert nwb.electrodes['location'][i] == 'PMd'
+                    assert nwb.electrodes['group_name'][i] == 'PMd'
+                    assert nwb.electrodes['group'][i].name == 'PMd'
+                else:
+                    assert nwb.electrodes['location'][i] == 'M1'
+                    assert nwb.electrodes['group_name'][i] == 'M1'
+                    assert nwb.electrodes['group'][i].name == 'M1'
                 if i%2 == 0:
                     assert nwb.electrodes['prop2'][i] == chan_id
                     assert nwb.electrodes['prop3'][i] == str(chan_id)

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -483,5 +483,23 @@ class TestWriteElectrodes(unittest.TestCase):
                     assert np.isnan(nwb.electrodes['prop2'][i])
                     assert nwb.electrodes['prop_new'][i]==chan_id
 
+    def test_group_set_custom_description(self):
+        for i,grp_name in enumerate(['PMd','M1']):
+            self.metadata_list[i]['Ecephys'].update(ElectrodeGroup=[dict(name=grp_name,
+                                                                     description=grp_name+' description')])
+        write_recording(recording=self.RX, nwbfile=self.nwbfile1, metadata=self.metadata_list[0], es_key='es1')
+        write_recording(recording=self.RX2, nwbfile=self.nwbfile1, metadata=self.metadata_list[1], es_key='es2')
+        with NWBHDF5IO(str(self.path1), 'w') as io:
+            io.write(self.nwbfile1)
+        with NWBHDF5IO(str(self.path1), 'r') as io:
+            nwb = io.read()
+            for i, chan_id in enumerate(nwb.electrodes.id.data):
+                if i<len(nwb.electrodes.id.data)/2:
+                    assert nwb.electrodes['group_name'][i]=='PMd'
+                    assert nwb.electrodes['group'][i].description == 'PMd description'
+                else:
+                    assert nwb.electrodes['group_name'][i] == 'M1'
+                    assert nwb.electrodes['group'][i].description == 'M1 description'
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a PR for some minor fixes over the #181 which were overlooked.
## Motivation

Setting property  'brain_area'  for `recordingextractor `was not being correctly written as a location property for the nwb file electrodes table. 
'group_name' property was not correctly overriding the `recordingextractor's `'group' property while writing the group/group_name for the nwbfile electrodes table.  

## How to test the behavior?
Have updated the test files.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Is your contribution compliant with our coding style? Read about [PEP8](https://www.python.org/dev/peps/pep-0008/) and [black](https://black.readthedocs.io/en/stable/the_black_code_style.html).
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
