### PR TITLE
small spelling mistake in the NeuroscopeSortingInterface

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -243,7 +243,7 @@ class NeuroscopeSortingInterface(BaseSortingExtractorInterface):
         session_path = Path(self.source_data["folder_path"])
         session_id = session_path.stem
         metadata = NeuroscopeRecordingInterface.get_ecephys_metadata(
-           xml_file_path=str((session_path / f"{session_id}.xml").absolute())
+            xml_file_path=str((session_path / f"{session_id}.xml").absolute())
         )
         metadata.update(UnitProperties=[])
         return metadata


### PR DESCRIPTION
## Motivation

Fix #286 
This should fix the minor spelling error in `NueroScopeSortingInterface`.

## Checklist

- [*] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [*] Have you ensured the PR description clearly describes the problem and solutions?
- [*] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [*] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
