### PR TITLE
add option to set nwbfile before calling add_methods

### DIFF
--- a/nwb_conversion_tools/utils/basenwbephyswriter.py
+++ b/nwb_conversion_tools/utils/basenwbephyswriter.py
@@ -18,7 +18,7 @@ from .common_writer_tools import (
     set_dynamic_table_property,
     check_module,
     DynamicTableSupportedDtypes,
-    default_export_ops_schema
+    default_export_ops_schema,
 )
 from .nwbephyswriterdatachunkiterator import NwbEphysWriterDataChunkIterator
 
@@ -33,7 +33,7 @@ class BaseNwbEphysWriter(ABC):
         self._conversion_ops = dict()
         self.metadata = dict()
 
-    def set_nwbfile(self, nwbfile:pynwb.NWBFile, metadata:dict, **kwargs):
+    def set_nwbfile(self, nwbfile: pynwb.NWBFile, metadata: dict, **kwargs):
         assert nwbfile is not None and isinstance(nwbfile, pynwb.NWBFile), "Instantiate an NWBFile and pass as argument"
         if metadata is not None:
             self.metadata.update(metadata)

--- a/nwb_conversion_tools/utils/basenwbephyswriter.py
+++ b/nwb_conversion_tools/utils/basenwbephyswriter.py
@@ -10,7 +10,7 @@ import psutil
 import pynwb
 from hdmf.backends.hdf5.h5_utils import H5DataIO
 from hdmf.data_utils import DataChunkIterator
-
+from jsonschema import validate
 from .common_writer_tools import (
     default_export_ops,
     _default_sorting_property_descriptions,
@@ -18,6 +18,7 @@ from .common_writer_tools import (
     set_dynamic_table_property,
     check_module,
     DynamicTableSupportedDtypes,
+    default_export_ops_schema
 )
 from .nwbephyswriterdatachunkiterator import NwbEphysWriterDataChunkIterator
 
@@ -31,6 +32,17 @@ class BaseNwbEphysWriter(ABC):
         self.nwbfile = None
         self._conversion_ops = dict()
         self.metadata = dict()
+
+    def set_nwbfile(self, nwbfile:pynwb.NWBFile, metadata:dict, **kwargs):
+        assert nwbfile is not None and isinstance(nwbfile, pynwb.NWBFile), "Instantiate an NWBFile and pass as argument"
+        if metadata is not None:
+            self.metadata.update(metadata)
+        self.nwbfile = nwbfile
+        conversion_ops = default_export_ops()
+        conversion_ops.update(kwargs)
+        self._conversion_ops.update(**conversion_ops)
+        conversion_opt_schema = default_export_ops_schema()
+        validate(instance=self._conversion_ops, schema=conversion_opt_schema)
 
     @abstractmethod
     def get_num_segments(self):

--- a/nwb_conversion_tools/utils/basesinwbephyswriter.py
+++ b/nwb_conversion_tools/utils/basesinwbephyswriter.py
@@ -68,7 +68,7 @@ class BaseSINwbEphysWriter(BaseNwbEphysWriter, ABC):
 
     def add_to_nwb(self, nwbfile: pynwb.NWBFile, metadata=None, **kwargs):
         if self.nwbfile is None:
-            self.set_nwbfile(nwbfile, metadata,**kwargs)
+            self.set_nwbfile(nwbfile, metadata, **kwargs)
         if self.waveforms is not None:
             self.add_recording()
             self.add_sorting()

--- a/nwb_conversion_tools/utils/basesinwbephyswriter.py
+++ b/nwb_conversion_tools/utils/basesinwbephyswriter.py
@@ -67,10 +67,8 @@ class BaseSINwbEphysWriter(BaseNwbEphysWriter, ABC):
             self.add_units_waveforms()
 
     def add_to_nwb(self, nwbfile: pynwb.NWBFile, metadata=None, **kwargs):
-        assert nwbfile is not None and isinstance(nwbfile, pynwb.NWBFile), "Instantiate an NWBFile and pass as argument"
-        self.metadata = metadata if metadata is not None else dict()
-        self.nwbfile = nwbfile
-        self._conversion_ops = kwargs
+        if self.nwbfile is None:
+            self.set_nwbfile(nwbfile, metadata,**kwargs)
         if self.waveforms is not None:
             self.add_recording()
             self.add_sorting()


### PR DESCRIPTION
### Problem:
The ephys writers may want to be used outside of:
1.  Export method [here](https://github.com/catalystneuro/nwb-conversion-tools/blob/135d325b3e674c1474e1dba21c6760fc1def0f2a/nwb_conversion_tools/utils/ephys_writer.py#L36)
2. Using the sorting/recording datainterfaces. 
Both these methods instantiate an nwbfile and require all of sorting/recording extractor information to be written to the nwbfile (so they directly use the `add_to_nwb()` method. 

But there could be cases where we want have a preinstantiated nwbfile and use `add_*()` methods directly to write only specific details into the nwbfile. 

### Implementation:


### Motivation: 
The sorging/recording datainterfaces may require to retrieve some info from the sorting/recording [like here](https://github.com/catalystneuro/nwb-conversion-tools/blob/dbb0290346d1e9cf8094cbfa7d72b9e892f0ce4a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py#L82). The `nwbfile`, `metadata` arguments are only required at `run_conversion()` so we should be able to instantiate the ephyswriter class without args: `nwbfile`,`metadata` also. [here](https://github.com/catalystneuro/nwb-conversion-tools/blob/dbb0290346d1e9cf8094cbfa7d72b9e892f0ce4a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py#L37)
