### PR TITLE
adding nsx_to_load as arg for Blackrock files. Fixing tests

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -31,16 +31,10 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["filename"]["description"] = "Path to Blackrock file."
         return source_schema
 
-    def __init__(self, filename: FilePathType, nsx_override: OptionalFilePathType = None):
-        nsx_to_load = int(str(filename).split(".")[-1][-1])
-        super().__init__(filename=filename, nsx_to_load=nsx_to_load)
-        # super().__init__(filename=filename, nsx_override=nsx_override)
-        # if self.source_data["nsx_override"] is not None:
-        #     # if 'nsx_override' is specified as a path, then the 'filename' argument is ignored
-        #     # This filename be used to extract the version of nsx: ns3/4/5/6 from the filepath
-        #     self.data_filename = self.source_data["nsx_override"]
-        # else:
-        #     self.data_filename = self.source_data["filename"]
+    def __init__(self, filename: FilePathType,
+                 nsx_override: OptionalFilePathType = None,
+                 nsx_to_load: OptionalFilePathType = None):
+        super().__init__(filename=filename, nsx_override=nsx_override, nsx_to_load=nsx_to_load)
 
     def get_metadata_schema(self):
         """Compile metadata schema for the RecordingExtractor."""
@@ -110,7 +104,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         stub_test: bool, optional (default False)
             If True, will truncate the data to run the conversion faster and take up less memory.
         """
-        if self.source_data["filename"].split(".")[-1][-1] == "6":
+        if 6 in self.RX.neo_reader.nsx_to_load:
             write_as = "raw"
         elif write_as not in ["processed", "lfp"]:
             write_as = "processed"

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -135,7 +135,7 @@ class BlackrockSortingExtractorInterface(BaseSortingExtractorInterface):
     def get_source_schema(cls):
         """Compile input schema for the RecordingExtractor."""
         metadata_schema = get_schema_from_method_signature(
-            class_method=cls.SX.__init__, exclude=["block_index", "seg_index", "nsx_to_load"]
+            class_method=cls.__init__, exclude=["block_index", "seg_index"]
         )
         metadata_schema["additionalProperties"] = True
         metadata_schema["properties"]["file_path"]["description"] = "Path to Blackrock file."

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -107,7 +107,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         stub_test: bool, optional (default False)
             If True, will truncate the data to run the conversion faster and take up less memory.
         """
-        if 6 in self.recording_extractor.neo_reader.nsx_to_load:
+        if max(self.recording_extractor.neo_reader.nsx_to_load) >= 5:
             write_as = "raw"
         elif write_as not in ["processed", "lfp"]:
             write_as = "processed"

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -28,16 +28,16 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         source_schema = get_schema_from_method_signature(
             class_method=cls.__init__, exclude=["block_index", "seg_index"]
         )
-        source_schema["properties"]["file_path"]["description"] = "Path to Blackrock file."
+        source_schema["properties"]["filename"]["description"] = "Path to Blackrock file."
         return source_schema
 
     def __init__(
         self,
-        file_path: FilePathType,
+        filename: FilePathType,
         nsx_override: OptionalFilePathType = None,
         nsx_to_load: Optional[int] = None,
     ):
-        super().__init__(file_path=file_path, nsx_override=nsx_override, nsx_to_load=nsx_to_load)
+        super().__init__(filename=filename, nsx_override=nsx_override, nsx_to_load=nsx_to_load)
 
     def get_metadata_schema(self):
         """Compile metadata schema for the RecordingExtractor."""
@@ -53,7 +53,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         metadata = super().get_metadata()
 
         # Open file and extract headers
-        nsx_file = NsxFile(datafile=self.source_data["file_path"])
+        nsx_file = NsxFile(datafile=self.source_data["filename"])
         session_start_time = nsx_file.basic_header["TimeOrigin"]
         session_start_time_tzaware = pytz.timezone("EST").localize(session_start_time)
         comment = nsx_file.basic_header["Comment"]
@@ -138,10 +138,10 @@ class BlackrockSortingExtractorInterface(BaseSortingExtractorInterface):
             class_method=cls.__init__, exclude=["block_index", "seg_index"]
         )
         metadata_schema["additionalProperties"] = True
-        metadata_schema["properties"]["file_path"]["description"] = "Path to Blackrock file."
+        metadata_schema["properties"]["filename"]["description"] = "Path to Blackrock file."
         return metadata_schema
 
     def __init__(
-        self, file_path: FilePathType, nsx_to_load: Optional[int] = None, nev_override: OptionalFilePathType = None
+        self, filename: FilePathType, nsx_to_load: Optional[int] = None, nev_override: OptionalFilePathType = None
     ):
-        super().__init__(file_path=file_path, nsx_to_load=nsx_to_load, nev_override=nev_override)
+        super().__init__(filename=filename, nsx_to_load=nsx_to_load, nev_override=nev_override)

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -32,7 +32,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         return source_schema
 
     def __init__(self, filename: FilePathType, nsx_override: OptionalFilePathType = None):
-        nsx_to_load = int(str(filename).split('.')[-1][-1])
+        nsx_to_load = int(str(filename).split(".")[-1][-1])
         super().__init__(filename=filename, nsx_to_load=nsx_to_load)
         # super().__init__(filename=filename, nsx_override=nsx_override)
         # if self.source_data["nsx_override"] is not None:
@@ -56,7 +56,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         metadata = super().get_metadata()
 
         # Open file and extract headers
-        nsx_file = NsxFile(datafile=self.source_data['filename'])
+        nsx_file = NsxFile(datafile=self.source_data["filename"])
         session_start_time = nsx_file.basic_header["TimeOrigin"]
         session_start_time_tzaware = pytz.timezone("EST").localize(session_start_time)
         comment = nsx_file.basic_header["Comment"]
@@ -68,7 +68,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         )
 
         # Checks if data is raw or processed
-        if self.source_data['filename'].split(".")[-1][-1] == "6":
+        if self.source_data["filename"].split(".")[-1][-1] == "6":
             metadata["Ecephys"]["ElectricalSeries_raw"] = dict(name="ElectricalSeries_raw")
         else:
             metadata["Ecephys"]["ElectricalSeries_processed"] = dict(name="ElectricalSeries_processed")
@@ -110,7 +110,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         stub_test: bool, optional (default False)
             If True, will truncate the data to run the conversion faster and take up less memory.
         """
-        if self.source_data['filename'].split(".")[-1][-1] == "6":
+        if self.source_data["filename"].split(".")[-1][-1] == "6":
             write_as = "raw"
         elif write_as not in ["processed", "lfp"]:
             write_as = "processed"

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -28,7 +28,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         source_schema = get_schema_from_method_signature(
             class_method=cls.__init__, exclude=["block_index", "seg_index"]
         )
-        source_schema["properties"]["filename"]["description"] = "Path to Blackrock file."
+        source_schema["properties"]["file_path"]["description"] = "Path to Blackrock file."
         return source_schema
 
     def __init__(
@@ -138,10 +138,10 @@ class BlackrockSortingExtractorInterface(BaseSortingExtractorInterface):
             class_method=cls.SX.__init__, exclude=["block_index", "seg_index", "nsx_to_load"]
         )
         metadata_schema["additionalProperties"] = True
-        metadata_schema["properties"]["filename"]["description"] = "Path to Blackrock file."
+        metadata_schema["properties"]["file_path"]["description"] = "Path to Blackrock file."
         return metadata_schema
 
     def __init__(
-        self, filename: FilePathType, nsx_to_load: Optional[int] = None, nev_override: OptionalFilePathType = None
+        self, file_path: FilePathType, nsx_to_load: Optional[int] = None, nev_override: OptionalFilePathType = None
     ):
-        super().__init__(filename=filename, nsx_to_load=nsx_to_load, nev_override=nev_override)
+        super().__init__(file_path=file_path, nsx_to_load=nsx_to_load, nev_override=nev_override)

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -33,11 +33,11 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
 
     def __init__(
         self,
-        filename: FilePathType,
+        file_path: FilePathType,
         nsx_override: OptionalFilePathType = None,
         nsx_to_load: OptionalFilePathType = None,
     ):
-        super().__init__(filename=filename, nsx_override=nsx_override, nsx_to_load=nsx_to_load)
+        super().__init__(file_path=file_path, nsx_override=nsx_override, nsx_to_load=nsx_to_load)
 
     def get_metadata_schema(self):
         """Compile metadata schema for the RecordingExtractor."""
@@ -53,7 +53,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         metadata = super().get_metadata()
 
         # Open file and extract headers
-        nsx_file = NsxFile(datafile=self.source_data["filename"])
+        nsx_file = NsxFile(datafile=self.source_data["file_path"])
         session_start_time = nsx_file.basic_header["TimeOrigin"]
         session_start_time_tzaware = pytz.timezone("EST").localize(session_start_time)
         comment = nsx_file.basic_header["Comment"]

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -65,7 +65,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         )
 
         # Checks if data is raw or processed
-        if max(self.recording_extractor.neo_reader.nsx_to_load) >=5:
+        if max(self.recording_extractor.neo_reader.nsx_to_load) >= 5:
             metadata["Ecephys"]["ElectricalSeries_raw"] = dict(name="ElectricalSeries_raw")
         else:
             metadata["Ecephys"]["ElectricalSeries_processed"] = dict(name="ElectricalSeries_processed")

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -65,7 +65,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         )
 
         # Checks if data is raw or processed
-        if 6 in self.recording_extractor.neo_reader.nsx_to_load:
+        if max(self.recording_extractor.neo_reader.nsx_to_load) >=5:
             metadata["Ecephys"]["ElectricalSeries_raw"] = dict(name="ElectricalSeries_raw")
         else:
             metadata["Ecephys"]["ElectricalSeries_processed"] = dict(name="ElectricalSeries_processed")

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -35,7 +35,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         self,
         file_path: FilePathType,
         nsx_override: OptionalFilePathType = None,
-        nsx_to_load: OptionalFilePathType = None,
+        nsx_to_load: Optional[int] = None,
     ):
         super().__init__(file_path=file_path, nsx_override=nsx_override, nsx_to_load=nsx_to_load)
 

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -65,7 +65,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         )
 
         # Checks if data is raw or processed
-        if 6 in self.RX.neo_reader.nsx_to_load:
+        if 6 in self.recording_extractor.neo_reader.nsx_to_load:
             metadata["Ecephys"]["ElectricalSeries_raw"] = dict(name="ElectricalSeries_raw")
         else:
             metadata["Ecephys"]["ElectricalSeries_processed"] = dict(name="ElectricalSeries_processed")
@@ -107,7 +107,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         stub_test: bool, optional (default False)
             If True, will truncate the data to run the conversion faster and take up less memory.
         """
-        if 6 in self.RX.neo_reader.nsx_to_load:
+        if 6 in self.recording_extractor.neo_reader.nsx_to_load:
             write_as = "raw"
         elif write_as not in ["processed", "lfp"]:
             write_as = "processed"

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -62,7 +62,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         )
 
         # Checks if data is raw or processed
-        if self.source_data["filename"].split(".")[-1][-1] == "6":
+        if 6 in self.RX.neo_reader.nsx_to_load:
             metadata["Ecephys"]["ElectricalSeries_raw"] = dict(name="ElectricalSeries_raw")
         else:
             metadata["Ecephys"]["ElectricalSeries_processed"] = dict(name="ElectricalSeries_processed")

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -14,6 +14,7 @@ from nwb_conversion_tools import (
     PhySortingInterface,
     SpikeGLXRecordingInterface,
     BlackrockRecordingExtractorInterface,
+    BlackrockSortingExtractorInterface
 )
 
 try:
@@ -182,6 +183,11 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                     sorting_interface=PhySortingInterface,
                     dataset_path="phy/phy_example_0",
                     interface_kwargs=dict(folder_path=str(data_path / "phy" / "phy_example_0")),
+                ),
+                (
+                    BlackrockSortingExtractorInterface,
+                    "blackrock",
+                    dict(filename=str(data_path/"blackrock"/"FileSpec2.3001.nev")),
                 )
             ]
         )

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -11,6 +11,7 @@ from nwb_conversion_tools import (
     NeuralynxRecordingInterface,
     NeuroscopeRecordingInterface,
     SpikeGLXRecordingInterface,
+    BlackrockRecordingExtractorInterface
 )
 
 try:
@@ -101,6 +102,18 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                             / "Noise4Sam_g0_imec0"
                             / "Noise4Sam_g0_t0.imec0.lf.bin"
                         )
+                    ),
+                ),
+                (
+                    BlackrockRecordingExtractorInterface,
+                    "blackrock/blackrock_2_1",
+                    dict(
+                        file_path=str(
+                            data_path
+                            /"blackrock"
+                            /"blackrock_2_1"
+                        ),
+                        nsx_to_load=5
                     ),
                 ),
             ]

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -149,8 +149,8 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                 ),
                 (
                     BlackrockRecordingExtractorInterface,
-                    "blackrock/blackrock_2_1",
-                    dict(filename=str(data_path / "blackrock" / "blackrock_2_1" / "l101210-001.ns5"), nsx_to_load=5),
+                    "blackrock",
+                    dict(filename=str(data_path / "blackrock" / "FileSpec2.3001.ns5"), nsx_to_load=5),
                 ),
             ]
         )

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -150,7 +150,7 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                 (
                     BlackrockRecordingExtractorInterface,
                     "blackrock/blackrock_2_1",
-                    dict(file_path=str(data_path / "blackrock" / "blackrock_2_1"), nsx_to_load=5),
+                    dict(filename=str(data_path / "blackrock" / "blackrock_2_1"), nsx_to_load=5),
                 ),
             ]
         )

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -14,7 +14,7 @@ from nwb_conversion_tools import (
     PhySortingInterface,
     SpikeGLXRecordingInterface,
     BlackrockRecordingExtractorInterface,
-    BlackrockSortingExtractorInterface
+    BlackrockSortingExtractorInterface,
 )
 
 try:
@@ -187,8 +187,8 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                 (
                     BlackrockSortingExtractorInterface,
                     "blackrock",
-                    dict(filename=str(data_path/"blackrock"/"FileSpec2.3001.nev")),
-                )
+                    dict(filename=str(data_path / "blackrock" / "FileSpec2.3001.nev")),
+                ),
             ]
         )
         def test_convert_sorting_extractor_to_nwb(self, sorting_interface, dataset_path, interface_kwargs):

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -150,7 +150,10 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                 (
                     BlackrockRecordingExtractorInterface,
                     "blackrock/blackrock_2_1",
-                    dict(filename=str(data_path / "blackrock" / "blackrock_2_1"), nsx_to_load=5),
+                    dict(filename=str(data_path
+                                      / "blackrock"
+                                      / "blackrock_2_1"
+                                      / "l101210-001.ns5"), nsx_to_load=5),
                 ),
             ]
         )


### PR DESCRIPTION
## Motivation

Latest changes broke BlackrockRecordingExtractorInterface.
@Saksham20 I reverted back your changes, because locally for me they broke the conversion, due to older spikeextractor not being able to deal with multiple streams. I believe your changes had the newer SI/NEO in mind?
I left them commented out for easy reference, cloud you please check them out?

## How to test the behavior?
```
from movshon_lab_to_nwb import MovshonBlackrockNWBConverter
from pathlib import Path

# Source data
base_path = Path('/home/luiz/storage/taufferconsulting/client_ben/project_movshon/data_blackrock_0/')
file_recording_raw = str(base_path / 'XX_LE_textures_20191128_002.ns6')
file_recording_processed = str(base_path / 'XX_LE_textures_20191128_002.ns3')
file_sorting = str(base_path / 'XX_LE_textures_20191128_002.nev')

source_data = dict(
    BlackrockRaw=dict(filename=file_recording_raw),
    BlackrockProcessed=dict(filename=file_recording_processed),
    BlackrockSorting=dict(
        filename=file_sorting,
        nsx_to_load=6
    )
)

# Initialize converter
converter = MovshonBlackrockNWBConverter(source_data=source_data)

# Get metadata from source data and modify any values you want
metadata = converter.get_metadata()
metadata['NWBFile']['session_description'] = 'my example conversion'

# Get conversion options and modify any values you want
conversion_options = converter.get_conversion_options()
conversion_options['BlackrockRaw'] = dict(stub_test=True)
conversion_options['BlackrockProcessed'] = dict(stub_test=True)

# Run conversion
output_file = 'out_example_blackrock.nwb'

converter.run_conversion(
    metadata=metadata, 
    nwbfile_path=output_file, 
    save_to_file=True,
    overwrite=True,
    conversion_options=conversion_options
)
```
