### PR TITLE
Add badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-Status
-======
-
+[![PyPI version](https://badge.fury.io/py/nwb-conversion-tools.svg)](https://badge.fury.io/py/nwb-conversion-tools)
 ![example workflow](https://github.com/catalystneuro/nwb-conversion-tools/actions/workflows/ci-production.yml/badge.svg)
 ![example workflow](https://github.com/catalystneuro/nwb-conversion-tools/actions/workflows/ci-development.yml/badge.svg)
 ![example workflow](https://github.com/catalystneuro/nwb-conversion-tools/actions/workflows/python-publish-v2.yml/badge.svg)
@@ -9,7 +7,6 @@ Status
 [![License](https://img.shields.io/pypi/l/pynwb.svg)](https://github.com/catalystneuro/nwb-conversion-tools/license.txt)
 
 # NWB conversion tools
-[![PyPI version](https://badge.fury.io/py/nwb-conversion-tools.svg)](https://badge.fury.io/py/nwb-conversion-tools)
 
 NWB Conversion Tools is a package for creating NWB files by converting and 
 combining neural data in proprietary formats and adding essential metadata.


### PR DESCRIPTION
fix #273 

## Motivation

Added multiple decorative badges to `readme.md` showing information on workflow status, coverage, documentation, and license.

## How to test the behavior?

Not sure of any way to test these links always return a good image - @bendichter any ideas? I ask because in searching on how to do this, many repos I found had some errors where instead of a badge, it showed up as a broken link. Just wouldn't want that to happen here.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [X] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
