### PR TITLE
axona style suggestions

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/axona/axonadatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/axona/axonadatainterface.py
@@ -76,20 +76,10 @@ class AxonaRecordingExtractorInterface(BaseRecordingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls):
+        return get_schema_from_method_signature(cls.__init__)
 
-        source_schema = dict(
-            required=["filename"],
-            properties=dict(
-                filename=dict(
-                    type="string",
-                    format="file",
-                    description="Full path to Axona .set file.",
-                )
-            ),
-            type="object",
-            additionalProperties=True,
-        )
-        return source_schema
+    def __init__(self, filename: str):
+        super().__init__(filename=filename)
 
     def get_metadata_schema(self):
         """Compile metadata schema for the RecordingExtractor."""
@@ -298,8 +288,7 @@ class AxonaPositionDataInterface(BaseDataInterface):
         return get_schema_from_method_signature(cls.__init__)
 
     def __init__(self, filename: str):
-        super().__init__()
-        self.source_data = dict(filename=filename)
+        super().__init__(filename=filename)
 
     def run_conversion(self, nwbfile: NWBFile, metadata: dict, **conversion_options):
         """

--- a/nwb_conversion_tools/datainterfaces/ecephys/axona/axonadatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/axona/axonadatainterface.py
@@ -10,7 +10,10 @@ from pynwb import NWBFile
 from pynwb.behavior import Position, SpatialSeries
 from pynwb.ecephys import ElectricalSeries
 
-from ....utils.json_schema import get_schema_from_hdmf_class
+from ....utils.json_schema import (
+    get_schema_from_hdmf_class,
+    get_schema_from_method_signature,
+)
 from ....basedatainterface import BaseDataInterface
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....utils.conversion_tools import get_module
@@ -36,15 +39,17 @@ def parse_generic_header(filename, params):
     """
     header = dict()
     params = set(params)
-    with open(filename, 'rb') as f:
+    with open(filename, "rb") as f:
         for bin_line in f:
-            if b'data_start' in bin_line:
+            if b"data_start" in bin_line:
                 break
-            line = bin_line.decode('cp1252').replace('\r\n', '').replace('\r', '').strip()
-            parts = line.split(' ')
+            line = (
+                bin_line.decode("cp1252").replace("\r\n", "").replace("\r", "").strip()
+            )
+            parts = line.split(" ")
             key = parts[0]
             if key in params:
-                header[key] = ' '.join(parts[1:])
+                header[key] = " ".join(parts[1:])
 
     return header
 
@@ -54,14 +59,14 @@ def read_axona_iso_datetime(set_file):
     Creates datetime object (y, m, d, h, m, s) from .set file header
     and converts it to ISO 8601 format
     """
-    with open(set_file, 'r', encoding='cp1252') as f:
+    with open(set_file, "r", encoding="cp1252") as f:
         for line in f:
-            if line.startswith('trial_date'):
-                date_string = line[len('trial_date')+1::].replace('\n', '')
-            if line.startswith('trial_time'):
-                time_string = line[len('trial_time')+1::].replace('\n', '')
+            if line.startswith("trial_date"):
+                date_string = line[len("trial_date") + 1:].replace("\n", "")
+            if line.startswith("trial_time"):
+                time_string = line[len("trial_time") + 1:].replace("\n", "")
 
-    return dateutil.parser.parse(date_string + ' ' + time_string).isoformat()
+    return dateutil.parser.parse(date_string + " " + time_string).isoformat()
 
 
 class AxonaRecordingExtractorInterface(BaseRecordingExtractorInterface):
@@ -73,23 +78,23 @@ class AxonaRecordingExtractorInterface(BaseRecordingExtractorInterface):
     def get_source_schema(cls):
 
         source_schema = dict(
-            required=['filename'],
+            required=["filename"],
             properties=dict(
                 filename=dict(
-                    type='string',
-                    format='file',
-                    description='Full path to Axona .set file.'
+                    type="string",
+                    format="file",
+                    description="Full path to Axona .set file.",
                 )
             ),
-            type='object',
-            additionalProperties=True
+            type="object",
+            additionalProperties=True,
         )
         return source_schema
 
     def get_metadata_schema(self):
         """Compile metadata schema for the RecordingExtractor."""
         metadata_schema = super().get_metadata_schema()
-        metadata_schema['properties']['Ecephys']['properties'].update(
+        metadata_schema["properties"]["Ecephys"]["properties"].update(
             ElectricalSeries_raw=get_schema_from_hdmf_class(ElectricalSeries)
         )
         return metadata_schema
@@ -97,13 +102,8 @@ class AxonaRecordingExtractorInterface(BaseRecordingExtractorInterface):
     def get_metadata(self):
 
         # Extract information for specific parameters from .set file
-        params_of_interest = [
-            'experimenter',
-            'comments',
-            'duration',
-            'sw_version'
-        ]
-        set_file = self.source_data['filename'].split('.')[0]+'.set'
+        params_of_interest = ["experimenter", "comments", "duration", "sw_version"]
+        set_file = self.source_data["filename"].split(".")[0] + ".set"
         par = parse_generic_header(set_file, params_of_interest)
 
         # Extract information from AxonaRecordingExtractor
@@ -112,42 +112,42 @@ class AxonaRecordingExtractorInterface(BaseRecordingExtractorInterface):
 
         # Add available metadata
         metadata = super().get_metadata()
-        metadata['NWBFile'] = dict(
+        metadata["NWBFile"] = dict(
             session_start_time=read_axona_iso_datetime(set_file),
-            session_description=par['comments'],
-            experimenter=[par['experimenter']]
+            session_description=par["comments"],
+            experimenter=[par["experimenter"]],
         )
 
-        metadata['Ecephys'] = dict(
+        metadata["Ecephys"] = dict(
             Device=[
                 dict(
                     name="Axona",
-                    description="Axona DacqUSB, sw_version={}"
-                                .format(par['sw_version']),
-                    manufacturer="Axona"
+                    description="Axona DacqUSB, sw_version={}".format(
+                        par["sw_version"]
+                    ),
+                    manufacturer="Axona",
                 ),
             ],
             ElectrodeGroup=[
                 dict(
-                    name=f'Group{group_name}',
-                    location='',
-                    device='Axona',
+                    name=f"Group{group_name}",
+                    location="",
+                    device="Axona",
                     description=f"Group {group_name} electrodes.",
                 )
                 for group_name in unique_elec_group_names
             ],
             Electrodes=[
                 dict(
-                    name='group_name',
+                    name="group_name",
                     description="""The name of the ElectrodeGroup this electrode
                                 is a part of.""",
-                    data=[f"Group{x}" for x in elec_group_names]
+                    data=[f"Group{x}" for x in elec_group_names],
                 )
             ],
             ElectricalSeries_raw=dict(
-                name='ElectricalSeries_raw',
-                description="Raw acquisition traces."
-            )
+                name="ElectricalSeries_raw", description="Raw acquisition traces."
+            ),
         )
 
         return metadata
@@ -155,7 +155,7 @@ class AxonaRecordingExtractorInterface(BaseRecordingExtractorInterface):
 
 # Helper functions for AxonaPositionDataInterface
 def establish_mmap_to_position_data(filename):
-    '''
+    """
     Generates a memory map (mmap) object connected to an Axona .bin
     file, referencing only the animal position data (if present).
 
@@ -172,65 +172,67 @@ def establish_mmap_to_position_data(filename):
     Returns:
     -------
     mm (mmap or None): Memory map to .bin file position data
-    '''
+    """
     mmpos = None
 
-    bin_file = filename.split('.')[0]+'.bin'
-    set_file = filename.split('.')[0]+'.set'
-    par = parse_generic_header(set_file, ['rawRate', 'duration'])
-    sr_ecephys = int(par['rawRate'])
+    bin_file = filename.split(".")[0] + ".bin"
+    set_file = filename.split(".")[0] + ".set"
+    par = parse_generic_header(set_file, ["rawRate", "duration"])
+    sr_ecephys = int(par["rawRate"])
     sr_pos = 100
     bytes_packet = 432
 
     num_packets = int(os.path.getsize(bin_file) / bytes_packet)
     num_ecephys_samples = num_packets * 3
     dur_ecephys = num_ecephys_samples / sr_ecephys
-    assert dur_ecephys == float(par['duration'])
+    assert dur_ecephys == float(par["duration"])
 
     # Check if position data exists in .bin file
-    with open(bin_file, 'rb') as f:
+    with open(bin_file, "rb") as f:
         with contextlib.closing(
-            mmap.mmap(f.fileno(), sr_ecephys // 3 // sr_pos
-                      * bytes_packet, access=mmap.ACCESS_READ)
+            mmap.mmap(
+                f.fileno(),
+                sr_ecephys // 3 // sr_pos * bytes_packet,
+                access=mmap.ACCESS_READ,
+            )
         ) as mmap_obj:
-            contains_pos_tracking = mmap_obj.find(b'ADU2') > -1
+            contains_pos_tracking = mmap_obj.find(b"ADU2") > -1
 
     # Establish memory map to .bin file, considering only position data
     if contains_pos_tracking:
-        fbin = open(bin_file, 'rb')
+        fbin = open(bin_file, "rb")
         mmpos = mmap.mmap(fbin.fileno(), 0, access=mmap.ACCESS_READ)
 
     return mmpos
 
 
 def read_bin_file_position_data(filename):
-    '''
+    """
     Reads position data from Axona .bin file (if present in
     recording) and returns it as a numpy.array.
 
     Parameters:
     -------
-    filename (Path or Str): Full filename of Axona file with any
-        extension.
+    filename: path-like
+        Full filename of Axona file with any extension.
 
     Returns:
     -------
     pos (np.array)
-    '''
-    bin_file = filename.split('.')[0]+'.bin'
+    """
+
+    bin_file = filename.split(".")[0] + ".bin"
     mm = establish_mmap_to_position_data(bin_file)
 
     bytes_packet = 432
     num_packets = int(os.path.getsize(bin_file) / bytes_packet)
 
-    set_file = filename.split('.')[0]+'.set'
-    par = parse_generic_header(set_file, ['rawRate', 'duration'])
-    sr_ecephys = int(par['rawRate'])
+    set_file = filename.split(".")[0] + ".set"
+    par = parse_generic_header(set_file, ["rawRate", "duration"])
+    sr_ecephys = int(par["rawRate"])
 
-    pos = np.array([]).astype(float)
-
-    flags = np.ndarray((num_packets,), 'S4', mm, 0, bytes_packet)
-    ADU2_idx = np.where(flags == b'ADU2')
+    flags = np.ndarray((num_packets,), "S4", mm, 0, bytes_packet)
+    ADU2_idx = np.where(flags == b"ADU2")
 
     pos = np.ndarray(
         (num_packets,), (np.int16, (1, 8)), mm, 16, (bytes_packet,)
@@ -246,8 +248,8 @@ def read_bin_file_position_data(filename):
     return pos
 
 
-def generate_position_data(filename):
-    '''
+def get_position_object(filename):
+    """
     Read position data from .bin or .pos file and convert to
     pynwb.behavior.SpatialSeries objects.
 
@@ -259,10 +261,19 @@ def generate_position_data(filename):
     Returns:
     -------
     position (pynwb.behavior.Position)
-    '''
+    """
     position = Position()
 
-    position_channel_names = 't,x1,y1,x2,y2,numpix1,numpix2,unused'.split(',')
+    position_channel_names = [
+        "t",
+        "x1",
+        "y1",
+        "x2",
+        "y2",
+        "numpix1",
+        "numpix2",
+        "unused",
+    ]
     position_data = read_bin_file_position_data(filename)
     position_timestamps = position_data[:, 0]
 
@@ -272,7 +283,7 @@ def generate_position_data(filename):
             name=position_channel_names[ichan],
             timestamps=position_timestamps,
             data=position_data[:, ichan],
-            reference_frame='start of raw aquisition (.bin file)'
+            reference_frame="start of raw acquisition (.bin file)",
         )
         position.add_spatial_series(spatial_series)
 
@@ -284,24 +295,13 @@ class AxonaPositionDataInterface(BaseDataInterface):
 
     @classmethod
     def get_source_schema(cls):
+        return get_schema_from_method_signature(cls.__init__)
 
-        source_schema = super().get_source_schema()
-        source_schema.update(
-            required=['filename'],
-            properties=dict(
-                filename=dict(
-                    type='string',
-                    format='file',
-                    description='Full filename of Axona .bin or .pos file'
-                )
-            ),
-            type='object',
-            additionalProperties=True
-        )
+    def __init__(self, filename: str):
+        super().__init__()
+        self.source_data = dict(filename=filename)
 
-        return source_schema
-
-    def run_conversion(self, nwbfile: NWBFile, metadata: dict):
+    def run_conversion(self, nwbfile: NWBFile, metadata: dict, **conversion_options):
         """
         Run conversion for this data interface.
 
@@ -310,9 +310,10 @@ class AxonaPositionDataInterface(BaseDataInterface):
         nwbfile : NWBFile
         metadata : dict
         """
-        filename = self.source_data['filename']
-        position = generate_position_data(filename)
+        filename = self.source_data["filename"]
 
         # Create or update processing module for behavioral data
-        get_module(nwbfile=nwbfile, name='behavior', description='behavioral data')
-        nwbfile.processing['behavior'].add(position)
+        behavior_module = get_module(
+            nwbfile=nwbfile, name="behavior", description="behavioral data"
+        )
+        behavior_module.add(get_position_object(filename))

--- a/nwb_conversion_tools/utils/conversion_tools.py
+++ b/nwb_conversion_tools/utils/conversion_tools.py
@@ -14,13 +14,13 @@ from .json_schema import dict_deep_update
 
 def get_module(nwbfile: NWBFile, name: str, description: str = None):
     """Check if processing module exists. If not, create it. Then return module."""
-    if name in nwbfile.modules:
+    if name in nwbfile.processing:
         if description is not None and nwbfile.modules[name].description != description:
             warn(
                 "Custom description given to get_module does not match existing module description! "
                 "Ignoring custom description."
             )
-        return nwbfile.modules[name]
+        return nwbfile.processing[name]
     else:
         if description is None:
             description = "No description."


### PR DESCRIPTION
in axondadatainterface.py:
* run BLACK
* change name of "generate_position_data" to "get_position_object"
* explicitly define __init__ for AxonaRecordingExtarctor
* generate source schema from explicit AxonaRecordingExtarctor.__init__

in conversion_tools.py, use nwb.processing instead of deprecated nwb.modules

## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

## How to test the behavior?
```
Show here how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [ ] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Is your contribution compliant with our coding style? Read about [PEP8](https://www.python.org/dev/peps/pep-0008/) and [black](https://black.readthedocs.io/en/stable/the_black_code_style.html).
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
