### PR TITLE
generalized get_source_schema() across all interfaces

### DIFF
--- a/nwb_conversion_tools/basedatainterface.py
+++ b/nwb_conversion_tools/basedatainterface.py
@@ -6,7 +6,6 @@ from .utils.json_schema import get_base_schema, get_schema_from_method_signature
 
 
 class BaseDataInterface(ABC):
-
     @classmethod
     def get_source_schema(cls):
         return get_schema_from_method_signature(cls.__init__)

--- a/nwb_conversion_tools/basedatainterface.py
+++ b/nwb_conversion_tools/basedatainterface.py
@@ -6,9 +6,10 @@ from .utils.json_schema import get_base_schema, get_schema_from_method_signature
 
 
 class BaseDataInterface(ABC):
+
     @classmethod
     def get_source_schema(cls):
-        return get_base_schema()
+        return get_schema_from_method_signature(cls.__init__)
 
     @classmethod
     def get_conversion_options_schema(cls):

--- a/nwb_conversion_tools/basedatainterface.py
+++ b/nwb_conversion_tools/basedatainterface.py
@@ -8,7 +8,7 @@ from .utils.json_schema import get_base_schema, get_schema_from_method_signature
 class BaseDataInterface(ABC):
     @classmethod
     def get_source_schema(cls):
-        return get_schema_from_method_signature(cls.__init__)
+        return get_schema_from_method_signature(cls.__init__, exclude=["source_data"])
 
     @classmethod
     def get_conversion_options_schema(cls):

--- a/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
@@ -42,10 +42,6 @@ class MovieInterface(BaseDataInterface):
         assert HAVE_OPENCV, INSTALL_MESSAGE
         super().__init__(file_paths=file_paths)
 
-    @classmethod
-    def get_source_schema(cls):
-        return get_schema_from_method_signature(cls.__init__)
-
     def run_conversion(
         self,
         nwbfile: NWBFile,

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -23,11 +23,6 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
 
     RX = None
 
-    @classmethod
-    def get_source_schema(cls):
-        """Compile input schema for the RecordingExtractor."""
-        return get_schema_from_method_signature(cls.__init__)
-
     def __init__(self, **source_data):
         super().__init__(**source_data)
         self.recording_extractor = self.RX(**source_data)

--- a/nwb_conversion_tools/datainterfaces/ecephys/basesortingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/basesortingextractorinterface.py
@@ -16,11 +16,6 @@ class BaseSortingExtractorInterface(BaseDataInterface, ABC):
 
     SX = None
 
-    @classmethod
-    def get_source_schema(cls):
-        """Compile input schema for the SortingExtractor."""
-        return get_schema_from_method_signature(cls.__init__)
-
     def __init__(self, **source_data):
         super().__init__(**source_data)
         self.sorting_extractor = self.SX(**source_data)

--- a/nwb_conversion_tools/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -16,10 +16,6 @@ from ...utils.json_schema import (
 class BaseImagingExtractorInterface(BaseDataInterface):
     IX = None
 
-    @classmethod
-    def get_source_schema(cls):
-        return get_schema_from_method_signature(cls.__init__)
-
     def __init__(self, **source_data):
         super().__init__(**source_data)
         self.imaging_extractor = self.IX(**source_data)

--- a/nwb_conversion_tools/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -18,10 +18,6 @@ from ...utils.json_schema import (
 class BaseSegmentationExtractorInterface(BaseDataInterface, ABC):
     SegX = None
 
-    @classmethod
-    def get_source_schema(cls):
-        return get_schema_from_method_signature(cls.__init__)
-
     def __init__(self, **source_data):
         super().__init__(**source_data)
         self.segmentation_extractor = self.SegX(**source_data)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -21,8 +21,6 @@ def test_converter():
         nwbfile_path = str(test_dir / "extension_test.nwb")
 
         class NdxEventsInterface(BaseDataInterface):
-            def __init__(self):
-                super().__init__()
 
             def run_conversion(self, nwbfile: NWBFile, metadata: dict):
                 events = LabeledEvents(

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -21,7 +21,6 @@ def test_converter():
         nwbfile_path = str(test_dir / "extension_test.nwb")
 
         class NdxEventsInterface(BaseDataInterface):
-
             def run_conversion(self, nwbfile: NWBFile, metadata: dict):
                 events = LabeledEvents(
                     name="LabeledEvents",

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -21,6 +21,9 @@ def test_converter():
         nwbfile_path = str(test_dir / "extension_test.nwb")
 
         class NdxEventsInterface(BaseDataInterface):
+            def __init__(self):
+                super().__init__()
+
             def run_conversion(self, nwbfile: NWBFile, metadata: dict):
                 events = LabeledEvents(
                     name="LabeledEvents",


### PR DESCRIPTION
## Motivation

I noticed that, as of PR #257, all of our BaseDataInterfaces use direct schema generation from class initialization arguments. This, therefore, generalizes it to always apply in place of a base_schema for the abstract DataInterface.

## How to test the behavior?
No behavior change

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
