### PR TITLE
add ElectricalSeries_lfp to get_metadata_schema in BaseLFPExtractorInterface

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from pynwb import NWBFile
 from pynwb.device import Device
-from pynwb.ecephys import ElectrodeGroup
+from pynwb.ecephys import ElectrodeGroup, ElectricalSeries
 
 from .baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ...utils.spike_interface import write_recording
@@ -16,6 +16,13 @@ OptionalPathType = Optional[Union[str, Path]]
 
 class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
     """Primary class for all LFP data interfaces."""
+
+    def get_metadata_schema(self):
+        metadata_schema = super().get_metadata_schema()
+        metadata_schema["properties"]["Ecephys"]["properties"].update(
+            ElectricalSeries_lfp=get_schema_from_hdmf_class(ElectricalSeries)
+        )
+        return metadata_schema
 
     def get_metadata(self):
         metadata = super().get_metadata()


### PR DESCRIPTION
## Motivation

BaseLFPExtractorInterface makes minor modifications to BaseRecordingExtractorInterface, i.e. adding `ElectricalSeries_lfp` to the metadata and converting as `lfp` data. However, it does not change the metadata schema appropriately (i.e. including `ElectricalSeries_lfp`), thus failing the metadata schema validation. Here we include `ElectricalSeries_lfp` in the metadata schema.


## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Is your contribution compliant with our coding style? Read about [PEP8](https://www.python.org/dev/peps/pep-0008/) and [black](https://black.readthedocs.io/en/stable/the_black_code_style.html).
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
