### PR TITLE
dict deep update fix

### DIFF
--- a/nwb_conversion_tools/utils/json_schema.py
+++ b/nwb_conversion_tools/utils/json_schema.py
@@ -33,7 +33,7 @@ def append_replace_dict_in_list(d, ls, k):
         # Index where the value dictionary[k] exists in the list of dicts
         ind = np.where([d[k] == i[k] for i in ls])[0]
         if len(ind) > 0:
-            ls[ind[0]] = d
+            ls[ind[0]].update(d)
         else:
             ls.append(d)
     else:


### PR DESCRIPTION
## Motivation

_dict1_: to be updated
_dict2_: used to update dict1
While using `dict_deep_update()`: for a specific key, if the value is a list of dicts, in that case the base _dict1_ value's list is updated such that the element (each is also a dict) of the list that matches the 'name' key of the _dict2_ is completely replaced.

## How to test the behavior?
```python
dict1 = dict(mainname1 [dict(name='name0',description='desc0',location='location0'),dict(name='name1',description='desc1',location='location1')])
dict2 = dict(mainname1=[dict(name='name0',description='desc0 changed',device='device0 changed')])
from nwb_conversion_tools.utils.json_schema import dict_deep_update
d_out = dict_deep_update(dict1,dict2)
# old behavior: 
d_out 
>> {'mainname1': [{'name': 'name0', 'description': 'desc0 changed', 'device': 'device0 changed'}, {'name': 'name1', 'description': 'desc1', 'location': 'location1'}]}
# new behavior: 
d_out 
>> {'mainname1': [{'name': 'name0', 'description': 'desc0 changed', 'location': 'location0', 'device': 'device0 changed'}, {'name': 'name1', 'description': 'desc1', 'location': 'location1'}]}
```
Note how the in the new case, the first dict is updated so the '**location**' key remains. While in the first case (current) its simply replaced so the '**location**' key, value is gone
## Checklist

- [] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [] Have you ensured the PR description clearly describes the problem and solutions?
- [] Have you checked to ensure that there aren't other open or previously closed [Pull Requests]
