### PR TITLE
Adding OpenEphys tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,3 +18,4 @@ roiextractors==0.3.1
 ndx-events==0.2.0
 parameterized==0.8.1
 pyintan==0.3.0
+pyopenephys==1.1.2

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -54,6 +54,11 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                 "neuroscope/test1",
                 dict(file_path=str(data_path / "neuroscope" / "test1" / "test1.dat")),
             ),
+            (
+                OpenEphysRecordingExtractorInterface,
+                "openephys/OpenEphys_SampleData_1",
+                dict(folder_path=str(data_path / "openephys" / "OpenEphys_SampleData_1"))
+            ),
         ]
         for suffix in ["rhd", "rhs"]:
             parameterized_expand_list.append(
@@ -62,13 +67,6 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                     "intan",
                     dict(file_path=str(data_path / "intan" / f"intan_{suffix}_test_1.{suffix}")),
                 )
-            )
-        for outer_folder, inner_folder in zip(
-            ["openephys", "openephysbinary"], ["OpenEphys_SampleData_1", "v0.4.4.1_with_video_tracking"]
-        ):
-            sub_path = Path(outer_folder) / inner_folder
-            parameterized_expand_list.append(
-                (OpenEphysRecordingExtractorInterface, sub_path, dict(folder_path=str(data_path / sub_path)))
             )
         for suffix in ["ap", "lf"]:
             sub_path = Path("spikeglx") / "Noise4Sam_g0" / "Noise4Sam_g0_imec0"

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -80,9 +80,7 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                 param(
                     recording_interface=SpikeGLXRecordingInterface,
                     dataset_path=sub_path,
-                    interface_kwargs=dict(
-                        file_path=str(data_path / sub_path / f"Noise4Sam_g0_t0.imec0.{suffix}.bin")
-                    ),
+                    interface_kwargs=dict(file_path=str(data_path / sub_path / f"Noise4Sam_g0_t0.imec0.{suffix}.bin")),
                 )
             )
 

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -57,7 +57,7 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
             (
                 OpenEphysRecordingExtractorInterface,
                 "openephysbinary/v0.4.4.1_with_video_tracking",
-                dict(folder_path=str(data_path / "openephysbinary" / "v0.4.4.1_with_video_tracking"))
+                dict(folder_path=str(data_path / "openephysbinary" / "v0.4.4.1_with_video_tracking")),
             ),
         ]
         for suffix in ["rhd", "rhs"]:

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -56,8 +56,8 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
             ),
             (
                 OpenEphysRecordingExtractorInterface,
-                "openephys/OpenEphys_SampleData_1",
-                dict(folder_path=str(data_path / "openephys" / "OpenEphys_SampleData_1"))
+                "openephysbinary/v0.4.4.1_with_video_tracking",
+                dict(folder_path=str(data_path / "openephysbinary" / "v0.4.4.1_with_video_tracking"))
             ),
         ]
         for suffix in ["rhd", "rhs"]:


### PR DESCRIPTION
## Motivation

Adding OpenEphysRecording tests. Having trouble getting second ('binary') tests to pass on local versions of the GIN files (unbound file error somewhere in the messages of pyopenephys). Seeing if this occurs with datalad.

## How to test the behavior?
```
pytest
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
