### PR TITLE
Update neuroscope

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscope_utils.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscope_utils.py
@@ -1,0 +1,91 @@
+"""Authors: Cody Baker and Ben Dichter."""
+from pathlib import Path
+
+import numpy as np
+from lxml import etree as et
+from spikeextractors import RecordingExtractor
+
+
+def get_xml_file_path(data_file_path: str):
+    """
+    Infer the xml_file_path from the data_file_path (.dat or .eeg).
+
+    Assumes the two are in the same folder and follow the session_id naming convention.
+    """
+    session_path = Path(data_file_path).parent
+    return str(session_path / f"{session_path.stem}.xml")
+
+
+def get_xml(xml_file_path: str):
+    """Auxiliary function for retrieving root of xml."""
+    return et.parse(xml_file_path).getroot()
+
+
+def safe_find(root: et._Element, key: str, findall: bool = False):
+    """Auxiliary function for safe retrieval of single key from next level of lxml tree."""
+    if root is not None:
+        if findall:
+            return root.findall(key)
+        else:
+            return root.find(key)
+
+
+def safe_nested_find(root: et._Element, keys: list):
+    """Auxiliary function for safe retrieval of keys at multiple depths in lxml tree."""
+    for key in keys:
+        root = safe_find(root, key)
+    if root is not None:
+        return root
+
+
+def get_shank_channels(xml_file_path: str):
+    """Auxiliary function for retrieving the list of structured shank-only channels."""
+    root = get_xml(xml_file_path)
+    channel_groups = safe_find(safe_nested_find(root, ["spikeDetection", "channelGroups"]), "group", findall=True)
+    if channel_groups and all([safe_find(group, "channels") is not None for group in channel_groups]):
+        shank_channels = [
+            [int(channel.text) for channel in group.find("channels")] for group in channel_groups
+        ]
+        return shank_channels
+
+
+def get_channel_groups(xml_file_path: str):
+    """Auxiliary function for retrieving a list of groups, each containing a list of channels."""
+    root = get_xml(xml_file_path)
+    channel_groups = [
+        [int(channel.text) for channel in group.findall("channel")]
+        for group in root.find("anatomicalDescription").find("channelGroups").findall("group")
+    ]
+    return channel_groups
+
+
+def add_recording_extractor_properties(recording_extractor: RecordingExtractor, xml_file_path: str):
+    """Automatically add properties to RecordingExtractor object."""
+    channel_groups = get_channel_groups(xml_file_path=xml_file_path)
+    channel_map = {
+        channel_id: idx for idx, channel_id in enumerate(
+            [channel_id for group in channel_groups for channel_id in group]
+        )
+    }
+    shank_channels = get_shank_channels(xml_file_path=xml_file_path)
+    if shank_channels:
+        shank_channels = [channel_id for group in shank_channels for channel_id in group]
+    group_electrode_numbers = [x for channels in channel_groups for x, _ in enumerate(channels)]
+    group_nums = [n + 1 for n, channels in enumerate(channel_groups) for _ in channels]
+    group_names = [f"Group{n + 1}" for n in group_nums]
+    for channel_id in recording_extractor.get_channel_ids():
+        recording_extractor.set_channel_groups(
+            channel_ids=[channel_id], groups=group_nums[channel_map[channel_id]]
+        )
+        recording_extractor.set_channel_property(
+            channel_id=channel_id, property_name="group_name", value=group_names[channel_map[channel_id]]
+        )
+        recording_extractor.set_channel_property(
+            channel_id=channel_id,
+            property_name="shank_electrode_number",
+            value=group_electrode_numbers[channel_map[channel_id]]
+        )
+        if shank_channels is not None:
+            recording_extractor.set_channel_property(
+                channel_id=channel_id, property_name="spike_detection", value=channel_id in shank_channels
+            )

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -70,9 +70,6 @@ class NeuroscopeRecordingInterface(BaseRecordingExtractorInterface):
             Path to .xml file containing device and electrode configuration.
             If unspecified, it will be automatically set as the only .xml file in the same folder as the .dat file.
             The default is None.
-        channel_key : str, optional
-            Certain .xml files indicate shank structure via either "spikeDetection" or "anatomicalDescription" keys.
-            The default is "spikeDetection".
         """
         assert HAVE_LXML, INSTALL_MESSAGE
 
@@ -128,9 +125,6 @@ class NeuroscopeMultiRecordingTimeInterface(NeuroscopeRecordingInterface):
             Path to .xml file containing device and electrode configuration.
             If unspecified, it will be automatically set as the only .xml file in the same folder as the .dat file.
             The default is None.
-        channel_key : str, optional
-            Certain .xml files indicate shank structure via either "spikeDetection" or "anatomicalDescription" keys.
-            The default is "spikeDetection".
         """
         assert HAVE_LXML, INSTALL_MESSAGE
 
@@ -168,9 +162,6 @@ class NeuroscopeLFPInterface(BaseLFPExtractorInterface):
             Path to .xml file containing device and electrode configuration.
             If unspecified, it will be automatically set as the only .xml file in the same folder as the .dat file.
             The default is None.
-        channel_key : str, optional
-            Certain .xml files indicate shank structure via either "spikeDetection" or "anatomicalDescription" keys.
-            The default is "spikeDetection".
         """
         super().__init__(file_path=file_path, gain=gain, xml_file_path=xml_file_path)
         if xml_file_path is None:

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -421,7 +421,6 @@ def add_electrodes(recording: se.RecordingExtractor, nwbfile=None, metadata: dic
             if nwbfile.electrodes is None:
                 nwbfile.add_electrode_column(name=name, description=des_args["description"], index=des_args["index"])
             else:
-                # build default junk values for data to force add columns later:
                 combine_data = [channel_property_defaults[found_property_types[name]]] * len(nwbfile.electrodes.id)
                 des_args["data"] = combine_data + des_args["data"]
                 elec_columns_append[name] = des_args


### PR DESCRIPTION
## Motivation

The Neuroscope interface (especially its metadata) hadn't been fully used since older versions of nwb-conversion-tools. This updates a  couple of things that came up in the new `add_electrodes` functionality.

For cleanliness, I also separated the Neuroscope utility functions from the primary interfaces.

The biggest actual code changes are to the `get_shank_channels` function which previously used a messy try/except approach to automatically pull group structure from keys of the .xml which may or may not exist across different sessions, with the full `anatomicalDescription` always being the backup. Now it always pulls the full info from `anatomicalDescription` and adds a custom column for if it was used in `spikeDetection` based on the optional existence of that field.

Also added docstrings for the interfaces (this takes up about 75 of the added lines to the changelog).

## How to test the behavior?

Eventually, I really should add explicit metadata tests for formats like this. Right now it only tests if run_conversion() actually succeeds but does not look at the structure of the file explicitly beyond the actual data. Probably best to do that in a more general PR, though.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
