### PR TITLE
Add Neuralynx Interface

### DIFF
--- a/nwb_conversion_tools/datainterfaces/__init__.py
+++ b/nwb_conversion_tools/datainterfaces/__init__.py
@@ -29,6 +29,7 @@ from .ecephys.axona.axonadatainterface import (
     AxonaLFPDataInterface,
     AxonaUnitRecordingExtractorInterface,
 )
+from .ecephys.neuralynx.neuralynxdatainterface import NeuralynxRecordingInterface
 
 from .ophys.caiman.caimandatainterface import CaimanSegmentationInterface
 from .ophys.cnmfe.cnmfedatainterface import CnmfeSegmentationInterface

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -112,7 +112,6 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         use_times: bool = False,
         save_path: OptionalPathType = None,
         overwrite: bool = False,
-        buffer_mb: int = 500,
         write_as: str = "raw",
         es_key: str = None,
         compression: Optional[str] = "gzip",

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -1,0 +1,35 @@
+"""Authors: Cody Baker."""
+import numpy as np
+from pathlib import Path
+from natsort import natsorted
+from typing import Union
+
+from spikeextractors import MultiRecordingChannelExtractor, NeuralynxRecordingExtractor
+
+
+from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
+from ....utils.json_schema import get_schema_from_method_signature
+
+PathType = Union[str, Path]
+
+
+class NeuralynxRecordingInterface(BaseRecordingExtractorInterface):
+    """Primary data interface class for converting the Neuralynx format."""
+
+    RX = MultiRecordingChannelExtractor
+
+    @classmethod
+    def get_source_schema(cls):
+        """Compile input schema for the RecordingExtractor."""
+        return get_schema_from_method_signature(cls.__init__)
+
+    def __init__(self, folder_path: PathType):
+        self.subset_channels = None
+        self.source_data = dict(folder_path=folder_path)
+        neuralynx_files = natsorted([str(x) for x in Path(folder_path).iterdir() if ".ncs" in x.suffixes])
+        extractors = [NeuralynxRecordingExtractor(filename=filename, seg_index=0) for filename in neuralynx_files]
+        gains=[extractor.get_channel_gains()[0] for extractor in extractors]
+        for extractor in extractors:
+            extractor.clear_channel_gains()
+        self.recording_extractor = self.RX(extractors)
+        self.recording_extractor.set_channel_gains(gains=[extractor.get_channel_gains()[0] for extractor in extractors])

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,3 +18,4 @@ roiextractors==0.3.1
 ndx-events==0.2.0
 parameterized==0.8.1
 pyintan==0.3.0
+natsort==7.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ spikesorters==0.4.4
 spiketoolkit==0.7.5
 neo==0.9.0
 roiextractors==0.3.1
+natsort==7.1.1

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -9,6 +9,7 @@ from spikeextractors.testing import check_recordings_equal
 from nwb_conversion_tools import (
     NWBConverter,
     IntanRecordingInterface,
+    NeuralynxRecordingInterface
 )
 
 try:
@@ -61,6 +62,11 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                     IntanRecordingInterface,
                     "intan",
                     dict(file_path=str(data_path / "intan" / "intan_rhs_test_1.rhs")),
+                ),
+                (
+                    NeuralynxRecordingInterface,
+                    "neuralynx/Cheetah_v5.7.4/original_data",
+                    dict(folder_path=str(data_path / "neuralynx" / "Cheetah_v5.7.4" / "original_data")),
                 ),
             ]
         )


### PR DESCRIPTION
## Motivation

Previous PR #143 adding a Neuralynx interface became outdated against all the changes to the master branch, and the commit conflicts were harder to resolve than just redoing it from the current master branch with all the requested changes.

This PR adds a data interface for Neuralynx recordings. It does this safely by combining individual files through the `filename` usage of the `NeuralynxRecordingExtractor` since the `dirname` usage caused errors on certain versions.

Note that some functionality on some types of `.ncs` files may still be subject to the memory leak that `neo` is trying to fix as we speak.

## How to test the behavior?
GIN tests have been added for the Neuralynx interface

```
!pytest
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
