### PR TITLE
GIN as GitHub Artifacts

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-latest", "windows-latest"]
+        os: ["macos-latest", "windows-latest", "ubuntu-latest"]
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow --tags
@@ -18,6 +18,14 @@ jobs:
     - name: Install pip
       run: |
         python -m pip install --upgrade pip
+    - name: Download GIN artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ephy_testing_data
+        path: ./ephy_testing_data
+    - name: Display structure of downloaded files
+      run: ls -R
+      working-directory: ./ephy_testing_data
     - name: Install this package, on development mode
       env:
           NWB_CONVERSION_INSTALL_MODE: development

--- a/.github/workflows/update-gin-artifact.yml
+++ b/.github/workflows/update-gin-artifact.yml
@@ -1,7 +1,7 @@
 name: Update GIN artifact
 on: 
   schedule:
-    - cron: "0 0 * * 1"
+    - cron: "0 0 * * 1"  # every Monday morning
 jobs:
   run:
     name: Upload GIN artifact

--- a/.github/workflows/update-gin-artifact.yml
+++ b/.github/workflows/update-gin-artifact.yml
@@ -1,0 +1,35 @@
+name: Update GIN artifact
+on: 
+  schedule:
+    - cron: "0 0 * * 1"
+jobs:
+  run:
+    name: Upload GIN artifact
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: s-weigand/setup-conda@v1
+        with:
+          python-version: 3.8
+      - name: Which python
+        run: |
+          conda --version
+          which python
+      - run: git fetch --prune --unshallow --tags
+      - name: Install this package, on development mode
+        env:
+            NWB_CONVERSION_INSTALL_MODE: development
+        run: |
+          conda install -c conda-forge datalad==0.14.5
+          pip install -e .
+          # needed for correct operation of git/git-annex/DataLad
+          git config --global user.email "CI@example.com"
+          git config --global user.name "CI Almighty"
+      - name: Download entire repo
+        run: |
+          datalad install -r -g https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ephy_testing_data
+          path: ./ephy_testing_data

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -19,25 +19,16 @@ from nwb_conversion_tools import (
 )
 
 try:
-    from datalad.api import install, Dataset
-
-    HAVE_DATALAD = True
-except ImportError:
-    HAVE_DATALAD = False
-
-try:
     from parameterized import parameterized, param
 
     HAVE_PARAMETERIZED = True
 except ImportError:
     HAVE_PARAMETERIZED = False
 
-RUN_LOCAL = True
 LOCAL_PATH = Path(".")  # Path to dataset downloaded from https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
 
 
-if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL):
-
+if HAVE_PARAMETERIZED:
     def custom_name_func(testcase_func, param_num, param):
         return (
             f"{testcase_func.__name__}_{param_num}_"
@@ -47,11 +38,7 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
     class TestNwbConversions(unittest.TestCase):
         dataset = None
         savedir = Path(tempfile.mkdtemp())
-
-        if RUN_LOCAL and LOCAL_PATH.exists():
-            data_path = LOCAL_PATH
-        else:
-            data_path = Path.cwd() / "ephy_testing_data"
+        data_path = Path.cwd() / "ephy_testing_data"
 
         parameterized_expand_list = [
             param(
@@ -99,19 +86,6 @@ if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL
                     interface_kwargs=dict(file_path=str(data_path / sub_path / f"Noise4Sam_g0_t0.imec0.{suffix}.bin")),
                 )
             )
-
-        def setUp(self):
-            data_exists = self.data_path.exists()
-            if HAVE_DATALAD and data_exists:
-                self.dataset = Dataset(self.data_path)
-            if RUN_LOCAL:
-                if not data_exists:
-                    if HAVE_DATALAD:
-                        self.dataset = install("https://gin.g-node.org/NeuralEnsemble/ephy_testing_data")
-                    else:
-                        raise FileNotFoundError(f"The manually specified data path ({self.data_path}) does not exist!")
-            elif not data_exists:
-                self.dataset = install("https://gin.g-node.org/NeuralEnsemble/ephy_testing_data")
 
         @parameterized.expand(
             [

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -33,7 +33,7 @@ except ImportError:
     HAVE_PARAMETERIZED = False
 
 RUN_LOCAL = True
-LOCAL_PATH = Path("E:/GIN")  # Path to dataset downloaded from https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+LOCAL_PATH = Path(".")  # Path to dataset downloaded from https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
 
 
 if HAVE_PARAMETERIZED and (HAVE_DATALAD and sys.platform == "linux" or RUN_LOCAL):


### PR DESCRIPTION
## Motivation

Let's see if this works...

The idea is, instead of manually re-downloading the GIN datasets each time we want to do a full test, do (1) an initial download from GIN (takes about 42 minutes) and 'upload' to GitHub actions [as an artifact] (takes less than 5 minutes)(https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts), (2) then to perform tests 'download' the directory from the artifacts locally (download time TBD). This, in theory, should allow the full tests to run much faster.

This also simplifies the `test_gin` script to no longer need datalad through that imported python API (all gets offloaded to workflows), which reduces the amount of code needed by a significant margin.

This also allows the possibility of running full GIN tests on other parts of the OS matrix to ensure our awareness of OS specific issues.

## How to test the behavior?

No changes to the way testing behavior is called; the CI will report issues quickly if there's an issue with handling the artifact part.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
