### PR TITLE
Fix Neuroscope group increments

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -42,7 +42,7 @@ def add_recording_extractor_properties(recording_extractor: se.RecordingExtracto
     }
     group_electrode_numbers = [x for channels in channel_groups for x, _ in enumerate(channels)]
     group_nums = [n + 1 for n, channels in enumerate(channel_groups) for _ in channels]
-    group_names = [f"Group{n + 1}" for n in group_nums]
+    group_names = [f"Group{n}" for n in group_nums]
     for channel_id in recording_extractor.get_channel_ids():
         recording_extractor.set_channel_groups(channel_ids=[channel_id], groups=group_nums[channel_map[channel_id]])
         recording_extractor.set_channel_property(


### PR DESCRIPTION
## Motivation

Noticed in the most recent Buzsaki conversion that the group number increment is shifted twice on accident. This is most noticeable on a linear probe, where we know we only have one group but it shows up listed as `Group2`. Less noticeable for multi-shank experiments, which is why we didn't see this before.

## How to test the behavior?

It's on the to-do list to standardize all metadata appearance across interfaces and to automatically check that default structure as well as manually overridden items. Either way, it would catch this kind of thing across the repo.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
