### PR TITLE
get_metadata_schema as class method, with tests

### DIFF
--- a/nwb_conversion_tools/basedatainterface.py
+++ b/nwb_conversion_tools/basedatainterface.py
@@ -2,7 +2,7 @@
 from abc import abstractmethod, ABC
 import warnings
 
-from .utils.json_schema import get_base_schema, get_schema_from_method_signature, fill_defaults
+from .utils.json_schema import get_base_schema, get_schema_from_method_signature
 
 
 class BaseDataInterface(ABC):
@@ -14,10 +14,8 @@ class BaseDataInterface(ABC):
     def get_conversion_options_schema(cls):
         return get_schema_from_method_signature(cls.run_conversion, exclude=["nwbfile", "metadata"])
 
-    def __init__(self, **source_data):
-        self.source_data = source_data
-
-    def get_metadata_schema(self):
+    @classmethod
+    def get_metadata_schema(cls):
         metadata_schema = get_base_schema(
             id_="metadata.schema.json",
             root=True,
@@ -26,6 +24,9 @@ class BaseDataInterface(ABC):
             version="0.1.0",
         )
         return metadata_schema
+
+    def __init__(self, **source_data):
+        self.source_data = source_data
 
     def get_metadata(self):
         """Child DataInterface classes should override this to match their metadata"""

--- a/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -17,7 +17,8 @@ OptionalPathType = Optional[Union[str, Path]]
 class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
     """Primary class for all LFP data interfaces."""
 
-    def get_metadata_schema(self):
+    @classmethod
+    def get_metadata_schema(cls):
         metadata_schema = super().get_metadata_schema()
         metadata_schema["properties"]["Ecephys"]["properties"].update(
             ElectricalSeries_lfp=get_schema_from_hdmf_class(ElectricalSeries)

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -28,12 +28,8 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         """Compile input schema for the RecordingExtractor."""
         return get_schema_from_method_signature(cls.__init__)
 
-    def __init__(self, **source_data):
-        super().__init__(**source_data)
-        self.recording_extractor = self.RX(**source_data)
-        self.subset_channels = None
-
-    def get_metadata_schema(self):
+    @classmethod
+    def get_metadata_schema(cls):
         """Compile metadata schema for the RecordingExtractor."""
         metadata_schema = super().get_metadata_schema()
 
@@ -67,6 +63,11 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
             ),
         )
         return metadata_schema
+
+    def __init__(self, **source_data):
+        super().__init__(**source_data)
+        self.recording_extractor = self.RX(**source_data)
+        self.subset_channels = None
 
     def get_metadata(self):
         metadata = super().get_metadata()

--- a/nwb_conversion_tools/datainterfaces/ecephys/basesortingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/basesortingextractorinterface.py
@@ -21,16 +21,17 @@ class BaseSortingExtractorInterface(BaseDataInterface, ABC):
         """Compile input schema for the SortingExtractor."""
         return get_schema_from_method_signature(cls.__init__)
 
-    def __init__(self, **source_data):
-        super().__init__(**source_data)
-        self.sorting_extractor = self.SX(**source_data)
-
-    def get_metadata_schema(self):
+    @classmethod
+    def get_metadata_schema(cls):
         """Compile metadata schema for the RecordingExtractor."""
         metadata_schema = get_base_schema(
             properties=dict(SpikeEventSeries=get_schema_from_hdmf_class(SpikeEventSeries))
         )
         return metadata_schema
+
+    def __init__(self, **source_data):
+        super().__init__(**source_data)
+        self.sorting_extractor = self.SX(**source_data)
 
     def run_conversion(
         self, nwbfile: NWBFile, metadata: dict, stub_test: bool = False, write_ecephys_metadata: bool = False

--- a/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -31,12 +31,8 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["filename"]["description"] = "Path to Blackrock file."
         return source_schema
 
-    def __init__(
-        self, filename: FilePathType, nsx_override: OptionalFilePathType = None, nsx_to_load: Optional[int] = None
-    ):
-        super().__init__(filename=filename, nsx_override=nsx_override, nsx_to_load=nsx_to_load)
-
-    def get_metadata_schema(self):
+    @classmethod
+    def get_metadata_schema(cls):
         """Compile metadata schema for the RecordingExtractor."""
         metadata_schema = super().get_metadata_schema()
         metadata_schema["properties"]["Ecephys"]["properties"].update(
@@ -44,6 +40,11 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
             ElectricalSeries_processed=get_schema_from_hdmf_class(ElectricalSeries),
         )
         return metadata_schema
+
+    def __init__(
+        self, filename: FilePathType, nsx_override: OptionalFilePathType = None, nsx_to_load: Optional[int] = None
+    ):
+        super().__init__(filename=filename, nsx_override=nsx_override, nsx_to_load=nsx_to_load)
 
     def get_metadata(self):
         """Auto-fill as much of the metadata as possible. Must comply with metadata schema."""

--- a/nwb_conversion_tools/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/intan/intandatainterface.py
@@ -21,6 +21,14 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
 
     RX = se.IntanRecordingExtractor
 
+    @classmethod
+    def get_metadata_schema(cls):
+        metadata_schema = super().get_metadata_schema()
+        metadata_schema["properties"]["Ecephys"]["properties"].update(
+            ElectricalSeries_raw=get_schema_from_hdmf_class(ElectricalSeries)
+        )
+        return metadata_schema
+
     def __init__(self, file_path: FilePathType):
         assert HAVE_PYINTAN, INSTALL_MESSAGE
         super().__init__(file_path=file_path)
@@ -55,13 +63,6 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
                 self.recording_extractor.set_channel_property(
                     channel_id=channel_id, property_name="custom_channel_name", value=custom_name
                 )
-
-    def get_metadata_schema(self):
-        metadata_schema = super().get_metadata_schema()
-        metadata_schema["properties"]["Ecephys"]["properties"].update(
-            ElectricalSeries_raw=get_schema_from_hdmf_class(ElectricalSeries)
-        )
-        return metadata_schema
 
     def get_metadata(self):
         channel_ids = self.recording_extractor.get_channel_ids()

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -65,6 +65,14 @@ class NeuroscopeRecordingInterface(BaseRecordingExtractorInterface):
 
     RX = se.NeuroscopeRecordingExtractor
 
+    @classmethod
+    def get_metadata_schema(cls):
+        metadata_schema = super().get_metadata_schema()
+        metadata_schema["properties"]["Ecephys"]["properties"].update(
+            ElectricalSeries_raw=get_schema_from_hdmf_class(ElectricalSeries)
+        )
+        return metadata_schema
+
     @staticmethod
     def get_ecephys_metadata(xml_file_path: str):
         """Auto-populates ecephys metadata from the xml_file_path."""
@@ -98,13 +106,6 @@ class NeuroscopeRecordingInterface(BaseRecordingExtractorInterface):
                 channel_id=channel_id, property_name="group_name", value=group_name
             )
 
-    def get_metadata_schema(self):
-        metadata_schema = super().get_metadata_schema()
-        metadata_schema["properties"]["Ecephys"]["properties"].update(
-            ElectricalSeries_raw=get_schema_from_hdmf_class(ElectricalSeries)
-        )
-        return metadata_schema
-
     def get_metadata(self):
         """Retrieve Ecephys metadata specific to the Neuroscope format."""
         metadata = super().get_metadata()
@@ -124,6 +125,14 @@ class NeuroscopeMultiRecordingTimeInterface(BaseRecordingExtractorInterface):
 
     RX = se.NeuroscopeMultiRecordingTimeExtractor
 
+    @classmethod
+    def get_metadata_schema(cls):
+        metadata_schema = super().get_metadata_schema()
+        metadata_schema["properties"]["Ecephys"]["properties"].update(
+            ElectricalSeries_raw=get_schema_from_hdmf_class(ElectricalSeries)
+        )
+        return metadata_schema
+
     def __init__(self, folder_path: FolderPathType):
         super().__init__(folder_path=folder_path)
         xml_file_path = get_xml_file_path(data_file_path=self.source_data["folder_path"])
@@ -140,13 +149,6 @@ class NeuroscopeMultiRecordingTimeInterface(BaseRecordingExtractorInterface):
             self.recording_extractor.set_channel_property(
                 channel_id=channel_id, property_name="group_name", value=group_name
             )
-
-    def get_metadata_schema(self):
-        metadata_schema = super().get_metadata_schema()
-        metadata_schema["properties"]["Ecephys"]["properties"].update(
-            ElectricalSeries_raw=get_schema_from_hdmf_class(ElectricalSeries)
-        )
-        return metadata_schema
 
     def get_metadata(self):
         """Retrieve Ecephys metadata specific to the Neuroscope format."""
@@ -168,18 +170,19 @@ class NeuroscopeLFPInterface(BaseLFPExtractorInterface):
 
     RX = se.NeuroscopeRecordingExtractor
 
-    def __init__(self, file_path: FilePathType):
-        super().__init__(file_path=file_path)
-        self.subset_channels = get_shank_channels(
-            xml_file_path=get_xml_file_path(data_file_path=self.source_data["file_path"]), sort=True
-        )
-
-    def get_metadata_schema(self):
+    @classmethod
+    def get_metadata_schema(cls):
         metadata_schema = super().get_metadata_schema()
         metadata_schema["properties"]["Ecephys"]["properties"].update(
             ElectricalSeries_lfp=get_schema_from_hdmf_class(ElectricalSeries)
         )
         return metadata_schema
+
+    def __init__(self, file_path: FilePathType):
+        super().__init__(file_path=file_path)
+        self.subset_channels = get_shank_channels(
+            xml_file_path=get_xml_file_path(data_file_path=self.source_data["file_path"]), sort=True
+        )
 
     def get_metadata(self):
         """Retrieve Ecephys metadata specific to the Neuroscope format."""

--- a/nwb_conversion_tools/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -44,6 +44,14 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["file_path"]["description"] = "Path to SpikeGLX file."
         return source_schema
 
+    @classmethod
+    def get_metadata_schema(cls):
+        metadata_schema = super().get_metadata_schema()
+        metadata_schema["properties"]["Ecephys"]["properties"].update(
+            ElectricalSeries_raw=get_schema_from_hdmf_class(ElectricalSeries)
+        )
+        return metadata_schema
+
     def __init__(self, file_path: FilePathType, stub_test: Optional[bool] = False):
         super().__init__(file_path=str(file_path))
         if stub_test:
@@ -57,13 +65,6 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
             self.recording_extractor.set_channel_property(
                 channel_id=ch, property_name="shank_group_name", value="Shank1"
             )
-
-    def get_metadata_schema(self):
-        metadata_schema = super().get_metadata_schema()
-        metadata_schema["properties"]["Ecephys"]["properties"].update(
-            ElectricalSeries_raw=get_schema_from_hdmf_class(ElectricalSeries)
-        )
-        return metadata_schema
 
     def get_metadata(self):
         metadata = super().get_metadata()
@@ -92,6 +93,14 @@ class SpikeGLXLFPInterface(BaseLFPExtractorInterface):
         source_schema["properties"]["file_path"]["description"] = "Path to SpikeGLX file."
         return source_schema
 
+    @classmethod
+    def get_metadata_schema(cls):
+        metadata_schema = super().get_metadata_schema()
+        metadata_schema["properties"]["Ecephys"]["properties"].update(
+            ElectricalSeries_lfp=get_schema_from_hdmf_class(ElectricalSeries)
+        )
+        return metadata_schema
+
     def __init__(self, file_path: FilePathType, stub_test: Optional[bool] = False):
         super().__init__(file_path=str(file_path))
         if stub_test:
@@ -105,13 +114,6 @@ class SpikeGLXLFPInterface(BaseLFPExtractorInterface):
             self.recording_extractor.set_channel_property(
                 channel_id=ch, property_name="shank_group_name", value="Shank1"
             )
-
-    def get_metadata_schema(self):
-        metadata_schema = super().get_metadata_schema()
-        metadata_schema["properties"]["Ecephys"]["properties"].update(
-            ElectricalSeries_lfp=get_schema_from_hdmf_class(ElectricalSeries)
-        )
-        return metadata_schema
 
     def get_metadata(self):
         metadata = super().get_metadata()

--- a/nwb_conversion_tools/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -20,11 +20,8 @@ class BaseImagingExtractorInterface(BaseDataInterface):
     def get_source_schema(cls):
         return get_schema_from_method_signature(cls.__init__)
 
-    def __init__(self, **source_data):
-        super().__init__(**source_data)
-        self.imaging_extractor = self.IX(**source_data)
-
-    def get_metadata_schema(self):
+    @classmethod
+    def get_metadata_schema(cls):
         """Compile metadata schema for the ImageExtractor."""
         metadata_schema = super().get_metadata_schema()
         metadata_schema["required"] = ["Ophys"]
@@ -49,8 +46,12 @@ class BaseImagingExtractorInterface(BaseDataInterface):
             TwoPhotonSeries=get_schema_from_hdmf_class(TwoPhotonSeries),
         )
 
-        fill_defaults(metadata_schema, self.get_metadata())
+        # fill_defaults(metadata_schema, self.get_metadata())
         return metadata_schema
+
+    def __init__(self, **source_data):
+        super().__init__(**source_data)
+        self.imaging_extractor = self.IX(**source_data)
 
     def get_metadata(self):
         """Auto-fill metadata with values found from the corresponding imageextractor."""

--- a/nwb_conversion_tools/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -22,11 +22,8 @@ class BaseSegmentationExtractorInterface(BaseDataInterface, ABC):
     def get_source_schema(cls):
         return get_schema_from_method_signature(cls.__init__)
 
-    def __init__(self, **source_data):
-        super().__init__(**source_data)
-        self.segmentation_extractor = self.SegX(**source_data)
-
-    def get_metadata_schema(self):
+    @classmethod
+    def get_metadata_schema(cls):
         """Compile metadata schema for the RoiExtractor."""
         metadata_schema = super().get_metadata_schema()
         metadata_schema["required"] = ["Ophys"]
@@ -40,8 +37,12 @@ class BaseSegmentationExtractorInterface(BaseDataInterface, ABC):
             TwoPhotonSeries=get_schema_from_hdmf_class(TwoPhotonSeries),
         )
         metadata_schema["properties"]["Ophys"]["required"] = ["Device", "Fluorescence", "ImageSegmentation"]
-        fill_defaults(metadata_schema, self.get_metadata())
+        # fill_defaults(metadata_schema, self.get_metadata())
         return metadata_schema
+
+    def __init__(self, **source_data):
+        super().__init__(**source_data)
+        self.segmentation_extractor = self.SegX(**source_data)
 
     def get_metadata(self):
         """Auto-fill metadata with values found from the corresponding roiextractor.

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -24,6 +24,12 @@ def test_interface_source_schema(data_interface):
 
 
 @pytest.mark.parametrize("data_interface", interface_list)
+def test_interface_metadata_schema(data_interface):
+    schema = data_interface.get_metadata_schema()
+    Draft7Validator.check_schema(schema)
+
+
+@pytest.mark.parametrize("data_interface", interface_list)
 def test_interface_conversion_options_schema(data_interface):
     schema = data_interface.get_conversion_options_schema()
     Draft7Validator.check_schema(schema)


### PR DESCRIPTION
fix #261 

## Motivation

Previously, the `get_metadata_schema` methods were instance-specific compared to the other `get_*_schema` methods. This shows what it would be like if they were class methods

Listing as draft until we can discuss some of the specifics on the ophys default value setting. @Saksham20 @luiztauffer would know more about that, or possible @alejoe91...

## How to test the behavior?
Added (and debugged) new tests to ensure all set metadata schemas are proper for interfaces in our `interface_list`

```
pytest
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [X] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
