### PR TITLE
channel ids for dtype bug fix

### DIFF
--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -656,7 +656,7 @@ def add_electrical_series(
             eseries_kwargs.update(conversion=1e-6)
             eseries_kwargs.update(channel_conversion=channel_conversion)
 
-    trace_dtype = recording.get_traces(channel_ids=[0], end_frame=1).dtype
+    trace_dtype = recording.get_traces(channel_ids=channel_ids[:1], end_frame=1).dtype
     estimated_memory = trace_dtype.itemsize * recording.get_num_channels() * recording.get_num_frames()
     if not iterate and psutil.virtual_memory().available <= estimated_memory:
         warn("iteration was disabled, but not enough memory to load traces! Forcing iterate=True.")

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -697,12 +697,9 @@ def add_electrical_series(
     eseries_kwargs.update(data=H5DataIO(ephys_data, compression=compression, compression_opts=compression_opts))
     if not use_times:
         eseries_kwargs.update(
+            starting_time=float(recording.frame_to_time(0)),
             rate=float(recording.get_sampling_frequency())
         )
-        if 'starting_time' not in eseries_kwargs:
-            eseries_kwargs.update(
-                starting_time=float(recording.frame_to_time(0))
-            )
     else:
         eseries_kwargs.update(
             timestamps=H5DataIO(

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -697,9 +697,12 @@ def add_electrical_series(
     eseries_kwargs.update(data=H5DataIO(ephys_data, compression=compression, compression_opts=compression_opts))
     if not use_times:
         eseries_kwargs.update(
-            starting_time=float(recording.frame_to_time(0)),
             rate=float(recording.get_sampling_frequency())
         )
+        if 'starting_time' not in eseries_kwargs:
+            eseries_kwargs.update(
+                starting_time=float(recording.frame_to_time(0))
+            )
     else:
         eseries_kwargs.update(
             timestamps=H5DataIO(


### PR DESCRIPTION
There are two small fixes that I'm proposing in this PR for the `add_electrodes()` method of spike_interface:
-  Bug fix: to find the dtype of the electrical series the channel_ids should be one from the list of `extractor.get_channel_ids()` and not default to 0. [Here ](https://github.com/catalystneuro/nwb-conversion-tools/pull/222/commits/93b8a23cc39215898c26e192f58fc0a84874dc1b)
- Enhancement: having the functionality to enter a custom `starting_time` for the `ElectricalSeries`. [Here](https://github.com/catalystneuro/nwb-conversion-tools/pull/222/commits/5d4391c7328a8d32bf31d553410c2ec226f99ac5)
