### PR TITLE
Add speed testing for writing recordings

### DIFF
--- a/nwb_conversion_tools/utils/conversion_tools.py
+++ b/nwb_conversion_tools/utils/conversion_tools.py
@@ -75,9 +75,7 @@ def check_regular_timestamps(ts):
 
 
 def estimate_recording_conversion_time(
-    recording: RecordingExtractor,
-    mb_threshold: float = 100.0,
-    write_kwargs: Optional[dict] = None
+    recording: RecordingExtractor, mb_threshold: float = 100.0, write_kwargs: Optional[dict] = None
 ) -> (float, float):
     """
     Test the write speed of recording data to NWB on this system.

--- a/nwb_conversion_tools/utils/conversion_tools.py
+++ b/nwb_conversion_tools/utils/conversion_tools.py
@@ -4,12 +4,17 @@ import numpy as np
 import uuid
 from datetime import datetime
 from warnings import warn
+from tempfile import mkdtemp
+from shutil import rmtree
+from time import perf_counter
+from typing import Optional
 
 from pynwb import NWBFile
 from pynwb.file import Subject
-import spikeextractors as se
+from spikeextractors import RecordingExtractor, SubRecordingExtractor
 
 from .json_schema import dict_deep_update
+from .spike_interface import write_recording
 
 
 def get_module(nwbfile: NWBFile, name: str, description: str = None):
@@ -67,3 +72,46 @@ def check_regular_timestamps(ts):
     time_tol_decimals = 9
     uniq_diff_ts = np.unique(np.diff(ts).round(decimals=time_tol_decimals))
     return len(uniq_diff_ts) == 1
+
+
+def estimate_recording_conversion_time(
+    recording: RecordingExtractor,
+    mb_threshold: float = 100.0,
+    write_kwargs: Optional[dict] = None
+) -> float:
+    """
+    Test the write speed of recording data to NWB on this system.
+
+    recording : RecordingExtractor
+        The recording object to be written.
+    mb_threshold : float
+        Maximum amount of data to test with. Defaults to 100, which is just over 2 seconds of standard SpikeGLX data.
+
+    Returns
+    -------
+    float
+        Speed of the conversion in MB/s.
+    """
+    if write_kwargs is None:
+        write_kwargs = dict()
+
+    temp_dir = Path(mkdtemp())
+    test_nwbfile_path = temp_dir / "recording_speed_test.nwb"
+
+    num_channels = recording.get_num_channels()
+    itemsize = recording.get_dtype().itemsize
+    if recording.get_num_frames() * num_channels * itemsize / 1e6 > mb_threshold:
+        truncation = np.floor(mb_threshold * 1e6 / (num_channels * itemsize))
+        test_recording = SubRecordingExtractor(parent_recording=recording, end_frame=truncation)
+    else:
+        test_recording = recording
+
+    actual_mb = test_recording.get_num_frames() * num_channels * itemsize / 1e6
+    start = perf_counter()
+    write_recording(recording=test_recording, save_path=test_nwbfile_path, overwrite=True, **write_kwargs)
+    end = perf_counter()
+    delta = end - start
+    speed = actual_mb / delta
+
+    rmtree(temp_dir)
+    return speed

--- a/nwb_conversion_tools/utils/conversion_tools.py
+++ b/nwb_conversion_tools/utils/conversion_tools.py
@@ -92,7 +92,7 @@ def estimate_recording_conversion_time(
     speed : float
         Speed of the conversion in MB/s.
     total_time : float
-        Estimate of total time to write all data based on speed estimate and known total data size.
+        Estimate of total time (in minutes) to write all data based on speed estimate and known total data size.
     """
     if write_kwargs is None:
         write_kwargs = dict()
@@ -115,7 +115,7 @@ def estimate_recording_conversion_time(
     end = perf_counter()
     delta = end - start
     speed = actual_test_mb / delta
-    total_time = total_mb / speed
+    total_time = (total_mb / speed) / 60
 
     rmtree(temp_dir)
     return speed, total_time

--- a/nwb_conversion_tools/utils/conversion_tools.py
+++ b/nwb_conversion_tools/utils/conversion_tools.py
@@ -89,10 +89,10 @@ def estimate_recording_conversion_time(
 
     Returns
     -------
-    speed : float
-        Speed of the conversion in MB/s.
     total_time : float
         Estimate of total time (in minutes) to write all data based on speed estimate and known total data size.
+    speed : float
+        Speed of the conversion in MB/s.
     """
     if write_kwargs is None:
         write_kwargs = dict()
@@ -118,4 +118,4 @@ def estimate_recording_conversion_time(
     total_time = (total_mb / speed) / 60
 
     rmtree(temp_dir)
-    return speed, total_time
+    return total_time, speed

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -38,6 +38,5 @@ class TestConversionTools(TestCase):
 
         estimated_write_time, estimated_write_speed = estimate_recording_conversion_time(recording=recording)
         estimated_write_time, estimated_write_speed = estimate_recording_conversion_time(
-            recording=recording,
-            write_kwargs=dict(iterate=False, compression=None)
+            recording=recording, write_kwargs=dict(iterate=False, compression=None)
         )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,8 +1,11 @@
 from unittest import TestCase
+import numpy as np
 
 from pynwb.base import ProcessingModule
+from spikeextractors import NumpyRecordingExtractor
 
 from nwb_conversion_tools.utils.conversion_tools import check_regular_timestamps, get_module, make_nwbfile_from_metadata
+from nwb_conversion_tools.utils.conversion_tools import estimate_recording_conversion_time
 
 
 class TestConversionTools(TestCase):
@@ -25,3 +28,16 @@ class TestConversionTools(TestCase):
         assert isinstance(mod_2, ProcessingModule)
         assert mod_2.description == description_2
         self.assertWarns(UserWarning, get_module, **dict(nwbfile=nwbfile, name=name_1, description=description_2))
+
+    def test_estimate_recording_conversion_time(self):
+        num_channels = 4
+        sampling_frequency = 30000
+        num_frames = sampling_frequency * 1
+        timeseries = np.random.randint(low=-32768, high=32767, size=[num_channels, num_frames], dtype=np.dtype("int16"))
+        recording = NumpyRecordingExtractor(timeseries=timeseries, sampling_frequency=sampling_frequency)
+
+        estimated_write_time, estimated_write_speed = estimate_recording_conversion_time(recording=recording)
+        estimated_write_time, estimated_write_speed = estimate_recording_conversion_time(
+            recording=recording,
+            write_kwargs=dict(iterate=False, compression=None)
+        )


### PR DESCRIPTION
## Motivation

Hidden behind some recent changes to control over electrical series writing of RecordingExtractor objects (and some future DataChunking changes as well) was an assumed speed increase. This adds a conversion tool that anyone can use to confirm it, but more usefully returns the estimated amount of time the entire conversion will take - which is nice to have for hefty conversions that can take on the order of hours.

## How to test the behavior?

Basic tests for the function have been added to ensure it runs without error, but truly useful information would come from more extensive local testing that I don't want to force the CI to do every single push.

Here's an all-encompassing code block that tests the speed differences of some of the recent changes.

```
import numpy as np

from spikeextractors import NumpyRecordingExtractor
from nwb_conversion_tools.utils.conversion_tools import estimate_recording_conversion_time

num_channels = 384
sampling_frequency = 30000
num_frames = sampling_frequency * 5
timeseries = np.random.randint(low=-32768, high=32767, size=[num_channels, num_frames], dtype=np.dtype("int16"))
recording = NumpyRecordingExtractor(timeseries=timeseries, sampling_frequency=sampling_frequency)

_, estimated_write_speed = estimate_recording_conversion_time(recording=recording)
_, estimated_write_speed_no_iter = estimate_recording_conversion_time(
    recording=recording,
    write_kwargs=dict(iterate=False)
)
_, estimated_write_speed_no_comp = estimate_recording_conversion_time(
    recording=recording,
    write_kwargs=dict(compression=None)
)
_, estimated_write_speed_no_iter_or_comp = estimate_recording_conversion_time(
    recording=recording,
    write_kwargs=dict(iterate=False, compression=None)
)
```

which reveals, on my own system, the following differences:

- Basic: ~4.7 MB/s
- No iteration: ~39 MB/s
- No compression: ~58 MB/s
- No compression or iteration: ~105 MB/s

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
