### PR TITLE
Fix stub conversion factor

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -93,6 +93,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
             kwargs.update(channel_ids=self.subset_channels)
 
         recording_extractor = se.SubRecordingExtractor(self.recording_extractor, **kwargs)
+        recording_extractor.set_channel_gains(gains=self.recording_extractor.get_channel_gains())
         return recording_extractor
 
     def run_conversion(

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -83,7 +83,6 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         stub_test : bool, optional (default False)
         """
         kwargs = dict()
-
         if stub_test:
             num_frames = 100
             end_frame = min([num_frames, self.recording_extractor.get_num_frames()])
@@ -92,7 +91,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         if self.subset_channels is not None:
             kwargs.update(channel_ids=self.subset_channels)
 
-        recording_extractor = se.SubRecordingExtractor(self.recording_extractor, **kwargs)
+        recording_extractor = se.SubRecordingExtractor(parent_recording=self.recording_extractor, **kwargs)
         recording_extractor.set_channel_gains(gains=self.recording_extractor.get_channel_gains())
         return recording_extractor
 

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -28,6 +28,7 @@ def subset_shank_channels(recording_extractor: se.RecordingExtractor, xml_file_p
             parent_recording=recording_extractor,
             channel_ids=[channel_id for group in shank_channels for channel_id in group],
         )
+        sub_recording.set_channel_gains(gains=recording_extractor.get_channel_gains())
     else:
         sub_recording = recording_extractor
     return sub_recording

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -28,7 +28,7 @@ except ImportError:
 #   ecephys: https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
 #   ophys: TODO
 #   icephys: TODO
-LOCAL_PATH = Path("E:/GIN/")  # Must be set to "." for CI - temporarily override for local testing
+LOCAL_PATH = Path(".)  # Must be set to "." for CI - temporarily override for local testing
 DATA_PATH = LOCAL_PATH / "ephy_testing_data"
 HAVE_DATA = DATA_PATH.exists()
 

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -28,7 +28,7 @@ except ImportError:
 #   ecephys: https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
 #   ophys: TODO
 #   icephys: TODO
-LOCAL_PATH = Path(".)  # Must be set to "." for CI - temporarily override for local testing
+LOCAL_PATH = Path(".")  # Must be set to "." for CI - temporarily override for local testing
 DATA_PATH = LOCAL_PATH / "ephy_testing_data"
 HAVE_DATA = DATA_PATH.exists()
 


### PR DESCRIPTION
## Motivation

Further debug for writing proper conversion factors to an ElectricalSeries run under `stub_test=True` mode. In general, any use of a `SubRecording` or `SubSorting` does not copy properties, including gains, from the parent class.

## How to test the behavior?
I added new tests specifically for this behavior, at least with the Neuroscope interface. I think most others set their gains automatically rather than manually. I can extend it to other interfaces if you want, though.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
