### PR TITLE
fixing issue 207

### DIFF
--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -666,7 +666,7 @@ def add_electrical_series(
     eseries_kwargs.update(data=H5DataIO(ephys_data, compression="gzip"))
     if not use_times:
         eseries_kwargs.update(
-            starting_time=recording.frame_to_time(0),
+            starting_time=float(recording.frame_to_time(0)),
             rate=float(recording.get_sampling_frequency())
         )
     else:


### PR DESCRIPTION
fix #207 

## Motivation

In v0.8.5 of nwb-conversion-tools, it is possible for a RecordingExtractor object to have a `starting_time` value that is not a `float` as expected of `pynwb.ecephys.ElectricalSeries` part of the `utils.spike_interface.write_recording(...)`.

This fixes it by hard casting the value at time of write within `utils.spike_interface.write_recording(...)`.

## How to test the behavior?
```
import spikeextractors as se
from nwb_conversion_tools.utils.spike_interface import write_recording
from pynwb import NWBHDF5IO

nwbfile_path = ".../test.nwb"

recording_extractor = se.example_datasets.toy_example()[0]
recording_extractor._times = [int(1)]
write_recording(recording=recording_extractor, save_path=nwbfile_path, overwrite=True)

with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
    out_nwbfile = io.read()
    print(out_nwbfile.acquisition)
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Is your contribution compliant with our coding style? Read about [PEP8](https://www.python.org/dev/peps/pep-0008/) and [black](https://black.readthedocs.io/en/stable/the_black_code_style.html).
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
