### PR TITLE
v2 release action

### DIFF
--- a/.github/workflows/python-publish-v2.yml
+++ b/.github/workflows/python-publish-v2.yml
@@ -1,7 +1,7 @@
 # This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
-name: Upload Python Package
+name: Upload Python Package v2
 
 on:
   release:


### PR DESCRIPTION
## Motivation

Actions for auto release is not working. 
Based on the error track, I suspect the error can be due to the package `build`, which is suggested [here](https://docs.github.com/en/actions/guides/building-and-testing-python#publishing-to-package-registries).
I never used it before, I always build packages using `python setup.py sdist bdist_wheel`. So this is what I'm trying here now.

## How to test the behavior?
Run github action `Upload Python Package v2`
