### PR TITLE
Blackrock interface updated kwargs

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -33,9 +33,8 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         source_schema['properties']['filename']['description'] = 'Path to Blackrock file.'
         return source_schema
     
-    def __init__(self, filename: PathType):
-        nsx_to_load = int(str(filename).split('.')[-1][-1])
-        super().__init__(filename=filename, nsx_to_load=nsx_to_load)
+    def __init__(self, filename: PathType, nsx_override: PathType=None, nev_override: PathType=None):
+        super().__init__(filename=filename, nev_override=nev_override,nsx_override=nsx_override)
 
     def get_metadata_schema(self):
         """Compile metadata schema for the RecordingExtractor."""

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -36,6 +36,8 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
     def __init__(self, filename: PathType, nsx_override: PathType=None):
         super().__init__(filename=filename,nsx_override=nsx_override)
         if self.source_data['nsx_override'] is not None:
+            # storing the .nsx file name as an attribute. This will be used to extract the version
+            # of nsx: ns3/4/5/6 from the filepath
             self.data_filename = self.source_data['nsx_override']
         else:
             self.data_filename = self.source_data['filename']

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -152,5 +152,5 @@ class BlackrockSortingExtractorInterface(BaseSortingExtractorInterface):
         metadata_schema['properties']['filename']['description'] = 'Path to Blackrock file.'
         return metadata_schema
 
-    def __init__(self, filename: PathType, nsx_to_load: Optional[int] = None):
-        super().__init__(filename=filename, nsx_to_load=nsx_to_load)
+    def __init__(self, filename: PathType, nsx_to_load: Optional[int] = None, nev_override: PathType = None):
+        super().__init__(filename=filename, nsx_to_load=nsx_to_load, nev_override=nev_override)

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -36,8 +36,9 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
     def __init__(self, filename: PathType, nsx_override: PathType=None):
         super().__init__(filename=filename,nsx_override=nsx_override)
         if self.source_data['nsx_override'] is not None:
-            # storing the .nsx file name as an attribute. This will be used to extract the version
-            # of nsx: ns3/4/5/6 from the filepath
+            # if nsx_override is specified as a path, then the filepath is passed as an empty
+            # string and ignored.
+            # This filename be used to extract the version of nsx: ns3/4/5/6 from the filepath
             self.data_filename = self.source_data['nsx_override']
         else:
             self.data_filename = self.source_data['filename']

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -36,8 +36,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
     def __init__(self, filename: PathType, nsx_override: PathType=None):
         super().__init__(filename=filename,nsx_override=nsx_override)
         if self.source_data['nsx_override'] is not None:
-            # if nsx_override is specified as a path, then the filepath is passed as an empty
-            # string and ignored.
+            # if 'nsx_override' is specified as a path, then the 'filename' argument is ignored
             # This filename be used to extract the version of nsx: ns3/4/5/6 from the filepath
             self.data_filename = self.source_data['nsx_override']
         else:


### PR DESCRIPTION
## Motivation

This is related to PR https://github.com/SpikeInterface/spikeextractors/pull/659

To handle the above problem, the same arguments (nsx_override/nev_override) provided by `neo.BlackrockIO` should also be exposed at the blackrockdatainterface arguments. 

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Is your contribution compliant with our coding style? Read about [PEP8](https://www.python.org/dev/peps/pep-0008/) and [black](https://black.readthedocs.io/en/stable/the_black_code_style.html).
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
