### PR TITLE
Add SpikeInterface .pkl tests

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/spikeinterface/sipickledatainterfaces.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/spikeinterface/sipickledatainterfaces.py
@@ -3,26 +3,25 @@ from spikeextractors import load_extractor_from_pickle
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
-from ....utils.json_schema import get_base_schema, FilePathType
+from ....utils.json_schema import FilePathType
 
 
 class SIPickleRecordingExtractorInterface(BaseRecordingExtractorInterface):
-    """Primary interface for reading and converting SpikeInterface objects through Pickle files."""
+    """Primary interface for reading and converting SpikeInterface Recording objects through .pkl files."""
 
-    RX = load_extractor_from_pickle
+    RX = None
 
     def __init__(self, pkl_file: FilePathType):
-        super().__init__(pkl_file=pkl_file)
+        self.recording_extractor = load_extractor_from_pickle(pkl_file=pkl_file)
+        self.subset_channels = None
+        self.source_data = dict(pkl_file=pkl_file)
 
 
 class SIPickleSortingExtractorInterface(BaseSortingExtractorInterface):
-    """Primary interface for reading and converting SpikeInterface objects through Pickle files."""
+    """Primary interface for reading and converting SpikeInterface Sorting objects through .pkl files."""
 
-    SX = load_extractor_from_pickle
-
-    @classmethod
-    def get_source_schema(cls):
-        return get_base_schema(required=["pkl_file"], properties=dict(pkl_file=dict(type="string")))
+    SX = None
 
     def __init__(self, pkl_file: FilePathType):
-        super().__init__(pkl_file=pkl_file)
+        self.sorting_extractor = load_extractor_from_pickle(pkl_file=pkl_file)
+        self.source_data = dict(pkl_file=pkl_file)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -17,7 +17,11 @@ except ImportError:
     HAVE_OPENCV = False
 
 from nwb_conversion_tools import (
-    NWBConverter, MovieInterface, SIPickleRecordingExtractorInterface, SIPickleSortingExtractorInterface, interface_list
+    NWBConverter,
+    MovieInterface,
+    SIPickleRecordingExtractorInterface,
+    SIPickleSortingExtractorInterface,
+    interface_list,
 )
 
 
@@ -46,9 +50,10 @@ def test_pkl_interface():
         data_interface_classes = dict(
             Recording=SIPickleRecordingExtractorInterface, Sorting=SIPickleSortingExtractorInterface
         )
+
     source_data = dict(
         Recording=dict(pkl_file=str(test_dir / "test_pkl" / "test_recording.pkl")),
-        Sorting=dict(pkl_file=str(test_dir / "test_pkl" / "test_sorting.pkl"))
+        Sorting=dict(pkl_file=str(test_dir / "test_pkl" / "test_sorting.pkl")),
     )
     converter = SpikeInterfaceTestNWBConverter(source_data=source_data)
     converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from itertools import product
 
 import pytest
+import spikeextractors as se
 
 try:
     import cv2
@@ -14,7 +15,9 @@ try:
 except ImportError:
     HAVE_OPENCV = False
 
-from nwb_conversion_tools import NWBConverter, MovieInterface, interface_list
+from nwb_conversion_tools import (
+    NWBConverter, MovieInterface, SIPickleRecordingExtractorInterface, SIPickleSortingExtractorInterface, interface_list
+)
 
 
 @pytest.mark.parametrize("data_interface", interface_list)
@@ -27,6 +30,34 @@ def test_interface_source_schema(data_interface):
 def test_interface_conversion_options_schema(data_interface):
     schema = data_interface.get_conversion_options_schema()
     Draft7Validator.check_schema(schema)
+
+
+def test_pkl_interface():
+    toy_data = se.example_datasets.toy_example()
+    test_dir = Path(mkdtemp())
+    output_folder = test_dir / "test_pkl"
+    nwbfile_path = str(test_dir / "test_pkl_files.nwb")
+
+    se.save_si_object(object_name="test_recording", si_object=toy_data[0], output_folder=output_folder)
+    se.save_si_object(object_name="test_sorting", si_object=toy_data[1], output_folder=output_folder)
+    print([x for x in output_folder.iterdir()])
+
+    class SpikeInterfaceTestNWBConverter(NWBConverter):
+        data_interface_classes = dict(
+            Recording=SIPickleRecordingExtractorInterface, Sorting=SIPickleRecordingExtractorInterface
+        )
+    source_data = dict(
+        Recording=dict(pkl_file=str(test_dir / "test_pkl" / "test_recording.pkl")),
+        Sorting=dict(pkl_file=str(test_dir / "test_pkl" / "test_sorting.pkl"))
+    )
+    converter = SpikeInterfaceTestNWBConverter(source_data=source_data)
+    converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True)
+
+    nwb_recording = se.NwbRecordingExtractor(file_path=nwbfile_path)
+    nwb_sorting = se.NwbSortingExtractor(file_path=nwbfile_path)
+    se.testing.check_recordings_equal(RX1=toy_data[0], RX2=nwb_recording)
+    se.testing.check_recordings_equal(RX1=toy_data[0], RX2=nwb_recording, return_scaled=False)
+    se.testing.check_sortings_equal(SX1=toy_data[1], SX2=nwb_sorting)
 
 
 def test_movie_interface():

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -7,6 +7,7 @@ from itertools import product
 
 import pytest
 import spikeextractors as se
+from spikeextractors.testing import check_recordings_equal, check_sortings_equal
 
 try:
     import cv2
@@ -40,11 +41,10 @@ def test_pkl_interface():
 
     se.save_si_object(object_name="test_recording", si_object=toy_data[0], output_folder=output_folder)
     se.save_si_object(object_name="test_sorting", si_object=toy_data[1], output_folder=output_folder)
-    print([x for x in output_folder.iterdir()])
 
     class SpikeInterfaceTestNWBConverter(NWBConverter):
         data_interface_classes = dict(
-            Recording=SIPickleRecordingExtractorInterface, Sorting=SIPickleRecordingExtractorInterface
+            Recording=SIPickleRecordingExtractorInterface, Sorting=SIPickleSortingExtractorInterface
         )
     source_data = dict(
         Recording=dict(pkl_file=str(test_dir / "test_pkl" / "test_recording.pkl")),
@@ -55,9 +55,9 @@ def test_pkl_interface():
 
     nwb_recording = se.NwbRecordingExtractor(file_path=nwbfile_path)
     nwb_sorting = se.NwbSortingExtractor(file_path=nwbfile_path)
-    se.testing.check_recordings_equal(RX1=toy_data[0], RX2=nwb_recording)
-    se.testing.check_recordings_equal(RX1=toy_data[0], RX2=nwb_recording, return_scaled=False)
-    se.testing.check_sortings_equal(SX1=toy_data[1], SX2=nwb_sorting)
+    check_recordings_equal(RX1=toy_data[0], RX2=nwb_recording)
+    check_recordings_equal(RX1=toy_data[0], RX2=nwb_recording, return_scaled=False)
+    check_sortings_equal(SX1=toy_data[1], SX2=nwb_sorting)
 
 
 def test_movie_interface():


### PR DESCRIPTION
## Motivation

Adding tests for one of our remaining untested interfaces; the SpikeInterface `.pkl` file interface.

## How to test the behavior?
There's no GIN data for it, not that we would need it since we can just generate synthetic data similar to the tutorial interfaces.

```
pytest
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
