### PR TITLE
Add gin tests

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -21,6 +21,9 @@ jobs:
           NWB_CONVERSION_INSTALL_MODE: development
       run: |
         pip install .
+        # needed for correct operation of git/git-annex/DataLad
+        git config --global user.email "CI@example.com"
+        git config --global user.name "CI Almighty"
     - name: Run tests and generate coverage report
       run: |
         pip install pytest

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -2,40 +2,41 @@ name: CI development environment
 on: [push]
 jobs:
   run:
+    name: Test on (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
+        fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
-    - uses: actions/checkout@v2
-    - run: git fetch --prune --unshallow --tags
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Install pip
-      run: |
-        python -m pip install --upgrade pip
-    - name: Install this package, on development mode
-      env:
-          NWB_CONVERSION_INSTALL_MODE: development
-      run: |
-        conda install -c conda-forge datalad==0.14.5
-        pip install -r requirements-dev.txt
-        pip install -e .
-        # needed for correct operation of git/git-annex/DataLad
-        git config --global user.email "CI@example.com"
-        git config --global user.name "CI Almighty"
-    - name: Run tests and generate coverage report
-      run: |
-        pip install pytest
-        pip install pytest-cov
-        pytest --cov=./ --cov-report=xml
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        yml: ./codecov.yml
+      - uses: actions/checkout@v2
+      - uses: s-weigand/setup-conda@v1
+        with:
+          python-version: 3.8
+      - name: Which python
+        run: |
+          conda --version
+          which python
+      - run: git fetch --prune --unshallow --tags
+      - name: Install this package, on development mode
+        env:
+            NWB_CONVERSION_INSTALL_MODE: development
+        run: |
+          conda install -c conda-forge datalad==0.14.5
+          pip install -e .
+          # needed for correct operation of git/git-annex/DataLad
+          git config --global user.email "CI@example.com"
+          git config --global user.name "CI Almighty"
+      - name: Run tests and generate coverage report
+        run: |
+          pip install pytest
+          pip install pytest-cov
+          pytest --cov=./ --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          yml: ./codecov.yml

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -20,7 +20,7 @@ jobs:
       env:
           NWB_CONVERSION_INSTALL_MODE: development
       run: |
-        conda install -c conda-forge datalad
+        conda install -c conda-forge datalad==0.14.5
         pip install -r requirements-dev.txt
         pip install -e .
         # needed for correct operation of git/git-annex/DataLad

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -20,6 +20,7 @@ jobs:
       env:
           NWB_CONVERSION_INSTALL_MODE: development
       run: |
+        conda install -c conda-forge datalad==0.14.7
         pip install .
         # needed for correct operation of git/git-annex/DataLad
         git config --global user.email "CI@example.com"

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -2,7 +2,7 @@ name: CI development environment
 on: [push]
 jobs:
   run:
-    name: Test on (${{ matrix.os }})
+    name: Full test on (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -20,8 +20,9 @@ jobs:
       env:
           NWB_CONVERSION_INSTALL_MODE: development
       run: |
-        conda install -c conda-forge datalad==0.14.7
-        pip install .
+        conda install -c conda-forge datalad
+        pip install -r requirements-dev.txt
+        pip install -e .
         # needed for correct operation of git/git-annex/DataLad
         git config --global user.email "CI@example.com"
         git config --global user.name "CI Almighty"

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -5,7 +5,7 @@ jobs:
     name: Test on (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: false
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:

--- a/.github/workflows/ci-production.yml
+++ b/.github/workflows/ci-production.yml
@@ -2,10 +2,12 @@ name: CI production environment
 on: [push]
 jobs:
   run:
+    name: Lazy test on (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow --tags

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ neo @ git+https://github.com/NeuralEnsemble/python-neo.git@master
 roiextractors==0.3.1
 ndx-events==0.2.0
 parameterized==0.8.1
+datalad==0.14.7

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,4 +17,3 @@ neo @ git+https://github.com/NeuralEnsemble/python-neo.git@master
 roiextractors==0.3.1
 ndx-events==0.2.0
 parameterized==0.8.1
-datalad==0.14.7

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ neo @ git+https://github.com/NeuralEnsemble/python-neo.git@master
 roiextractors==0.3.1
 ndx-events==0.2.0
 datalad==0.14.7
+parameterized==0.8.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,5 +16,4 @@ spiketoolkit @ git+https://github.com/SpikeInterface/spiketoolkit.git@master
 neo @ git+https://github.com/NeuralEnsemble/python-neo.git@master
 roiextractors==0.3.1
 ndx-events==0.2.0
-datalad==0.14.7
 parameterized==0.8.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,4 @@ spiketoolkit @ git+https://github.com/SpikeInterface/spiketoolkit.git@master
 neo @ git+https://github.com/NeuralEnsemble/python-neo.git@master
 roiextractors==0.3.1
 ndx-events==0.2.0
+datalad==0.14.7

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -21,8 +21,6 @@ from nwb_conversion_tools import (
 )
 
 run_local = False
-test_nwb = True
-test_caching = True
 
 if sys.platform == "linux" or run_local:
     class TestNwbConversions(unittest.TestCase):

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -24,10 +24,9 @@ try:
     HAVE_DATALAD = True
 except ImportError:
     HAVE_DATALAD = False
+    raise NotImplementedError("Test")
 
-run_local = False
-
-if HAVE_DATALAD and (sys.platform == "linux" or run_local):
+if HAVE_DATALAD and sys.platform == "linux":
 
     class TestNwbConversions(unittest.TestCase):
         def setUp(self):

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -3,9 +3,7 @@ import unittest
 from pathlib import Path
 import sys
 
-from datalad.api import install, Dataset
 from parameterized import parameterized
-
 from spikeextractors import NwbRecordingExtractor, NwbSortingExtractor
 from spikeextractors.testing import check_recordings_equal, check_sortings_equal
 from nwb_conversion_tools import (
@@ -20,9 +18,16 @@ from nwb_conversion_tools import (
     SpikeGLXRecordingInterface
 )
 
+try:
+    from datalad.api import install, Dataset
+
+    HAVE_DATALAD = True
+except ImportError:
+    HAVE_DATALAD = False
+
 run_local = False
 
-if sys.platform == "linux" or run_local:
+if HAVE_DATALAD and (sys.platform == "linux" or run_local):
     class TestNwbConversions(unittest.TestCase):
 
         def setUp(self):

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -24,7 +24,6 @@ try:
     HAVE_DATALAD = True
 except ImportError:
     HAVE_DATALAD = False
-    raise NotImplementedError("Test")
 
 if HAVE_DATALAD and sys.platform == "linux":
 

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -1,0 +1,246 @@
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+from datalad.api import install, Dataset
+from parameterized import parameterized
+
+from spikeextractors import NwbRecordingExtractor, NwbSortingExtractor
+from spikeextractors.testing import check_recordings_equal, check_sortings_equal
+from nwb_conversion_tools import (
+    NWBConverter,
+    AxonaRecordingExtractorInterface,
+    BlackrockRecordingExtractorInterface,
+    BlackrockSortingExtractorInterface,
+    IntanRecordingInterface,
+    NeuroscopeRecordingInterface,
+    OpenEphysRecordingExtractorInterface,
+    CEDRecordingInterface,
+    SpikeGLXRecordingInterface
+)
+
+run_local = False
+test_nwb = True
+test_caching = True
+
+if sys.platform == "linux" or run_local:
+    class TestNwbConversions(unittest.TestCase):
+
+        def setUp(self):
+            pt = Path.cwd() / 'ephy_testing_data'
+            if pt.exists():
+                self.dataset = Dataset(pt)
+            else:
+                self.dataset = install('https://gin.g-node.org/NeuralEnsemble/ephy_testing_data')
+            self.savedir = Path(tempfile.mkdtemp())
+
+        @parameterized.expand([
+            (
+                AxonaRecordingExtractorInterface,
+                "axona",
+                dict(filename=str(Path.cwd() / "ephy_testing_data" / "axona" / "axona_raw.set"))
+            ),
+            (
+                BlackrockRecordingExtractorInterface,
+                "blackrock/blackrock_2_1",
+                dict(
+                    filename=str(Path.cwd() / "ephy_testing_data" / "blackrock" / "blackrock_2_1" / "l101210-001"),
+                    seg_index=0,
+                    nsx_to_load=5
+                )
+            ),
+            (
+                IntanRecordingInterface,
+                "intan",
+                dict(file_path=Path.cwd() / "ephy_testing_data" / "intan" / "intan_rhd_test_1.rhd")
+            ),
+            (
+                IntanRecordingInterface,
+                "intan",
+                dict(file_path=Path.cwd() / "ephy_testing_data" / "intan" / "intan_rhs_test_1.rhs")
+            ),
+            # Klusta - no .prm config file in ephy_testing
+            # (
+            #     se.KlustaRecordingExtractor,
+            #     "kwik",
+            #     dict(folder_path=Path.cwd() / "ephy_testing_data" / "kwik")
+            # ),
+            # (
+            #     se.MEArecRecordingExtractor,
+            #     "mearec/mearec_test_10s.h5",
+            #     dict(file_path=Path.cwd() / "ephy_testing_data" / "mearec" / "mearec_test_10s.h5")
+            # ),
+            # (
+            #     se.NeuralynxRecordingExtractor,
+            #     "neuralynx/Cheetah_v5.7.4/original_data",
+            #     dict(
+            #         dirname=Path.cwd() / "ephy_testing_data" / "neuralynx" / "Cheetah_v5.7.4" / "original_data",
+            #         seg_index=0
+            #     )
+            # ),
+            (
+                NeuroscopeRecordingInterface,
+                "neuroscope/test1",
+                dict(file_path=Path.cwd() / "ephy_testing_data" / "neuroscope" / "test1" / "test1.dat")
+            ),
+            # Nixio - RuntimeError: Cannot open non-existent file in ReadOnly mode!
+            # (
+            #     se.NIXIORecordingExtractor,
+            #     "nix",
+            #     dict(file_path=str(Path.cwd() / "ephy_testing_data" / "neoraw.nix"))
+            # ),
+            (
+                OpenEphysRecordingExtractorInterface,
+                "openephys/OpenEphys_SampleData_1",
+                dict(folder_path=Path.cwd() / "ephy_testing_data" / "openephys" / "OpenEphys_SampleData_1")
+            ),
+            (
+                OpenEphysRecordingExtractorInterface,
+                "openephysbinary/v0.4.4.1_with_video_tracking",
+                dict(folder_path=Path.cwd() / "ephy_testing_data" / "openephysbinary" / "v0.4.4.1_with_video_tracking")
+            ),
+            (
+                OpenEphysRecordingExtractorInterface,
+                "openephysbinary/v0.5.3_two_neuropixels_stream",
+                dict(
+                    folder_path=Path.cwd() / "ephy_testing_data" / "openephysbinary" / "v0.5.3_two_neuropixels_stream"
+                    / "Record_Node_107"
+                )
+            ),
+            # (
+            #     se.NeuropixelsDatRecordingExtractor,
+            #     "openephysbinary/v0.5.3_two_neuropixels_stream",
+            #     dict(
+            #         file_path=Path.cwd() / "ephy_testing_data" / "openephysbinary" / "v0.5.3_two_neuropixels_stream" /
+            #                   "Record_Node_107" / "experiment1" / "recording1" / "continuous" /
+            #                   "Neuropix-PXI-116.0" / "continuous.dat",
+            #         settings_file=Path.cwd() / "ephy_testing_data" / "openephysbinary" /
+            #                       "v0.5.3_two_neuropixels_stream" / "Record_Node_107" / "settings.xml")
+            # ),
+            # (
+            #     se.PhyRecordingExtractor,
+            #     "phy/phy_example_0",
+            #     dict(folder_path=Path.cwd() / "ephy_testing_data" / "phy" / "phy_example_0")
+            # ),
+            # Plexon - AssertionError: This file have several channel groups spikeextractors support only one groups
+            # (
+            #     se.PlexonRecordingExtractor,
+            #     "plexon",
+            #     dict(filename=Path.cwd() / "ephy_testing_data" / "plexon" / "File_plexon_2.plx")
+            # ),
+            (
+                CEDRecordingInterface,
+                "spike2/m365_1sec.smrx",
+                dict(
+                    file_path=Path.cwd() / "ephy_testing_data" / "spike2" / "m365_1sec.smrx",
+                    smrx_channel_ids=range(10)
+                )
+            ),
+            (
+                SpikeGLXRecordingInterface,
+                "spikeglx/Noise4Sam_g0",
+                dict(
+                    file_path=Path.cwd() / "ephy_testing_data" / "spikeglx" / "Noise4Sam_g0" / "Noise4Sam_g0_imec0" /
+                    "Noise4Sam_g0_t0.imec0.ap.bin"
+                )
+            )
+        ])
+        def test_convert_recording_extractor_to_nwb(self, recording_interface, dataset_path, interface_kwargs):
+            print(f"\n\n\n TESTING {recording_interface.extractor_name}...")
+            dataset_stem = Path(dataset_path).stem
+            self.dataset.get(dataset_path)
+            nwbfile_path = self.savedir / f"{recording_interface.__name__}_test_{dataset_stem}.nwb"
+
+            class TestConverter(NWBConverter):
+                data_interface_classes = dict(TestRecording=recording_interface)
+
+            converter = TestConverter(source_data=dict(TestRecording=dict(interface_kwargs)))
+            converter.run_conversion(nwbfile_path=nwbfile_path)
+            nwb_recording = NwbRecordingExtractor(file_path=nwbfile_path)
+            check_recordings_equal(
+                RX1=converter.data_interface_objects["TestRecording"].recording_extractor,
+                RX2=nwb_recording,
+                check_times=False
+            )
+
+        @parameterized.expand([
+            (
+                BlackrockSortingExtractorInterface,
+                "blackrock/blackrock_2_1",
+                dict(
+                    filename=str(Path.cwd() / "ephy_testing_data" / "blackrock" / "blackrock_2_1" / "l101210-001"),
+                    seg_index=0,
+                    nsx_to_load=5
+                 )
+            ),
+            # (
+            #     se.KlustaSortingExtractor,
+            #     "kwik",
+            #     dict(file_or_folder_path=Path.cwd() / "ephy_testing_data" / "kwik" / "neo.kwik")
+            # ),
+            # Neuralynx - units_ids = nwbfile.units.id[:] - AttributeError: 'NoneType' object has no attribute 'id'
+            # Is the GIN data OK? Or are there no units?
+            # (
+            #     se.NeuralynxSortingExtractor,
+            #     "neuralynx/Cheetah_v5.7.4/original_data",
+            #     dict(
+            #         dirname=Path.cwd() / "ephy_testing_data" / "neuralynx" / "Cheetah_v5.7.4" / "original_data",
+            #         seg_index=0
+            #     )
+            # ),
+            # NIXIO - return [int(da.label) for da in self._spike_das]
+            # TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
+            # (
+            #     se.NIXIOSortingExtractor,
+            #     "nix/nixio_fr.nix",
+            #     dict(file_path=str(Path.cwd() / "ephy_testing_data" / "nix" / "nixio_fr.nix"))
+            # ),
+            # (
+            #     se.MEArecSortingExtractor,
+            #     "mearec/mearec_test_10s.h5",
+            #     dict(file_path=Path.cwd() / "ephy_testing_data" / "mearec" / "mearec_test_10s.h5")
+            # ),
+            # (
+            #     se.PhySortingExtractor,
+            #     "phy/phy_example_0",
+            #     dict(folder_path=Path.cwd() / "ephy_testing_data" / "phy" / "phy_example_0")
+            # ),
+            # (
+            #     se.PlexonSortingExtractor,
+            #     "plexon",
+            #     dict(filename=Path.cwd() / "ephy_testing_data" / "plexon" / "File_plexon_2.plx")
+            # ),
+            # (
+            #     se.SpykingCircusSortingExtractor,
+            #     "spykingcircus/spykingcircus_example0",
+            #     dict(
+            #         file_or_folder_path=Path.cwd() / "ephy_testing_data" / "spykingcircus" / "spykingcircus_example0" /
+            #                             "recording"
+            #     )
+            # ),
+            # # Tridesclous - dataio error, GIN data is not correct?
+            # (
+            #     se.TridesclousSortingExtractor,
+            #     "tridesclous/tdc_example0",
+            #     dict(folder_path=Path.cwd() / "ephy_testing_data" / "tridesclous" / "tdc_example0")
+            # )
+        ])
+        def test_convert_sorting_extractor_to_nwb(self, sorting_interface, dataset_path, interface_kwargs):
+            print(f"\n\n\n TESTING {sorting_interface.extractor_name}...")
+            dataset_stem = Path(dataset_path).stem
+            self.dataset.get(dataset_path)
+            nwbfile_path = self.savedir / f"{sorting_interface.__name__}_test_{dataset_stem}.nwb"
+
+            class TestConverter(NWBConverter):
+                data_interface_classes = dict(TestSorting=sorting_interface)
+
+            converter = TestConverter(source_data=dict(TestSorting=dict(interface_kwargs)))
+            converter.run_conversion(nwbfile_path=nwbfile_path)
+            nwb_recording = NwbSortingExtractor(file_path=nwbfile_path)
+            check_sortings_equal(
+                SX1=converter.data_interface_objects["TestRecording"].recording_extractor, SX2=nwb_recording
+            )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -3,7 +3,6 @@ import unittest
 from pathlib import Path
 import sys
 
-from parameterized import parameterized
 from spikeextractors import NwbRecordingExtractor, NwbSortingExtractor
 from spikeextractors.testing import check_recordings_equal, check_sortings_equal
 from nwb_conversion_tools import (
@@ -20,6 +19,7 @@ from nwb_conversion_tools import (
 
 try:
     from datalad.api import install, Dataset
+    from parameterized import parameterized
 
     HAVE_DATALAD = True
 except ImportError:
@@ -63,36 +63,11 @@ if HAVE_DATALAD and (sys.platform == "linux" or run_local):
                 "intan",
                 dict(file_path=Path.cwd() / "ephy_testing_data" / "intan" / "intan_rhs_test_1.rhs")
             ),
-            # Klusta - no .prm config file in ephy_testing
-            # (
-            #     se.KlustaRecordingExtractor,
-            #     "kwik",
-            #     dict(folder_path=Path.cwd() / "ephy_testing_data" / "kwik")
-            # ),
-            # (
-            #     se.MEArecRecordingExtractor,
-            #     "mearec/mearec_test_10s.h5",
-            #     dict(file_path=Path.cwd() / "ephy_testing_data" / "mearec" / "mearec_test_10s.h5")
-            # ),
-            # (
-            #     se.NeuralynxRecordingExtractor,
-            #     "neuralynx/Cheetah_v5.7.4/original_data",
-            #     dict(
-            #         dirname=Path.cwd() / "ephy_testing_data" / "neuralynx" / "Cheetah_v5.7.4" / "original_data",
-            #         seg_index=0
-            #     )
-            # ),
             (
                 NeuroscopeRecordingInterface,
                 "neuroscope/test1",
                 dict(file_path=Path.cwd() / "ephy_testing_data" / "neuroscope" / "test1" / "test1.dat")
             ),
-            # Nixio - RuntimeError: Cannot open non-existent file in ReadOnly mode!
-            # (
-            #     se.NIXIORecordingExtractor,
-            #     "nix",
-            #     dict(file_path=str(Path.cwd() / "ephy_testing_data" / "neoraw.nix"))
-            # ),
             (
                 OpenEphysRecordingExtractorInterface,
                 "openephys/OpenEphys_SampleData_1",
@@ -111,27 +86,6 @@ if HAVE_DATALAD and (sys.platform == "linux" or run_local):
                     / "Record_Node_107"
                 )
             ),
-            # (
-            #     se.NeuropixelsDatRecordingExtractor,
-            #     "openephysbinary/v0.5.3_two_neuropixels_stream",
-            #     dict(
-            #         file_path=Path.cwd() / "ephy_testing_data" / "openephysbinary" / "v0.5.3_two_neuropixels_stream" /
-            #                   "Record_Node_107" / "experiment1" / "recording1" / "continuous" /
-            #                   "Neuropix-PXI-116.0" / "continuous.dat",
-            #         settings_file=Path.cwd() / "ephy_testing_data" / "openephysbinary" /
-            #                       "v0.5.3_two_neuropixels_stream" / "Record_Node_107" / "settings.xml")
-            # ),
-            # (
-            #     se.PhyRecordingExtractor,
-            #     "phy/phy_example_0",
-            #     dict(folder_path=Path.cwd() / "ephy_testing_data" / "phy" / "phy_example_0")
-            # ),
-            # Plexon - AssertionError: This file have several channel groups spikeextractors support only one groups
-            # (
-            #     se.PlexonRecordingExtractor,
-            #     "plexon",
-            #     dict(filename=Path.cwd() / "ephy_testing_data" / "plexon" / "File_plexon_2.plx")
-            # ),
             (
                 CEDRecordingInterface,
                 "spike2/m365_1sec.smrx",
@@ -150,7 +104,7 @@ if HAVE_DATALAD and (sys.platform == "linux" or run_local):
             )
         ])
         def test_convert_recording_extractor_to_nwb(self, recording_interface, dataset_path, interface_kwargs):
-            print(f"\n\n\n TESTING {recording_interface.extractor_name}...")
+            print(f"\n\n\n TESTING {recording_interface.__name__}...")
             dataset_stem = Path(dataset_path).stem
             self.dataset.get(dataset_path)
             nwbfile_path = self.savedir / f"{recording_interface.__name__}_test_{dataset_stem}.nwb"
@@ -176,61 +130,10 @@ if HAVE_DATALAD and (sys.platform == "linux" or run_local):
                     seg_index=0,
                     nsx_to_load=5
                  )
-            ),
-            # (
-            #     se.KlustaSortingExtractor,
-            #     "kwik",
-            #     dict(file_or_folder_path=Path.cwd() / "ephy_testing_data" / "kwik" / "neo.kwik")
-            # ),
-            # Neuralynx - units_ids = nwbfile.units.id[:] - AttributeError: 'NoneType' object has no attribute 'id'
-            # Is the GIN data OK? Or are there no units?
-            # (
-            #     se.NeuralynxSortingExtractor,
-            #     "neuralynx/Cheetah_v5.7.4/original_data",
-            #     dict(
-            #         dirname=Path.cwd() / "ephy_testing_data" / "neuralynx" / "Cheetah_v5.7.4" / "original_data",
-            #         seg_index=0
-            #     )
-            # ),
-            # NIXIO - return [int(da.label) for da in self._spike_das]
-            # TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
-            # (
-            #     se.NIXIOSortingExtractor,
-            #     "nix/nixio_fr.nix",
-            #     dict(file_path=str(Path.cwd() / "ephy_testing_data" / "nix" / "nixio_fr.nix"))
-            # ),
-            # (
-            #     se.MEArecSortingExtractor,
-            #     "mearec/mearec_test_10s.h5",
-            #     dict(file_path=Path.cwd() / "ephy_testing_data" / "mearec" / "mearec_test_10s.h5")
-            # ),
-            # (
-            #     se.PhySortingExtractor,
-            #     "phy/phy_example_0",
-            #     dict(folder_path=Path.cwd() / "ephy_testing_data" / "phy" / "phy_example_0")
-            # ),
-            # (
-            #     se.PlexonSortingExtractor,
-            #     "plexon",
-            #     dict(filename=Path.cwd() / "ephy_testing_data" / "plexon" / "File_plexon_2.plx")
-            # ),
-            # (
-            #     se.SpykingCircusSortingExtractor,
-            #     "spykingcircus/spykingcircus_example0",
-            #     dict(
-            #         file_or_folder_path=Path.cwd() / "ephy_testing_data" / "spykingcircus" / "spykingcircus_example0" /
-            #                             "recording"
-            #     )
-            # ),
-            # # Tridesclous - dataio error, GIN data is not correct?
-            # (
-            #     se.TridesclousSortingExtractor,
-            #     "tridesclous/tdc_example0",
-            #     dict(folder_path=Path.cwd() / "ephy_testing_data" / "tridesclous" / "tdc_example0")
-            # )
+            )
         ])
         def test_convert_sorting_extractor_to_nwb(self, sorting_interface, dataset_path, interface_kwargs):
-            print(f"\n\n\n TESTING {sorting_interface.extractor_name}...")
+            print(f"\n\n\n TESTING {sorting_interface.__name__}...")
             dataset_stem = Path(dataset_path).stem
             self.dataset.get(dataset_path)
             nwbfile_path = self.savedir / f"{sorting_interface.__name__}_test_{dataset_stem}.nwb"

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -14,7 +14,7 @@ from nwb_conversion_tools import (
     NeuroscopeRecordingInterface,
     OpenEphysRecordingExtractorInterface,
     CEDRecordingInterface,
-    SpikeGLXRecordingInterface
+    SpikeGLXRecordingInterface,
 )
 
 try:
@@ -28,81 +28,95 @@ except ImportError:
 run_local = False
 
 if HAVE_DATALAD and (sys.platform == "linux" or run_local):
-    class TestNwbConversions(unittest.TestCase):
 
+    class TestNwbConversions(unittest.TestCase):
         def setUp(self):
-            pt = Path.cwd() / 'ephy_testing_data'
+            pt = Path.cwd() / "ephy_testing_data"
             if pt.exists():
                 self.dataset = Dataset(pt)
             else:
-                self.dataset = install('https://gin.g-node.org/NeuralEnsemble/ephy_testing_data')
+                self.dataset = install("https://gin.g-node.org/NeuralEnsemble/ephy_testing_data")
             self.savedir = Path(tempfile.mkdtemp())
 
-        @parameterized.expand([
-            (
-                AxonaRecordingExtractorInterface,
-                "axona",
-                dict(filename=str(Path.cwd() / "ephy_testing_data" / "axona" / "axona_raw.set"))
-            ),
-            (
-                BlackrockRecordingExtractorInterface,
-                "blackrock/blackrock_2_1",
-                dict(
-                    filename=str(Path.cwd() / "ephy_testing_data" / "blackrock" / "blackrock_2_1" / "l101210-001"),
-                    seg_index=0,
-                    nsx_to_load=5
-                )
-            ),
-            (
-                IntanRecordingInterface,
-                "intan",
-                dict(file_path=Path.cwd() / "ephy_testing_data" / "intan" / "intan_rhd_test_1.rhd")
-            ),
-            (
-                IntanRecordingInterface,
-                "intan",
-                dict(file_path=Path.cwd() / "ephy_testing_data" / "intan" / "intan_rhs_test_1.rhs")
-            ),
-            (
-                NeuroscopeRecordingInterface,
-                "neuroscope/test1",
-                dict(file_path=Path.cwd() / "ephy_testing_data" / "neuroscope" / "test1" / "test1.dat")
-            ),
-            (
-                OpenEphysRecordingExtractorInterface,
-                "openephys/OpenEphys_SampleData_1",
-                dict(folder_path=Path.cwd() / "ephy_testing_data" / "openephys" / "OpenEphys_SampleData_1")
-            ),
-            (
-                OpenEphysRecordingExtractorInterface,
-                "openephysbinary/v0.4.4.1_with_video_tracking",
-                dict(folder_path=Path.cwd() / "ephy_testing_data" / "openephysbinary" / "v0.4.4.1_with_video_tracking")
-            ),
-            (
-                OpenEphysRecordingExtractorInterface,
-                "openephysbinary/v0.5.3_two_neuropixels_stream",
-                dict(
-                    folder_path=Path.cwd() / "ephy_testing_data" / "openephysbinary" / "v0.5.3_two_neuropixels_stream"
-                    / "Record_Node_107"
-                )
-            ),
-            (
-                CEDRecordingInterface,
-                "spike2/m365_1sec.smrx",
-                dict(
-                    file_path=Path.cwd() / "ephy_testing_data" / "spike2" / "m365_1sec.smrx",
-                    smrx_channel_ids=range(10)
-                )
-            ),
-            (
-                SpikeGLXRecordingInterface,
-                "spikeglx/Noise4Sam_g0",
-                dict(
-                    file_path=Path.cwd() / "ephy_testing_data" / "spikeglx" / "Noise4Sam_g0" / "Noise4Sam_g0_imec0" /
-                    "Noise4Sam_g0_t0.imec0.ap.bin"
-                )
-            )
-        ])
+        @parameterized.expand(
+            [
+                (
+                    AxonaRecordingExtractorInterface,
+                    "axona",
+                    dict(filename=str(Path.cwd() / "ephy_testing_data" / "axona" / "axona_raw.set")),
+                ),
+                (
+                    BlackrockRecordingExtractorInterface,
+                    "blackrock/blackrock_2_1",
+                    dict(
+                        filename=str(Path.cwd() / "ephy_testing_data" / "blackrock" / "blackrock_2_1" / "l101210-001"),
+                        seg_index=0,
+                        nsx_to_load=5,
+                    ),
+                ),
+                (
+                    IntanRecordingInterface,
+                    "intan",
+                    dict(file_path=Path.cwd() / "ephy_testing_data" / "intan" / "intan_rhd_test_1.rhd"),
+                ),
+                (
+                    IntanRecordingInterface,
+                    "intan",
+                    dict(file_path=Path.cwd() / "ephy_testing_data" / "intan" / "intan_rhs_test_1.rhs"),
+                ),
+                (
+                    NeuroscopeRecordingInterface,
+                    "neuroscope/test1",
+                    dict(file_path=Path.cwd() / "ephy_testing_data" / "neuroscope" / "test1" / "test1.dat"),
+                ),
+                (
+                    OpenEphysRecordingExtractorInterface,
+                    "openephys/OpenEphys_SampleData_1",
+                    dict(folder_path=Path.cwd() / "ephy_testing_data" / "openephys" / "OpenEphys_SampleData_1"),
+                ),
+                (
+                    OpenEphysRecordingExtractorInterface,
+                    "openephysbinary/v0.4.4.1_with_video_tracking",
+                    dict(
+                        folder_path=Path.cwd()
+                        / "ephy_testing_data"
+                        / "openephysbinary"
+                        / "v0.4.4.1_with_video_tracking"
+                    ),
+                ),
+                (
+                    OpenEphysRecordingExtractorInterface,
+                    "openephysbinary/v0.5.3_two_neuropixels_stream",
+                    dict(
+                        folder_path=Path.cwd()
+                        / "ephy_testing_data"
+                        / "openephysbinary"
+                        / "v0.5.3_two_neuropixels_stream"
+                        / "Record_Node_107"
+                    ),
+                ),
+                (
+                    CEDRecordingInterface,
+                    "spike2/m365_1sec.smrx",
+                    dict(
+                        file_path=Path.cwd() / "ephy_testing_data" / "spike2" / "m365_1sec.smrx",
+                        smrx_channel_ids=range(10),
+                    ),
+                ),
+                (
+                    SpikeGLXRecordingInterface,
+                    "spikeglx/Noise4Sam_g0",
+                    dict(
+                        file_path=Path.cwd()
+                        / "ephy_testing_data"
+                        / "spikeglx"
+                        / "Noise4Sam_g0"
+                        / "Noise4Sam_g0_imec0"
+                        / "Noise4Sam_g0_t0.imec0.ap.bin"
+                    ),
+                ),
+            ]
+        )
         def test_convert_recording_extractor_to_nwb(self, recording_interface, dataset_path, interface_kwargs):
             print(f"\n\n\n TESTING {recording_interface.__name__}...")
             dataset_stem = Path(dataset_path).stem
@@ -118,20 +132,22 @@ if HAVE_DATALAD and (sys.platform == "linux" or run_local):
             check_recordings_equal(
                 RX1=converter.data_interface_objects["TestRecording"].recording_extractor,
                 RX2=nwb_recording,
-                check_times=False
+                check_times=False,
             )
 
-        @parameterized.expand([
-            (
-                BlackrockSortingExtractorInterface,
-                "blackrock/blackrock_2_1",
-                dict(
-                    filename=str(Path.cwd() / "ephy_testing_data" / "blackrock" / "blackrock_2_1" / "l101210-001"),
-                    seg_index=0,
-                    nsx_to_load=5
-                 )
-            )
-        ])
+        @parameterized.expand(
+            [
+                (
+                    BlackrockSortingExtractorInterface,
+                    "blackrock/blackrock_2_1",
+                    dict(
+                        filename=str(Path.cwd() / "ephy_testing_data" / "blackrock" / "blackrock_2_1" / "l101210-001"),
+                        seg_index=0,
+                        nsx_to_load=5,
+                    ),
+                )
+            ]
+        )
         def test_convert_sorting_extractor_to_nwb(self, sorting_interface, dataset_path, interface_kwargs):
             print(f"\n\n\n TESTING {sorting_interface.__name__}...")
             dataset_stem = Path(dataset_path).stem
@@ -148,5 +164,6 @@ if HAVE_DATALAD and (sys.platform == "linux" or run_local):
                 SX1=converter.data_interface_objects["TestRecording"].recording_extractor, SX2=nwb_recording
             )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

The GIN repo has been used on `neo` and `spikeextractors` to guarantee successful read (and some write) of the data formats supported there. Since our interfaces, particularly their metadata interaction functions, make use of data format specificities it's a good idea for us to ensure we can properly access those metadata fields from the source files.

## How to test the behavior?

I've included GIN in our main dev workflow (not production) and as such do not affect normal installation requirements (should just be for our own testing benefit). The dev CI will now take a bit longer to run, but well worth the cost.

@bendichter An alternative might be to add an entirely separate workflow just for the GIN, which would put all PRs at a 4/4 check for format, production release (all lazy imports), dev release (all interfaces with all imports loaded), and GIN. Do you have a preference?

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
