### PR TITLE
Add SpikeGLX GIN

### DIFF
--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -101,7 +101,7 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                             / "Noise4Sam_g0_imec0"
                             / "Noise4Sam_g0_t0.imec0.lf.bin"
                         )
-                    )
+                    ),
                 ),
             ]
         )

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -90,7 +90,7 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                     for file in Path(loc).iterdir():
                         self.dataset.get(f"{dataset_path}/{file.name}")
                 else:
-                    for dataset_file in Path(dataset_path).parent:
+                    for dataset_file in Path(dataset_path).parent.iterdir():
                         self.dataset.get(dataset_file)
             dataset_stem = Path(dataset_path).stem
             nwbfile_path = self.savedir / f"{recording_interface.__name__}_test_{dataset_stem}.nwb"

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -90,7 +90,8 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                     for file in Path(loc).iterdir():
                         self.dataset.get(f"{dataset_path}/{file.name}")
                 else:
-                    self.dataset.get(dataset_path)
+                    for dataset_file in Path(dataset_path).parent:
+                        self.dataset.get(dataset_file)
             dataset_stem = Path(dataset_path).stem
             nwbfile_path = self.savedir / f"{recording_interface.__name__}_test_{dataset_stem}.nwb"
 

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -73,10 +73,21 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                 ),
                 (
                     SpikeGLXRecordingInterface,
-                    "spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/Noise4Sam_g0_t0.imec0.ap.bin",
+                    "spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0",
                     dict(
                         file_path=str(
-                            data_path / "spikeglx" / "Noise4Sam_g0" / "Noise4Sam_g0_imec0" / "Noise4Sam_g0_t0.imec0.ap.bin"
+                            data_path / "spikeglx" / "Noise4Sam_g0" / "Noise4Sam_g0_imec0"
+                            / "Noise4Sam_g0_t0.imec0.ap.bin"
+                        )
+                    ),
+                ),
+                (
+                    SpikeGLXRecordingInterface,
+                    "spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0",
+                    dict(
+                        file_path=str(
+                            data_path / "spikeglx" / "Noise4Sam_g0" / "Noise4Sam_g0_imec0"
+                            / "Noise4Sam_g0_t0.imec0.lf.bin"
                         )
                     ),
                 ),
@@ -90,8 +101,7 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                     for file in Path(loc).iterdir():
                         self.dataset.get(f"{dataset_path}/{file.name}")
                 else:
-                    for dataset_file in Path(dataset_path).parent.iterdir():
-                        self.dataset.get(dataset_file)
+                    self.dataset.get(dataset_path)
             dataset_stem = Path(dataset_path).stem
             nwbfile_path = self.savedir / f"{recording_interface.__name__}_test_{dataset_stem}.nwb"
 

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -9,8 +9,6 @@ from nwb_conversion_tools import (
     NWBConverter,
     IntanRecordingInterface,
     NeuralynxRecordingInterface,
-    NeuroscopeRecordingInterface,
-    SpikeGadgetsRecordingInterface,
     SpikeGLXRecordingInterface
 )
 
@@ -29,7 +27,7 @@ except ImportError:
     HAVE_PARAMETERIZED = False
 
 RUN_LOCAL = True
-LOCAL_PATH = Path("E:/GIN")  # Path to dataset downloaded from https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+LOCAL_PATH = Path("D:/GIN")  # Path to dataset downloaded from https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
 
 
 if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL):
@@ -72,21 +70,6 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                     NeuralynxRecordingInterface,
                     "neuralynx/Cheetah_v5.7.4/original_data",
                     dict(folder_path=str(data_path / "neuralynx" / "Cheetah_v5.7.4" / "original_data")),
-                ),
-                (
-                    NeuroscopeRecordingInterface,
-                    "neuroscope/test_1",
-                    dict(file_path=str(data_path / "neuroscope" / "test1" / "test1.dat")),
-                ),
-                (
-                    SpikeGadgetsRecordingInterface,
-                    "spikegadgets",
-                    dict(filename=str(data_path / "spikegadgets" / "20210225_em8_minirec2_ac.rec")),
-                ),
-                (
-                    SpikeGadgetsRecordingInterface,
-                    "spikegadgets",
-                    dict(filename=str(data_path / "spikegadgets" / "W122_06_09_2019_1_fromSD.rec")),
                 ),
                 (
                     SpikeGLXRecordingInterface,

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -9,7 +9,7 @@ from nwb_conversion_tools import (
     NWBConverter,
     IntanRecordingInterface,
     NeuralynxRecordingInterface,
-    SpikeGLXRecordingInterface
+    SpikeGLXRecordingInterface,
 )
 
 try:
@@ -76,7 +76,10 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                     "spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0",
                     dict(
                         file_path=str(
-                            data_path / "spikeglx" / "Noise4Sam_g0" / "Noise4Sam_g0_imec0"
+                            data_path
+                            / "spikeglx"
+                            / "Noise4Sam_g0"
+                            / "Noise4Sam_g0_imec0"
                             / "Noise4Sam_g0_t0.imec0.ap.bin"
                         )
                     ),
@@ -86,7 +89,10 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                     "spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0",
                     dict(
                         file_path=str(
-                            data_path / "spikeglx" / "Noise4Sam_g0" / "Noise4Sam_g0_imec0"
+                            data_path
+                            / "spikeglx"
+                            / "Noise4Sam_g0"
+                            / "Noise4Sam_g0_imec0"
                             / "Noise4Sam_g0_t0.imec0.lf.bin"
                         )
                     ),


### PR DESCRIPTION
## Motivation

GIN data has been available for SpikeGLX for some time; finally getting around to adding it here to verify the metadata is being handled correctly and roundtrip works without error.

## How to test the behavior?
GIN tests added, interface debugged.

```
!pytest
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
