### PR TITLE
Add psutil in setup.py dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         'pynwb', 'tqdm', 'natsort', 'numpy', 'scipy', 'pandas', 'h5py',
         'pyyaml', 'spikeextractors', 'spikesorters', 'spiketoolkit',
-        'roiextractors', 'jsonschema', 'lxml'],
+        'roiextractors', 'jsonschema', 'lxml', 'psutil'],
     entry_points={
         'console_scripts': ['nwb-gui=nwb_conversion_tools.gui.command_line:main'],
     }


### PR DESCRIPTION
## Motivation

`psutil` is a requirement but not listed in the setup.py dependencies (https://github.com/catalystneuro/nwb-conversion-tools/issues/203).


## How to test the behavior?

After pip installing the package on a new env:
```
import nwb_conversion_tools 
```
throws an error (https://github.com/catalystneuro/nwb-conversion-tools/blob/master/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py#L4)

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Is your contribution compliant with our coding style? Read about [PEP8](https://www.python.org/dev/peps/pep-0008/) and [black](https://black.readthedocs.io/en/stable/the_black_code_style.html).
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
