### PR TITLE
Add phy gin

### DIFF
--- a/nwb_conversion_tools/datainterfaces/__init__.py
+++ b/nwb_conversion_tools/datainterfaces/__init__.py
@@ -30,6 +30,7 @@ from .ecephys.axona.axonadatainterface import (
     AxonaUnitRecordingExtractorInterface,
 )
 from .ecephys.neuralynx.neuralynxdatainterface import NeuralynxRecordingInterface
+from .ecephys.phy.phydatainterface import PhySortingInterface
 
 from .ophys.caiman.caimandatainterface import CaimanSegmentationInterface
 from .ophys.cnmfe.cnmfedatainterface import CnmfeSegmentationInterface
@@ -47,6 +48,7 @@ from .behavior.movie.moviedatainterface import MovieInterface
 interface_list = [
     RecordingTutorialInterface,
     SortingTutorialInterface,
+    NeuralynxRecordingInterface,
     NeuroscopeRecordingInterface,
     NeuroscopeMultiRecordingTimeInterface,
     NeuroscopeSortingInterface,
@@ -63,6 +65,7 @@ interface_list = [
     BlackrockSortingExtractorInterface,
     OpenEphysRecordingExtractorInterface,
     OpenEphysSortingExtractorInterface,
+    PhySortingInterface,
     AxonaRecordingExtractorInterface,
     AxonaPositionDataInterface,
     AxonaLFPDataInterface,

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -34,4 +34,4 @@ class NeuralynxRecordingInterface(BaseRecordingExtractorInterface):
         for extractor in extractors:
             extractor.clear_channel_gains()
         self.recording_extractor = self.RX(extractors)
-        self.recording_extractor.set_channel_gains(gains=[extractor.get_channel_gains()[0] for extractor in extractors])
+        self.recording_extractor.set_channel_gains(gains=gains)

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -154,10 +154,13 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
 
             converter = TestConverter(source_data=dict(TestSorting=dict(interface_kwargs)))
             converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True)
-            recording = converter.data_interface_objects["TestSorting"].sortinging_extractor
-            nwb_recording = NwbSortingExtractor(file_path=nwbfile_path)
-            check_sortings_equal(RX1=recording, RX2=nwb_recording, check_times=False, return_scaled=False)
-            check_sortings_equal(RX1=recording, RX2=nwb_recording, check_times=False, return_scaled=True)
+            sorting = converter.data_interface_objects["TestSorting"].sortinging_extractor
+            sf = sorting.get_sampling_frequency()
+            if sf is None:  # need to set dummy sampling frequency since no associated acquisition in file
+                sf = 30000
+                sorting.set_sampling_frequency(sf)
+            nwb_sorting = NwbSortingExtractor(file_path=nwbfile_path, sampling_frequency=sf)
+            check_sortings_equal(SX1=sorting, SX2=nwb_sorting)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -22,7 +22,7 @@ except ImportError:
     HAVE_DATALAD = False
 
 try:
-    from parameterized import parameterized
+    from parameterized import parameterized, param
 
     HAVE_PARAMETERIZED = True
 except ImportError:
@@ -58,30 +58,30 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
 
         @parameterized.expand(
             [
-                (
-                    IntanRecordingInterface,
-                    "intan",
-                    dict(file_path=str(data_path / "intan" / "intan_rhd_test_1.rhd")),
+                param(
+                    recording_interface=IntanRecordingInterface,
+                    dataset_path="intan",
+                    interface_kwargs=dict(file_path=str(data_path / "intan" / "intan_rhd_test_1.rhd")),
                 ),
-                (
-                    IntanRecordingInterface,
-                    "intan",
-                    dict(file_path=str(data_path / "intan" / "intan_rhs_test_1.rhs")),
+                param(
+                    recording_interface=IntanRecordingInterface,
+                    dataset_path="intan",
+                    interface_kwargs=dict(file_path=str(data_path / "intan" / "intan_rhs_test_1.rhs"))
                 ),
-                (
-                    NeuralynxRecordingInterface,
-                    "neuralynx/Cheetah_v5.7.4/original_data",
-                    dict(folder_path=str(data_path / "neuralynx" / "Cheetah_v5.7.4" / "original_data")),
+                param(
+                    recording_interface=NeuralynxRecordingInterface,
+                    dataset_path="neuralynx/Cheetah_v5.7.4/original_data",
+                    interface_kwargs=dict(folder_path=str(data_path / "neuralynx" / "Cheetah_v5.7.4" / "original_data")),
                 ),
-                (
-                    NeuroscopeRecordingInterface,
-                    "neuroscope/test1",
-                    dict(file_path=str(data_path / "neuroscope" / "test1" / "test1.dat")),
+                param(
+                    recording_interface=NeuroscopeRecordingInterface,
+                    dataset_path="neuroscope/test1",
+                    interface_kwargs=dict(file_path=str(data_path / "neuroscope" / "test1" / "test1.dat")),
                 ),
-                (
-                    SpikeGLXRecordingInterface,
-                    "spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0",
-                    dict(
+                param(
+                    recording_interface=SpikeGLXRecordingInterface,
+                    dataset_path="spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0",
+                    interface_kwargs=dict(
                         file_path=str(
                             data_path
                             / "spikeglx"
@@ -91,10 +91,10 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                         )
                     ),
                 ),
-                (
-                    SpikeGLXRecordingInterface,
-                    "spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0",
-                    dict(
+                param(
+                    recording_interface=SpikeGLXRecordingInterface,
+                    dataset_path="spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0",
+                    interface_kwargs=dict(
                         file_path=str(
                             data_path
                             / "spikeglx"
@@ -104,7 +104,8 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                         )
                     ),
                 ),
-            ]
+            ],
+            name_func=custom_name_func
         )
         def test_convert_recording_extractor_to_nwb(self, recording_interface, dataset_path, interface_kwargs):
             print(f"\n\n\n TESTING {recording_interface.__name__}...")
@@ -129,7 +130,13 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
             check_recordings_equal(RX1=recording, RX2=nwb_recording, check_times=False, return_scaled=True)
 
         @parameterized.expand(
-            [(PhySortingInterface, "phy/phy_example_0", dict(folder_path=str(data_path / "phy" / "phy_example_0")))]
+            [
+                param(
+                    sorting_interface=PhySortingInterface,
+                    dataset_path="phy/phy_example_0",
+                    interface_kwargs=dict(folder_path=str(data_path / "phy" / "phy_example_0")),
+                )
+            ]
         )
         def test_convert_sorting_extractor_to_nwb(self, sorting_interface, dataset_path, interface_kwargs):
             print(f"\n\n\n TESTING {sorting_interface.__name__}...")

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -129,13 +129,7 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
             check_recordings_equal(RX1=recording, RX2=nwb_recording, check_times=False, return_scaled=True)
 
         @parameterized.expand(
-            [
-                (
-                    PhySortingInterface,
-                    "phy/phy_example_0",
-                    dict(folder_path=str(data_path / "phy" / "phy_example_0"))
-                )
-            ]
+            [(PhySortingInterface, "phy/phy_example_0", dict(folder_path=str(data_path / "phy" / "phy_example_0")))]
         )
         def test_convert_sorting_extractor_to_nwb(self, sorting_interface, dataset_path, interface_kwargs):
             print(f"\n\n\n TESTING {sorting_interface.__name__}...")
@@ -161,6 +155,7 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                 sorting.set_sampling_frequency(sf)
             nwb_sorting = NwbSortingExtractor(file_path=nwbfile_path, sampling_frequency=sf)
             check_sortings_equal(SX1=sorting, SX2=nwb_sorting)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -10,11 +10,8 @@ from nwb_conversion_tools import (
     IntanRecordingInterface,
     NeuralynxRecordingInterface,
     NeuroscopeRecordingInterface,
-<<<<<<< HEAD
-    PhySortingInterface,
-=======
     OpenEphysRecordingExtractorInterface,
->>>>>>> master
+    PhySortingInterface,
     SpikeGLXRecordingInterface,
 )
 
@@ -101,63 +98,7 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
             elif not data_exists:
                 self.dataset = install("https://gin.g-node.org/NeuralEnsemble/ephy_testing_data")
 
-<<<<<<< HEAD
-        @parameterized.expand(
-            [
-                param(
-                    recording_interface=IntanRecordingInterface,
-                    dataset_path="intan",
-                    interface_kwargs=dict(file_path=str(data_path / "intan" / "intan_rhd_test_1.rhd")),
-                ),
-                param(
-                    recording_interface=IntanRecordingInterface,
-                    dataset_path="intan",
-                    interface_kwargs=dict(file_path=str(data_path / "intan" / "intan_rhs_test_1.rhs")),
-                ),
-                param(
-                    recording_interface=NeuralynxRecordingInterface,
-                    dataset_path="neuralynx/Cheetah_v5.7.4/original_data",
-                    interface_kwargs=dict(
-                        folder_path=str(data_path / "neuralynx" / "Cheetah_v5.7.4" / "original_data")
-                    ),
-                ),
-                param(
-                    recording_interface=NeuroscopeRecordingInterface,
-                    dataset_path="neuroscope/test1",
-                    interface_kwargs=dict(file_path=str(data_path / "neuroscope" / "test1" / "test1.dat")),
-                ),
-                param(
-                    recording_interface=SpikeGLXRecordingInterface,
-                    dataset_path="spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0",
-                    interface_kwargs=dict(
-                        file_path=str(
-                            data_path
-                            / "spikeglx"
-                            / "Noise4Sam_g0"
-                            / "Noise4Sam_g0_imec0"
-                            / "Noise4Sam_g0_t0.imec0.ap.bin"
-                        )
-                    ),
-                ),
-                param(
-                    recording_interface=SpikeGLXRecordingInterface,
-                    dataset_path="spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0",
-                    interface_kwargs=dict(
-                        file_path=str(
-                            data_path
-                            / "spikeglx"
-                            / "Noise4Sam_g0"
-                            / "Noise4Sam_g0_imec0"
-                            / "Noise4Sam_g0_t0.imec0.lf.bin"
-                        )
-                    ),
-                ),
-            ],
-            name_func=custom_name_func,
-        )
-=======
         @parameterized.expand(input=parameterized_expand_list, name_func=custom_name_func)
->>>>>>> master
         def test_convert_recording_extractor_to_nwb(self, recording_interface, dataset_path, interface_kwargs):
             print(f"\n\n\n TESTING {recording_interface.__name__}...")
             if HAVE_DATALAD:

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -34,6 +34,9 @@ LOCAL_PATH = Path("E:/GIN")  # Path to dataset downloaded from https://gin.g-nod
 
 if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL):
 
+    def custom_name_func(testcase_func, param_num, param):
+        return f"{testcase_func.__name__}_{param_num}_{parameterized.to_safe_name(str(param.args[0]))}"
+
     class TestNwbConversions(unittest.TestCase):
         dataset = None
         savedir = Path(tempfile.mkdtemp())

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -148,7 +148,7 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
 
             converter = TestConverter(source_data=dict(TestSorting=dict(interface_kwargs)))
             converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True)
-            sorting = converter.data_interface_objects["TestSorting"].sortinging_extractor
+            sorting = converter.data_interface_objects["TestSorting"].sorting_extractor
             sf = sorting.get_sampling_frequency()
             if sf is None:  # need to set dummy sampling frequency since no associated acquisition in file
                 sf = 30000

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -35,7 +35,8 @@ LOCAL_PATH = Path("E:/GIN")  # Path to dataset downloaded from https://gin.g-nod
 if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL):
 
     def custom_name_func(testcase_func, param_num, param):
-        return f"{testcase_func.__name__}_{param_num}_{parameterized.to_safe_name(str(param.args[0]))}"
+        return f"{testcase_func.__name__}_{param_num}_" \
+               f"{parameterized.to_safe_name(param.kwargs['recording_interface'].__name__)}"
 
     class TestNwbConversions(unittest.TestCase):
         dataset = None

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -35,8 +35,10 @@ LOCAL_PATH = Path("E:/GIN")  # Path to dataset downloaded from https://gin.g-nod
 if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL):
 
     def custom_name_func(testcase_func, param_num, param):
-        return f"{testcase_func.__name__}_{param_num}_" \
-               f"{parameterized.to_safe_name(param.kwargs['recording_interface'].__name__)}"
+        return (
+            f"{testcase_func.__name__}_{param_num}_"
+            f"{parameterized.to_safe_name(param.kwargs['recording_interface'].__name__)}"
+        )
 
     class TestNwbConversions(unittest.TestCase):
         dataset = None


### PR DESCRIPTION
## Motivation

Adding SortingInterface GIN test framework, starting with the PhySortingInterface tests. There is some pickling error occurring from spikeextractors occurring during the equality check when I run locally, seeing if it occurs on Linux as well.

## How to test the behavior?
```
pytest
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
