### PR TITLE
Update baselfpextractorinterface

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -37,7 +37,10 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
         use_times: bool = False,
         save_path: OptionalPathType = None,
         overwrite: bool = False,
-        buffer_mb: int = 500,
+        compression: Optional[str] = "gzip",
+        compression_opts: Optional[int] = None,
+        iterator_type: Optional[str] = None,
+        iterator_opts: Optional[dict] = None,
     ):
         """
         Primary function for converting low-pass recording extractor data to nwb.
@@ -60,14 +63,29 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
             If using save_path, whether or not to overwrite the NWBFile if it already exists.
         stub_test: bool, optional (default False)
             If True, will truncate the data to run the conversion faster and take up less memory.
-        buffer_mb: int (optional, defaults to 500MB)
-            Maximum amount of memory (in MB) to use per iteration of the internal DataChunkIterator.
-            Requires trace data in the RecordingExtractor to be a memmap object.
+        compression: str (optional, defaults to "gzip")
+            Type of compression to use. Valid types are "gzip" and "lzf".
+            Set to None to disable all compression.
+        compression_opts: int (optional, defaults to 4)
+            Only applies to compression="gzip". Controls the level of the GZIP.
+        iterator_type: str (optional, defaults to 'v2')
+            The type of DataChunkIterator to use.
+            'v1' is the original DataChunkIterator of the hdmf data_utils.
+            'v2' is the locally developed RecordingExtractorDataChunkIterator, which offers full control over chunking.
+        iterator_opts: dict (optional)
+            Dictionary of options for the RecordingExtractorDataChunkIterator (iterator_type='v2').
+            Valid options are
+                buffer_gb : float (optional, defaults to 1 GB)
+                    Recommended to be as much free RAM as available). Automatically calculates suitable buffer shape.
+                chunk_mb : float (optional, defaults to 1 MB)
+                    Should be below 1 MB. Automatically calculates suitable chunk shape.
+            If manual specification of buffer_shape and chunk_shape are desired, these may be specified as well.
         """
         if stub_test or self.subset_channels is not None:
             recording = self.subset_recording(stub_test=stub_test)
         else:
             recording = self.recording_extractor
+
         write_recording(
             recording=recording,
             nwbfile=nwbfile,
@@ -77,5 +95,8 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
             es_key="ElectricalSeries_lfp",
             save_path=save_path,
             overwrite=overwrite,
-            buffer_mb=buffer_mb,
+            compression=compression,
+            compression_opts=compression_opts,
+            iterator_type=iterator_type,
+            iterator_opts=iterator_opts,
         )

--- a/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from pynwb import NWBFile
 from pynwb.device import Device
-from pynwb.ecephys import ElectrodeGroup
+from pynwb.ecephys import ElectrodeGroup, ElectricalSeries
 
 from .baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ...utils.spike_interface import write_recording
@@ -16,6 +16,13 @@ OptionalPathType = Optional[Union[str, Path]]
 
 class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
     """Primary class for all LFP data interfaces."""
+
+    def get_metadata_schema(self):
+        metadata_schema = super().get_metadata_schema()
+        metadata_schema["properties"]["Ecephys"]["properties"].update(
+            ElectricalSeries_lfp=get_schema_from_hdmf_class(ElectricalSeries)
+        )
+        return metadata_schema
 
     def get_metadata(self):
         metadata = super().get_metadata()


### PR DESCRIPTION
## Motivation

`write_recording` has been updated with new parameters:

https://github.com/catalystneuro/nwb-conversion-tools/blob/58840f31f2cb86afd65663f8609e66df329b18c2/nwb_conversion_tools/utils/spike_interface.py#L829)

the current version of [`baselfpextractorinterface`](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py) still follows the old API.

This is relevant for all children of `baselfpextractorinterface`, including [`AxonaLFPDataInterface`](https://github.com/catalystneuro/nwb-conversion-tools/blob/58840f31f2cb86afd65663f8609e66df329b18c2/nwb_conversion_tools/datainterfaces/ecephys/axona/axonadatainterface.py#L519)

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
