### PR TITLE
Fix remaining annotations

### DIFF
--- a/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
@@ -12,8 +12,9 @@ from hdmf.backends.hdf5.h5_utils import H5DataIO
 from hdmf.data_utils import DataChunkIterator
 
 from ....basedatainterface import BaseDataInterface
-from .movie_utils import get_movie_timestamps, get_movie_fps, get_frame_shape
 from ....utils.conversion_tools import check_regular_timestamps, get_module
+from ....utils.json_schema import get_schema_from_method_signature
+from .movie_utils import get_movie_timestamps, get_movie_fps, get_frame_shape
 
 
 try:
@@ -26,20 +27,24 @@ INSTALL_MESSAGE = "Please install opencv to use this extractor (pip install open
 
 
 class MovieInterface(BaseDataInterface):
-    """
-    Data interface for writing movies as ImageSeries.
+    """Data interface for writing movies as ImageSeries."""
 
-    Source data input argument should be a dictionary with key 'file_paths' and value as an array of PathTypes
-    pointing to the video files.
-    """
+    def __init__(self, file_paths: list):
+        """
+        Create the interface for writing movies as ImageSeries.
 
-    def __init__(self, *args, **kwargs):
+        Parameters
+        ----------
+        file_paths : list of FilePathTypes
+            Many movie storage formats segment a sequence of movies over the course of the experiment.
+            Pass the file paths for this movies as a list in sorted, consecutive order.
+        """
         assert HAVE_OPENCV, INSTALL_MESSAGE
-        super().__init__(*args, **kwargs)
+        super().__init__(file_paths=file_paths)
 
     @classmethod
     def get_source_schema(cls):
-        return dict(properties=dict(file_paths=dict(type="array")))
+        return get_schema_from_method_signature(cls.__init__)
 
     def run_conversion(
         self,

--- a/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -9,7 +9,7 @@ from pynwb.ecephys import ElectrodeGroup, ElectricalSeries
 
 from .baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ...utils.spike_interface import write_recording
-from ...utils.json_schema import get_schema_from_hdmf_class, get_base_schema
+from ...utils.json_schema import get_schema_from_hdmf_class, get_base_schema, OptionalFilePathType
 
 OptionalPathType = Optional[Union[str, Path]]
 
@@ -35,7 +35,7 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
         metadata: dict = None,
         stub_test: bool = False,
         use_times: bool = False,
-        save_path: OptionalPathType = None,
+        save_path: OptionalFilePathType = None,
         overwrite: bool = False,
         compression: Optional[str] = "gzip",
         compression_opts: Optional[int] = None,
@@ -56,7 +56,7 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
         use_times: bool
             If True, the times are saved to the nwb file using recording.frame_to_time(). If False (default),
             the sampling rate is used.
-        save_path: PathType
+        save_path: OptionalFilePathType
             Required if an nwbfile is not passed. Must be the path to the nwbfile
             being appended, otherwise one is created and written.
         overwrite: bool

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -10,7 +10,10 @@ from pynwb.ecephys import ElectrodeGroup
 
 from ...basedatainterface import BaseDataInterface
 from ...utils.json_schema import (
-    get_schema_from_hdmf_class, get_schema_from_method_signature, get_base_schema, OptionalFilePathType
+    get_schema_from_hdmf_class,
+    get_schema_from_method_signature,
+    get_base_schema,
+    OptionalFilePathType,
 )
 from ...utils.spike_interface import write_recording
 

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -1,7 +1,6 @@
 """Authors: Cody Baker and Ben Dichter."""
 from abc import ABC
-from typing import Union, Optional
-from pathlib import Path
+from typing import Optional
 import numpy as np
 
 import spikeextractors as se
@@ -10,10 +9,10 @@ from pynwb.device import Device
 from pynwb.ecephys import ElectrodeGroup
 
 from ...basedatainterface import BaseDataInterface
-from ...utils.json_schema import get_schema_from_hdmf_class, get_schema_from_method_signature, get_base_schema
+from ...utils.json_schema import (
+    get_schema_from_hdmf_class, get_schema_from_method_signature, get_base_schema, OptionalFilePathType
+)
 from ...utils.spike_interface import write_recording
-
-OptionalPathType = Optional[Union[str, Path]]
 
 
 class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
@@ -104,7 +103,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         metadata: dict = None,
         stub_test: bool = False,
         use_times: bool = False,
-        save_path: OptionalPathType = None,
+        save_path: OptionalFilePathType = None,
         overwrite: bool = False,
         write_as: str = "raw",
         es_key: str = None,
@@ -127,7 +126,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         use_times: bool
             If True, the times are saved to the nwb file using recording.frame_to_time(). If False (default),
             the sampling rate is used.
-        save_path: PathType
+        save_path: OptionalFilePathType
             Required if an nwbfile is not passed. Must be the path to the nwbfile
             being appended, otherwise one is created and written.
         overwrite: bool

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -10,7 +10,10 @@ from .brpylib import NsxFile
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
 from ....utils.json_schema import (
-    get_schema_from_hdmf_class, get_schema_from_method_signature, FilePathType, OptionalFilePathType
+    get_schema_from_hdmf_class,
+    get_schema_from_method_signature,
+    FilePathType,
+    OptionalFilePathType,
 )
 
 

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -10,10 +10,7 @@ from .brpylib import NsxFile
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
 from ....utils.json_schema import (
-    get_schema_from_hdmf_class,
-    get_schema_from_method_signature,
-    FilePathType,
-    OptionalFilePathType,
+    get_schema_from_hdmf_class, get_schema_from_method_signature, FilePathType, OptionalFilePathType
 )
 
 
@@ -32,10 +29,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         return source_schema
 
     def __init__(
-        self,
-        filename: FilePathType,
-        nsx_override: OptionalFilePathType = None,
-        nsx_to_load: Optional[int] = None,
+        self, filename: FilePathType, nsx_override: OptionalFilePathType = None, nsx_to_load: Optional[int] = None
     ):
         super().__init__(filename=filename, nsx_override=nsx_override, nsx_to_load=nsx_to_load)
 
@@ -85,6 +79,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
     ):
         """
         Primary function for converting recording extractor data to nwb.
+
         Parameters
         ----------
         nwbfile: NWBFile
@@ -99,7 +94,7 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
             the sampling rate is used.
         write_as_lfp: bool (optional, defaults to False)
             If True, writes the traces under a processing LFP module in the NWBFile instead of acquisition.
-        save_path: PathType
+        save_path: OptionalFilePathType
             Required if an nwbfile is not passed. Must be the path to the nwbfile
             being appended, otherwise one is created and written.
         overwrite: bool

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -1,16 +1,11 @@
 """Authors: Cody Baker."""
-import numpy as np
 from pathlib import Path
 from natsort import natsorted
-from typing import Union
 
 from spikeextractors import MultiRecordingChannelExtractor, NeuralynxRecordingExtractor
 
-
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
-from ....utils.json_schema import get_schema_from_method_signature
-
-PathType = Union[str, Path]
+from ....utils.json_schema import FolderPathType
 
 
 class NeuralynxRecordingInterface(BaseRecordingExtractorInterface):
@@ -18,14 +13,7 @@ class NeuralynxRecordingInterface(BaseRecordingExtractorInterface):
 
     RX = MultiRecordingChannelExtractor
 
-    @classmethod
-    def get_source_schema(cls):
-        """Compile input schema for the RecordingExtractor."""
-        source_schema = get_schema_from_method_signature(cls.__init__)
-        source_schema["properties"]["folder_path"]["format"] = "directory"
-        return source_schema
-
-    def __init__(self, folder_path: PathType):
+    def __init__(self, folder_path: FolderPathType):
         self.subset_channels = None
         self.source_data = dict(folder_path=folder_path)
         neuralynx_files = natsorted([str(x) for x in Path(folder_path).iterdir() if ".ncs" in x.suffixes])

--- a/nwb_conversion_tools/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -1,7 +1,7 @@
 """Authors: Cody Baker and Ben Dichter."""
 from datetime import datetime
 from pathlib import Path
-from typing import Union, Optional
+from typing import Optional
 
 from spikeextractors import SpikeGLXRecordingExtractor, SubRecordingExtractor, RecordingExtractor
 from pynwb.ecephys import ElectricalSeries
@@ -9,8 +9,6 @@ from pynwb.ecephys import ElectricalSeries
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..baselfpextractorinterface import BaseLFPExtractorInterface
 from ....utils.json_schema import get_schema_from_method_signature, get_schema_from_hdmf_class, FilePathType
-
-PathType = Union[str, Path, None]
 
 
 def fetch_spikeglx_metadata(file_path: FilePathType, recording: RecordingExtractor, metadata: dict):

--- a/nwb_conversion_tools/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -18,11 +18,11 @@ class BaseImagingExtractorInterface(BaseDataInterface):
 
     @classmethod
     def get_source_schema(cls):
-        return get_schema_from_method_signature(cls.IX.__init__)
+        return get_schema_from_method_signature(cls.__init__)
 
-    def __init__(self, **input_args):
-        super().__init__(**input_args)
-        self.imaging_extractor = self.IX(**input_args)
+    def __init__(self, **source_data):
+        super().__init__(**source_data)
+        self.imaging_extractor = self.IX(**source_data)
 
     def get_metadata_schema(self):
         """Compile metadata schema for the ImageExtractor."""
@@ -53,8 +53,7 @@ class BaseImagingExtractorInterface(BaseDataInterface):
         return metadata_schema
 
     def get_metadata(self):
-        """Auto-fill metadata with values found from the corresponding imageextractor.
-        Must comply with metadata schema."""
+        """Auto-fill metadata with values found from the corresponding imageextractor."""
         metadata = super().get_metadata()
         metadata.update(re.NwbImagingExtractor.get_nwb_metadata(self.imaging_extractor))
         _ = metadata.pop("NWBFile")

--- a/nwb_conversion_tools/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -20,7 +20,7 @@ class BaseSegmentationExtractorInterface(BaseDataInterface, ABC):
 
     @classmethod
     def get_source_schema(cls):
-        return get_schema_from_method_signature(cls.SegX.__init__)
+        return get_schema_from_method_signature(cls.__init__)
 
     def __init__(self, **source_data):
         super().__init__(**source_data)

--- a/nwb_conversion_tools/datainterfaces/ophys/caiman/caimandatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/caiman/caimandatainterface.py
@@ -1,9 +1,13 @@
 from roiextractors import CaimanSegmentationExtractor
 
 from ..basesegmentationextractorinterface import BaseSegmentationExtractorInterface
+from ....utils.json_schema import FilePathType
 
 
 class CaimanSegmentationInterface(BaseSegmentationExtractorInterface):
-    """Data interface for CaimanSegmentationExtractor"""
+    """Data interface for CaimanSegmentationExtractor."""
 
     SegX = CaimanSegmentationExtractor
+
+    def __init__(self, file_path: FilePathType):
+        super().__init__(file_path=file_path)

--- a/nwb_conversion_tools/datainterfaces/ophys/cnmfe/cnmfedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/cnmfe/cnmfedatainterface.py
@@ -1,9 +1,13 @@
 from roiextractors import CnmfeSegmentationExtractor
 
 from ..basesegmentationextractorinterface import BaseSegmentationExtractorInterface
+from ....utils.json_schema import FilePathType
 
 
 class CnmfeSegmentationInterface(BaseSegmentationExtractorInterface):
-    """Data interface for CnmfeRecordingInterface"""
+    """Data interface for CnmfeRecordingInterface."""
 
     SegX = CnmfeSegmentationExtractor
+
+    def __init__(self, file_path: FilePathType):
+        super().__init__(file_path=file_path)

--- a/nwb_conversion_tools/datainterfaces/ophys/extract/extractdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/extract/extractdatainterface.py
@@ -1,9 +1,13 @@
 from roiextractors import ExtractSegmentationExtractor
 
 from ..basesegmentationextractorinterface import BaseSegmentationExtractorInterface
+from ....utils.json_schema import FilePathType
 
 
 class ExtractSegmentationInterface(BaseSegmentationExtractorInterface):
-    """Data interface for ExtractSegmentationExtractor"""
+    """Data interface for ExtractSegmentationExtractor."""
 
     SegX = ExtractSegmentationExtractor
+
+    def __init__(self, file_path: FilePathType):
+        super().__init__(file_path=file_path)

--- a/nwb_conversion_tools/datainterfaces/ophys/hdf5/hdf5datainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/hdf5/hdf5datainterface.py
@@ -1,9 +1,28 @@
 from roiextractors import Hdf5ImagingExtractor
 
 from ..baseimagingextractorinterface import BaseImagingExtractorInterface
+from ....utils.json_schema import FilePathType, FloatType, ArrayType
 
 
 class Hdf5ImagingInterface(BaseImagingExtractorInterface):
-    """Data Interface for Hdf5ImagingExtractor"""
+    """Data Interface for Hdf5ImagingExtractor."""
 
     IX = Hdf5ImagingExtractor
+
+    def __init__(
+        self,
+        file_path: FilePathType,
+        mov_field: str = "mov",
+        sampling_frequency: FloatType = None,
+        start_time: FloatType = None,
+        metadata: dict = None,
+        channel_names: ArrayType = None,
+    ):
+        super().__init__(
+            file_path=file_path,
+            mov_field=mov_field,
+            sampling_frequency=sampling_frequency,
+            start_time=start_time,
+            metadata=metadata,
+            channel_names=channel_names,
+        )

--- a/nwb_conversion_tools/datainterfaces/ophys/sbx/sbxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/sbx/sbxdatainterface.py
@@ -1,9 +1,13 @@
 from roiextractors import SbxImagingExtractor
 
 from ..baseimagingextractorinterface import BaseImagingExtractorInterface
+from ....utils.json_schema import FilePathType, FloatType
 
 
 class SbxImagingInterface(BaseImagingExtractorInterface):
-    """Data Interface for SbxImagingExtractor"""
+    """Data Interface for SbxImagingExtractor."""
 
     IX = SbxImagingExtractor
+
+    def __init__(self, file_path: FilePathType, sampling_frequency: FloatType = None):
+        super().__init__(file_path=file_path, sampling_frequency=sampling_frequency)

--- a/nwb_conversion_tools/datainterfaces/ophys/sima/simadatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/sima/simadatainterface.py
@@ -1,9 +1,13 @@
 from roiextractors import SimaSegmentationExtractor
 
 from ..basesegmentationextractorinterface import BaseSegmentationExtractorInterface
+from ....utils.json_schema import FilePathType
 
 
 class SimaSegmentationInterface(BaseSegmentationExtractorInterface):
-    """Data interface for SimaSegmentationExtractor"""
+    """Data interface for SimaSegmentationExtractor."""
 
     SegX = SimaSegmentationExtractor
+
+    def __init__(self, file_path: FilePathType, sima_segmentation_label: str = "auto_ROIs"):
+        super().__init__(file_path=file_path, sima_segmentation_label=sima_segmentation_label)

--- a/nwb_conversion_tools/datainterfaces/ophys/suite2p/suite2pdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/suite2p/suite2pdatainterface.py
@@ -2,9 +2,13 @@ from roiextractors import Suite2pSegmentationExtractor
 
 
 from ..basesegmentationextractorinterface import BaseSegmentationExtractorInterface
+from ....utils.json_schema import FilePathType, IntType
 
 
 class Suite2pSegmentationInterface(BaseSegmentationExtractorInterface):
-    """Data interface for Suite2pSegmentationExtractor"""
+    """Data interface for Suite2pSegmentationExtractor."""
 
     SegX = Suite2pSegmentationExtractor
+
+    def __init__(self, file_path: FilePathType, combined: bool = False, plane_no: IntType = 0):
+        super().__init__(file_path=file_path, combined=combined, plane_no=plane_no)

--- a/nwb_conversion_tools/datainterfaces/ophys/tiff/tiffdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/tiff/tiffdatainterface.py
@@ -1,16 +1,19 @@
 from roiextractors import TiffImagingExtractor
 
 from ..baseimagingextractorinterface import BaseImagingExtractorInterface
+from ....utils.json_schema import FilePathType, FloatType, ArrayType
 
 
 class TiffImagingInterface(BaseImagingExtractorInterface):
-    """Data Interface for TIffImagingExtractor"""
+    """Data Interface for TIffImagingExtractor."""
 
     IX = TiffImagingExtractor
 
     @classmethod
     def get_source_schema(cls):
         source_schema = super().get_source_schema()
-        source_schema["properties"]["file_path"]["format"] = "file"
         source_schema["properties"]["file_path"]["description"] = "Path to Tiff file."
         return source_schema
+
+    def __init__(self, file_path: FilePathType, sampling_frequency: FloatType, channel_names: ArrayType = None):
+        super().__init__(file_path=file_path, sampling_frequency=sampling_frequency, channel_names=channel_names)

--- a/nwb_conversion_tools/utils/json_schema.py
+++ b/nwb_conversion_tools/utils/json_schema.py
@@ -26,9 +26,7 @@ def append_replace_dict_in_list(d, ls, k):
     """
     Append a dictionary to a list of dictionaries.
 
-    If some dictionary already contains the same value as d[k], it gets
-    replaced by the new dict.
-    Returns the updated list.
+    If some dictionary already contains the same value as d[k], it gets replaced by the new dict.
     """
     if k in d and len(ls) > 0:
         # Index where the value dictionary[k] exists in the list of dicts
@@ -80,6 +78,7 @@ def get_base_schema(tag=None, root=False, id_=None, **kwargs) -> dict:
 def get_schema_from_method_signature(class_method: classmethod, exclude: list = None) -> dict:
     """
     Take a class method and return a json-schema of the input args.
+
     Parameters
     ----------
     class_method: function
@@ -150,6 +149,7 @@ def get_schema_from_method_signature(class_method: classmethod, exclude: list = 
 def fill_defaults(schema: dict, defaults: dict, overwrite: bool = True):
     """
     Insert the values of the defaults dict as default values in the schema in place.
+
     Parameters
     ----------
     schema: dict
@@ -168,6 +168,7 @@ def fill_defaults(schema: dict, defaults: dict, overwrite: bool = True):
 def unroot_schema(schema: dict):
     """
     Modify a json-schema dictionary to make it not root.
+
     Parameters
     ----------
     schema: dict

--- a/nwb_conversion_tools/utils/json_schema.py
+++ b/nwb_conversion_tools/utils/json_schema.py
@@ -5,13 +5,16 @@ import numpy as np
 from datetime import datetime
 from typing import TypeVar
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import pynwb
 
 FilePathType = TypeVar("FilePathType", str, Path)
 FolderPathType = TypeVar("FolderPathType", str, Path)
 OptionalFilePathType = Optional[FilePathType]
+ArrayType = Union[list, np.array]
+FloatType = Union[float, np.float]
+IntType = Union[int, np.integer]
 
 
 def exist_dict_in_list(d, ls):

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -4,9 +4,8 @@ import warnings
 import numpy as np
 import distutils.version
 from pathlib import Path
-from typing import Union, Optional, List
+from typing import Optional, List
 from warnings import warn
-import psutil
 from collections import defaultdict
 
 import spikeextractors as se
@@ -14,12 +13,9 @@ import pynwb
 from numbers import Real
 from hdmf.data_utils import DataChunkIterator
 from hdmf.backends.hdf5.h5_utils import H5DataIO
-from .json_schema import dict_deep_update
+from .json_schema import dict_deep_update, OptionalFilePathType, ArrayType
 
 from .recordingextractordatachunkiterator import RecordingExtractorDataChunkIterator
-
-PathType = Union[str, Path, None]
-ArrayType = Union[list, np.ndarray]
 
 
 def list_get(li: list, idx: int, default):
@@ -818,7 +814,7 @@ def add_all_to_nwbfile(
 
 def write_recording(
     recording: se.RecordingExtractor,
-    save_path: PathType = None,
+    save_path: OptionalFilePathType = None,
     overwrite: bool = False,
     nwbfile=None,
     use_times: bool = False,
@@ -837,7 +833,7 @@ def write_recording(
     Parameters
     ----------
     recording: RecordingExtractor
-    save_path: PathType
+    save_path: OptionalFilePathType
         Required if an nwbfile is not passed. Must be the path to the nwbfile
         being appended, otherwise one is created and written.
     overwrite: bool
@@ -1229,7 +1225,7 @@ def write_units(
 
 def write_sorting(
     sorting: se.SortingExtractor,
-    save_path: PathType = None,
+    save_path: OptionalFilePathType = None,
     overwrite: bool = False,
     nwbfile=None,
     property_descriptions: Optional[dict] = None,
@@ -1247,7 +1243,7 @@ def write_sorting(
     Parameters
     ----------
     sorting: SortingExtractor
-    save_path: PathType
+    save_path: OptionalFilePathType
         Required if an nwbfile is not passed. The location where the NWBFile either exists, or will be written.
     overwrite: bool
         If using save_path, whether or not to overwrite the NWBFile if it already exists.

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -4,7 +4,6 @@ import unittest
 from pathlib import Path
 import numpy as np
 from datetime import datetime
-from typing import Union
 
 import spikeextractors as se
 from spikeextractors.testing import (
@@ -18,8 +17,7 @@ from pynwb import NWBHDF5IO, NWBFile
 
 from nwb_conversion_tools.utils.spike_interface import get_nwb_metadata, write_recording, write_sorting
 from nwb_conversion_tools.utils.recordingextractordatachunkiterator import RecordingExtractorDataChunkIterator
-
-PathType = Union[str, Path]
+from nwb_conversion_tools.utils.json_schema import FilePathType
 
 
 def _create_example(seed):
@@ -115,7 +113,7 @@ class TestExtractors(unittest.TestCase):
         del self.RX, self.RX2, self.RX3, self.SX, self.SX2, self.SX3
         shutil.rmtree(self.test_dir)
 
-    def check_si_roundtrip(self, path: PathType):
+    def check_si_roundtrip(self, path: FilePathType):
         RX_nwb = se.NwbRecordingExtractor(path)
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)


### PR DESCRIPTION
## Motivation

We have recently enforced local control of method signature for the automated setting of source schemas for `ecephys` interfaces - this primarily extends it to the `ophys` interfaces as well removes a few random references to unspecified PathTypes that were previously missed.

All references to PathType across the repo should now be properly specified as `FilePathType`, `OptionalFilePathType`, or `FolderPathType` and import these directly from the utils rather than redefining them every time.

## How to test the behavior?
No changes to actual tests, but they are quite useful in checking that nothing gets broken with the update.

```
pytest
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
