### PR TITLE
pass one movie filepath to MovieInterface

### DIFF
--- a/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
@@ -13,7 +13,7 @@ from hdmf.data_utils import DataChunkIterator
 
 from ....basedatainterface import BaseDataInterface
 from ....utils.conversion_tools import check_regular_timestamps, get_module
-from ....utils.json_schema import get_schema_from_method_signature
+from ....utils.json_schema import get_schema_from_method_signature, FilePathType
 from .movie_utils import get_movie_timestamps, get_movie_fps, get_frame_shape
 
 
@@ -29,7 +29,7 @@ INSTALL_MESSAGE = "Please install opencv to use this extractor (pip install open
 class MovieInterface(BaseDataInterface):
     """Data interface for writing movies as ImageSeries."""
 
-    def __init__(self, file_paths: list):
+    def __init__(self, file_path: FilePathType):
         """
         Create the interface for writing movies as ImageSeries.
 
@@ -40,7 +40,7 @@ class MovieInterface(BaseDataInterface):
             Pass the file paths for this movies as a list in sorted, consecutive order.
         """
         assert HAVE_OPENCV, INSTALL_MESSAGE
-        super().__init__(file_paths=file_paths)
+        super().__init__(file_path=file_path)
 
     @classmethod
     def get_source_schema(cls):
@@ -52,7 +52,7 @@ class MovieInterface(BaseDataInterface):
         metadata: dict,
         stub_test: bool = False,
         external_mode: bool = True,
-        starting_times: Optional[list] = None,
+        starting_time: Optional[float] = None,
         chunk_data: bool = True,
         module_name: Optional[str] = None,
         module_description: Optional[str] = None,
@@ -72,7 +72,7 @@ class MovieInterface(BaseDataInterface):
             data sharing, the video files must be contained in the same folder as the NWBFile. If the intention of this
             NWBFile involves an upload to DANDI, the non-NWBFile types are not allowed so this flag would have to be
             set to False. The default is True.
-        starting_times : list, optional
+        starting_time : list, optional
             List of start times for each movie. If unspecified, assumes that the movies in the file_paths list are in
             sequential order and are contiguous.
         chunk_data : bool, optional
@@ -87,108 +87,102 @@ class MovieInterface(BaseDataInterface):
             If the processing module specified by module_name does not exist, it will be created with this description.
             The default description is the same as used by the conversion_tools.get_module function.
         """
-        file_paths = self.source_data["file_paths"]
+        file_path = self.source_data["file_path"]
 
         if stub_test:
             count_max = 10
         else:
             count_max = np.inf
-        if starting_times is not None:
-            assert (
-                isinstance(starting_times, list)
-                and all([isinstance(x, float) for x in starting_times])
-                and len(starting_times) == len(file_paths)
-            ), "Argument 'starting_times' must be a list of floats in one-to-one correspondence with 'file_paths'!"
+        if starting_time is None:
+            starting_time = 0.0
+        
+        timestamps = starting_time + get_movie_timestamps(movie_file=file_path)
+        nwb_module = 'acquisition' if module_name is None else module_name
+            
+        image_series_kwargs = dict(
+            name=f"Video: {Path(file_path).stem}", description="Video recorded by camera.", unit="Frames"
+        )
+        if nwb_module in metadata and 'ImageSeries' in metadata[nwb_module]:
+            image_series_kwargs.update(metadata[nwb_module]['ImageSeries'])
+            
+        if check_regular_timestamps(ts=timestamps):
+            fps = get_movie_fps(movie_file=file_path)
+            image_series_kwargs.update(starting_time=starting_time, rate=fps)
         else:
-            starting_times = [0.0]
+            image_series_kwargs.update(timestamps=H5DataIO(timestamps, compression="gzip"))
 
-        for j, file in enumerate(file_paths):
-            timestamps = starting_times[j] + get_movie_timestamps(movie_file=file)
+        if external_mode:
+            image_series_kwargs.update(format="external", external_file=[file_path])
+        else:
+            uncompressed_estimate = Path(file_path).stat().st_size * 70
+            available_memory = psutil.virtual_memory().available
+            if not chunk_data and uncompressed_estimate >= available_memory:
+                warn(
+                    f"Not enough memory (estimated {round(uncompressed_estimate/1e9, 2)} GB) to load movie file as "
+                    f"array ({round(available_memory/1e9, 2)} GB available)! Forcing chunk_data to True."
+                )
+                chunk_data = True
 
-            if len(starting_times) != len(file_paths):
-                starting_times.append(timestamps[-1])
+            total_frames = len(timestamps)
+            frame_shape = get_frame_shape(movie_file=file_path)
+            maxshape = [total_frames]
+            maxshape.extend(frame_shape)
+            best_gzip_chunk = (1, frame_shape[0], frame_shape[1], 3)
+            tqdm_pos, tqdm_mininterval = (0, 10)
+            if chunk_data:
 
-            image_series_kwargs = dict(
-                name=f"Video: {Path(file).stem}", description="Video recorded by camera.", unit="Frames"
-            )
-            if check_regular_timestamps(ts=timestamps):
-                fps = get_movie_fps(movie_file=file)
-                image_series_kwargs.update(starting_time=starting_times[j], rate=fps)
-            else:
-                image_series_kwargs.update(timestamps=H5DataIO(timestamps, compression="gzip"))
-
-            if external_mode:
-                image_series_kwargs.update(format="external", external_file=[file])
-            else:
-                uncompressed_estimate = Path(file).stat().st_size * 70
-                available_memory = psutil.virtual_memory().available
-                if not chunk_data and uncompressed_estimate >= available_memory:
-                    warn(
-                        f"Not enough memory (estimated {round(uncompressed_estimate/1e9, 2)} GB) to load movie file as "
-                        f"array ({round(available_memory/1e9, 2)} GB available)! Forcing chunk_data to True."
-                    )
-                    chunk_data = True
-
-                total_frames = len(timestamps)
-                frame_shape = get_frame_shape(movie_file=file)
-                maxshape = [total_frames]
-                maxshape.extend(frame_shape)
-                best_gzip_chunk = (1, frame_shape[0], frame_shape[1], 3)
-                tqdm_pos, tqdm_mininterval = (0, 10)
-                if chunk_data:
-
-                    def data_generator(file, count_max):
-                        cap = cv2.VideoCapture(str(file))
-                        for _ in range(min(count_max, total_frames)):
-                            success, frame = cap.read()
-                            yield frame
-                        cap.release()
-
-                    mov = DataChunkIterator(
-                        data=tqdm(
-                            iterable=data_generator(file=file, count_max=count_max),
-                            desc=f"Copying movie data for {Path(file).name}",
-                            position=tqdm_pos,
-                            total=total_frames,
-                            mininterval=tqdm_mininterval,
-                        ),
-                        iter_axis=0,  # nwb standard is time as zero axis
-                        maxshape=tuple(maxshape),
-                    )
-                    image_series_kwargs.update(data=H5DataIO(mov, compression="gzip", chunks=best_gzip_chunk))
-                else:
+                def data_generator(file, count_max):
                     cap = cv2.VideoCapture(str(file))
-                    mov = []
-                    with tqdm(
-                        desc=f"Reading movie data for {Path(file).name}",
+                    for _ in range(min(count_max, total_frames)):
+                        success, frame = cap.read()
+                        yield frame
+                    cap.release()
+
+                mov = DataChunkIterator(
+                    data=tqdm(
+                        iterable=data_generator(file=file_path, count_max=count_max),
+                        desc=f"Copying movie data for {Path(file_path).name}",
                         position=tqdm_pos,
                         total=total_frames,
                         mininterval=tqdm_mininterval,
-                    ) as pbar:
-                        for _ in range(min(count_max, total_frames)):
-                            success, frame = cap.read()
-                            mov.append(frame)
-                            pbar.update(1)
-                    cap.release()
-                    image_series_kwargs.update(
-                        data=H5DataIO(
-                            DataChunkIterator(
-                                tqdm(
-                                    iterable=np.array(mov),
-                                    desc=f"Writing movie data for {Path(file).name}",
-                                    position=tqdm_pos,
-                                    mininterval=tqdm_mininterval,
-                                ),
-                                iter_axis=0,  # nwb standard is time as zero axis
-                                maxshape=tuple(maxshape),
-                            ),
-                            compression="gzip",
-                            chunks=best_gzip_chunk,
-                        )
-                    )
-            if module_name is None:
-                nwbfile.add_acquisition(ImageSeries(**image_series_kwargs))
-            else:
-                get_module(nwbfile=nwbfile, name=module_name, description=module_description).add(
-                    ImageSeries(**image_series_kwargs)
+                    ),
+                    iter_axis=0,  # nwb standard is time as zero axis
+                    maxshape=tuple(maxshape),
                 )
+                image_series_kwargs.update(data=H5DataIO(mov, compression="gzip", chunks=best_gzip_chunk))
+            else:
+                cap = cv2.VideoCapture(str(file_path))
+                mov = []
+                with tqdm(
+                    desc=f"Reading movie data for {Path(file_path).name}",
+                    position=tqdm_pos,
+                    total=total_frames,
+                    mininterval=tqdm_mininterval,
+                ) as pbar:
+                    for _ in range(min(count_max, total_frames)):
+                        success, frame = cap.read()
+                        mov.append(frame)
+                        pbar.update(1)
+                cap.release()
+                image_series_kwargs.update(
+                    data=H5DataIO(
+                        DataChunkIterator(
+                            tqdm(
+                                iterable=np.array(mov),
+                                desc=f"Writing movie data for {Path(file_path).name}",
+                                position=tqdm_pos,
+                                mininterval=tqdm_mininterval,
+                            ),
+                            iter_axis=0,  # nwb standard is time as zero axis
+                            maxshape=tuple(maxshape),
+                        ),
+                        compression="gzip",
+                        chunks=best_gzip_chunk,
+                    )
+                )
+        if module_name is None:
+            nwbfile.add_acquisition(ImageSeries(**image_series_kwargs))
+        else:
+            get_module(nwbfile=nwbfile, name=module_name, description=module_description).add(
+                ImageSeries(**image_series_kwargs)
+            )

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -50,7 +50,7 @@ def test_movie_interface():
         class MovieTestNWBConverter(NWBConverter):
             data_interface_classes = dict(Movie=MovieInterface)
 
-        source_data = dict(Movie=dict(file_paths=[movie_file]))
+        source_data = dict(Movie=dict(file_path=movie_file))
         converter = MovieTestNWBConverter(source_data)
         metadata = converter.get_metadata()
 
@@ -62,7 +62,7 @@ def test_movie_interface():
             metadata=metadata,
             nwbfile_path=nwbfile_path,
             overwrite=True,
-            conversion_options=dict(Movie=dict(starting_times=[123.0])),
+            conversion_options=dict(Movie=dict(starting_time=123.0)),
         )
 
         # These conversion options do not operate independently, so test them jointly


### PR DESCRIPTION
## Motivation

Providing option to overrite the name, description and other metadata for ImageSeries that stores the Movie. 

The `MovieInterface.run_conversion()` takes metadata as arg but it is not used. 