### PR TITLE
removing spurious codecov runs; expanding OS coverage

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -1,42 +1,28 @@
 name: CI development environment
-on: [push]
+on: [pull_request]
 jobs:
   run:
-    name: Full test on (${{ matrix.os }})
+    name: Development test on (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["macos-latest", "windows-latest"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: s-weigand/setup-conda@v1
-        with:
-          python-version: 3.8
-      - name: Which python
-        run: |
-          conda --version
-          which python
-      - run: git fetch --prune --unshallow --tags
-      - name: Install this package, on development mode
-        env:
-            NWB_CONVERSION_INSTALL_MODE: development
-        run: |
-          conda install -c conda-forge datalad==0.14.5
-          pip install -e .
-          # needed for correct operation of git/git-annex/DataLad
-          git config --global user.email "CI@example.com"
-          git config --global user.name "CI Almighty"
-      - name: Run tests and generate coverage report
-        run: |
-          pip install pytest
-          pip install pytest-cov
-          pytest --cov=./ --cov-report=xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
-          yml: ./codecov.yml
+    - uses: actions/checkout@v2
+    - run: git fetch --prune --unshallow --tags
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install pip
+      run: |
+        python -m pip install --upgrade pip
+    - name: Install this package, on development mode
+      env:
+          NWB_CONVERSION_INSTALL_MODE: development
+      run: |
+        pip install .
+    - name: Run tests
+      run: |
+        pip install pytest

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -1,8 +1,8 @@
-name: CI development environment
+name: CI development
 on: [pull_request]
 jobs:
   run:
-    name: Development test on (${{ matrix.os }})
+    name: Development tests on (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v2
       - uses: s-weigand/setup-conda@v1

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,0 +1,42 @@
+name: CI GIN environment
+on: [pull_request]
+jobs:
+  run:
+    name: Full test on (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: s-weigand/setup-conda@v1
+        with:
+          python-version: 3.8
+      - name: Which python
+        run: |
+          conda --version
+          which python
+      - run: git fetch --prune --unshallow --tags
+      - name: Install this package, on development mode
+        env:
+            NWB_CONVERSION_INSTALL_MODE: development
+        run: |
+          conda install -c conda-forge datalad==0.14.5
+          pip install -e .
+          # needed for correct operation of git/git-annex/DataLad
+          git config --global user.email "CI@example.com"
+          git config --global user.name "CI Almighty"
+      - name: Run tests and generate coverage report
+        run: |
+          pip install pytest
+          pip install pytest-cov
+          pytest --cov=./ --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          yml: ./codecov.yml

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,8 +1,8 @@
-name: CI GIN environment
+name: CI GIN
 on: [pull_request]
 jobs:
   run:
-    name: Full test on (${{ matrix.os }})
+    name: Full tests on (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-production.yml
+++ b/.github/workflows/ci-production.yml
@@ -1,5 +1,5 @@
 name: CI production environment
-on: [push]
+on: [pull_request]
 jobs:
   run:
     name: Lazy test on (${{ matrix.os }})

--- a/.github/workflows/ci-production.yml
+++ b/.github/workflows/ci-production.yml
@@ -1,8 +1,8 @@
-name: CI production environment
+name: CI production
 on: [pull_request]
 jobs:
   run:
-    name: Lazy test on (${{ matrix.os }})
+    name: Lazy tests on (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-production.yml
+++ b/.github/workflows/ci-production.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow --tags
@@ -23,16 +23,6 @@ jobs:
           NWB_CONVERSION_INSTALL_MODE: production
       run: |
         pip install .
-    - name: Run tests and generate coverage report
+    - name: Run tests
       run: |
         pip install pytest
-        pip install pytest-cov
-        pytest --cov=./ --cov-report=xml
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        yml: ./codecov.yml


### PR DESCRIPTION
## Motivation

The codecov runs and uploads from the lazy test pipeline do not count the results of GIN tests and so falsely report massive decreases to coverage. Also, in general, unnecessarily duplicates the number of codecov uploads. This PR removes them.

The PR also adds coverage for the other operating systems; however, reading on [pricing for GitHub actions](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions), at least for private repo's, the mac system in particular is billed 10x as much as the linux, and with our current test run speeds we could eat that up very quickly. Since we're a public repo I think we still get as much as we want for free, but if @bendichter could triple check under `settings -> billing` to make sure that is the case

## How to test the behavior?
No changes to repo behavior or even the tests themselves.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
