### PR TITLE
load metadata from file

### DIFF
--- a/nwb_conversion_tools/utils/metadata.py
+++ b/nwb_conversion_tools/utils/metadata.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import yaml
+import json
+
+
+class NoDatesSafeLoader(yaml.SafeLoader):
+    @classmethod
+    def remove_implicit_resolver(cls, tag_to_remove):
+        """
+        Solution from here: https://stackoverflow.com/a/37958106/11483674
+        Remove implicit resolvers for a particular tag
+
+        Takes care not to modify resolvers in super classes.
+
+        We want to load datetimes as strings, not dates, because we
+        go on to serialise as json which doesn't have the advanced types
+        of yaml, and leads to incompatibilities down the track.
+        """
+        if not 'yaml_implicit_resolvers' in cls.__dict__:
+            cls.yaml_implicit_resolvers = cls.yaml_implicit_resolvers.copy()
+
+        for first_letter, mappings in cls.yaml_implicit_resolvers.items():
+            cls.yaml_implicit_resolvers[first_letter] = [(tag, regexp) 
+                                                         for tag, regexp in mappings
+                                                         if tag != tag_to_remove]
+
+NoDatesSafeLoader.remove_implicit_resolver('tag:yaml.org,2002:timestamp')
+
+
+def load_metadata_from_file(file) -> dict:
+    """
+    Function to safely load metadata from YAML and JSON files.
+    """
+    assert Path(file).is_file(), f"{file} is not a file."
+    assert Path(file).suffix in ['.yml', '.json'], f"{file} is not a valid .yml or .json file."
+
+    if Path(file).suffix == '.yml':
+        with open(file, 'r') as f:
+            metadata = yaml.load(f, Loader=NoDatesSafeLoader)
+    elif Path(file).suffix == '.json':
+        with open(file, "r") as f:
+            metadata = json.load(f)
+
+    return metadata

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='nwb-conversion-tools',
-    version='0.8.0',
+    version='0.8.1',
     description='Convert data to nwb',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/metadata_tests.json
+++ b/tests/metadata_tests.json
@@ -1,0 +1,42 @@
+{
+    "NWBFile": {
+        "experimenter": "Mr Tester",
+        "identifier": "abc123",
+        "institution": "My University",
+        "lab": "My lab",
+        "session_description": "testing conversion tools software",
+        "session_start_time": "2020-04-15T10:00:00+00:00"
+    },
+    "Subject": {
+        "description": "ADDME",
+        "sex": "M",
+        "species": "ADDME",
+        "subject_id": "sid000",
+        "weight": "10g",
+        "date_of_birth": "2020-04-07T00:15:00+00:00"
+    },
+    "Ecephys": {
+        "Device": [
+            {
+                "name": "device_ecephys"
+            }
+        ],
+        "ElectricalSeries": [
+            {
+                "description": "ADDME",
+                "name": "ElectricalSeries",
+                "rate": 10.0,
+                "starting_time": 0.0,
+                "conversion": 1.0
+            }
+        ],
+        "ElectrodeGroup": [
+            {
+                "description": "ADDME",
+                "device": "device_ecephys",
+                "location": "ADDME",
+                "name": "ElectrodeGroup"
+            }
+        ]
+    }
+}

--- a/tests/metadata_tests.yml
+++ b/tests/metadata_tests.yml
@@ -4,14 +4,14 @@ NWBFile:
   institution: My University
   lab: My lab
   session_description: testing conversion tools software
-  session_start_time: 2020-04-01 10:00:00
+  session_start_time: 2020-04-15T10:00:00+00:00
 Subject:
   description: ADDME
   sex: M
   species: ADDME
   subject_id: sid000
   weight: 10g
-  date_of_birth: 2020-04-07 00:15:00
+  date_of_birth: 2020-04-07T00:15:00+00:00
 Ecephys:
   Device:
     - name: device_ecephys
@@ -26,11 +26,3 @@ Ecephys:
       device: device_ecephys
       location: ADDME
       name: ElectrodeGroup
-Behavior:
-  BehavioralTimeSeries:
-    name: BehavioralTimeSeries
-    time_series:
-      - name: InterestingBehavior1
-        description: ADDME
-      - name: InterestingBehavior2
-        description: ADDME

--- a/tests/test_json_schema_utils.py
+++ b/tests/test_json_schema_utils.py
@@ -1,12 +1,18 @@
 import json
 from pathlib import Path
 from typing import Union
+import os
 
 from nwb_conversion_tools.utils.json_schema import get_schema_from_method_signature, dict_deep_update, fill_defaults
+from nwb_conversion_tools.utils.metadata import load_metadata_from_file
 
 
 def compare_dicts(a: dict, b: dict):
     assert json.dumps(a, sort_keys=True, indent=2) == json.dumps(b, sort_keys=True, indent=2)
+
+
+def compare_dicts_2(a: dict, b: dict):
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
 
 
 def test_get_schema_from_method_signature():
@@ -132,3 +138,57 @@ def test_fill_defaults():
     )
 
     compare_dicts(schema, correct_new_schema)
+
+
+def test_load_metadata_from_file():
+    m0 = dict(
+        NWBFile=dict(
+            experimenter='Mr Tester',
+            identifier='abc123',
+            institution='My University',
+            lab='My lab',
+            session_description='testing conversion tools software',
+            session_start_time='2020-04-15T10:00:00+00:00'
+        ),
+        Subject=dict(
+            description='ADDME',
+            sex='M',
+            species='ADDME',
+            subject_id='sid000',
+            weight='10g',
+            date_of_birth='2020-04-07T00:15:00+00:00'
+        ),
+        Ecephys=dict(
+            Device=[
+                dict(
+                    name='device_ecephys'
+                )
+            ],
+            ElectricalSeries=[
+                dict(
+                    description='ADDME',
+                    name='ElectricalSeries',
+                    rate=10.0,
+                    starting_time=0.0,
+                    conversion=1.0
+                )
+            ],
+            ElectrodeGroup=[
+                dict(
+                    description='ADDME',
+                    device='device_ecephys',
+                    location='ADDME',
+                    name='ElectrodeGroup'
+                )
+            ]
+        )
+    )
+
+    yaml_file = os.path.join(os.path.dirname(__file__), 'metadata_tests.yml')
+    json_file = os.path.join(os.path.dirname(__file__), 'metadata_tests.json')
+    
+    m1 = load_metadata_from_file(file=yaml_file)
+    compare_dicts_2(m0, m1)
+
+    m2 = load_metadata_from_file(file=json_file)
+    compare_dicts_2(m0, m2)


### PR DESCRIPTION
Convenient util function to load metadata from yaml and json files

The `load_metadata_from_file()` function will be helpful any time a script might load the user-customized metadata from files (which can cbe yaml or json). 
For example, when running the conversion scripts [from command line](https://github.com/catalystneuro/movshon-lab-to-nwb/blob/6b705c24615c098399ca0c48c0535f6564d67f1d/scripts/convert_blackrock.py#L23) that is the only feasible way of passing user metadata. Of course this can be used in any notebook or other script as well.