### PR TITLE
GenericDataChunkIterator improvements

### DIFF
--- a/nwb_conversion_tools/utils/genericdatachunkiterator.py
+++ b/nwb_conversion_tools/utils/genericdatachunkiterator.py
@@ -1,5 +1,5 @@
 """Authors: Cody Baker, Saksham Sharda, and Oliver Ruebel."""
-from typing import Iterable, Optional
+from typing import Iterable, Tuple, Optional
 import numpy as np
 import psutil
 from abc import abstractmethod
@@ -153,7 +153,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         return DataChunk(data=self._get_data(selection=buffer_selection), selection=buffer_selection)
 
     @abstractmethod
-    def _get_data(self, selection: Iterable[slice]) -> np.ndarray:
+    def _get_data(self, selection: Tuple[slice]) -> np.ndarray:
         """
         Retrieve the data specified by the selection using minimal I/O.
 

--- a/nwb_conversion_tools/utils/genericdatachunkiterator.py
+++ b/nwb_conversion_tools/utils/genericdatachunkiterator.py
@@ -1,9 +1,9 @@
 """Authors: Cody Baker, Saksham Sharda, and Oliver Ruebel."""
-from typing import Iterable, Tuple, Optional
+from typing import Iterable, Optional
 import numpy as np
 import psutil
 from abc import abstractmethod
-from itertools import product
+from itertools import product, chain
 
 from hdmf.data_utils import AbstractDataChunkIterator, DataChunk
 
@@ -31,7 +31,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             v[v_ind] = np.floor(next_v / np.min(next_v))
             prod_v = np.prod(v)
         k = np.floor((chunk_bytes / (prod_v * itemsize)) ** (1 / n_dims))
-        self.chunk_shape = tuple([min(int(x), self.maxshape[dim]) for dim, x in enumerate(k * v)])
+        return tuple([min(int(x), self.maxshape[dim]) for dim, x in enumerate(k * v)])
 
     def _set_buffer_shape(self, buffer_gb):
         """
@@ -42,13 +42,10 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         buffer_gb : float
             The maximum amount of RAM to use to buffer the chunks.
         """
-        assert (
-            buffer_gb > 0 and buffer_gb < psutil.virtual_memory().available / 1e9
-        ), f"Not enough memory in system handle buffer_gb of {buffer_gb}!"
         k = np.floor(
             (buffer_gb * 1e9 / (np.prod(self.chunk_shape) * self.dtype.itemsize)) ** (1 / len(self.chunk_shape))
         )
-        self.buffer_shape = tuple([min(int(x), self.maxshape[j]) for j, x in enumerate(k * np.array(self.chunk_shape))])
+        return tuple([min(int(x), self.maxshape[j]) for j, x in enumerate(k * np.array(self.chunk_shape))])
 
     def __init__(
         self,
@@ -58,10 +55,15 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         chunk_shape: Optional[tuple] = None,
     ):
         """
-        Break a dataset into buffers containing chunks, with the chunk as they are written into the H5 dataset.
+        Break a dataset into buffers containing multiple chunks to be written into an HDF5 dataset.
 
-        Basic users should set the buffer_gb argument to as much free RAM space as can be safely allowed.
-        Advanced users are offered full control over the shape paramters for the buffer and the chunks.
+        Basic users should set the buffer_gb argument to as much free RAM space as can be safely allocated.
+        Advanced users are offered full control over the shape paramters for the buffer and the chunks; however,
+        the chunk shape must perfectly divide the buffer shape along each axis.
+
+        HDF5 also recommends not setting chunk_mb greater than 1 MB for optimal caching speeds.
+        See https://support.hdfgroup.org/HDF5/doc/TechNotes/TechNote-HDF5-ImprovingIOPerformanceCompressedDatasets.pdf
+        for more details.
 
         Parameters
         ----------
@@ -72,7 +74,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             Manually defined shape of the buffer. Defaults to None.
         chunk_mb : float, optional
             If chunk_shape is not specified, it will be inferred as the smallest chunk below the chunk_mb threshold.
-            H5 reccomends setting this to around 1 MB (our default) for optimal performance.
+            Defaults to 1 MB.
         chunk_shape : tuple, optional
             Manually defined shape of the chunks. Defaults to None.
         """
@@ -90,31 +92,51 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         self._maxshape = self._get_maxshape()
         self._dtype = self._get_dtype()
         if chunk_shape is None:
-            self._set_chunk_shape(chunk_mb=chunk_mb)
+            self.chunk_shape = self._set_chunk_shape(chunk_mb=chunk_mb)
         else:
-            assert all(
-                np.array(chunk_shape) <= self.maxshape
-            ), f"Some dimensions of chunk_shape ({self.chunk_shape}) exceed the data dimensions ({self.maxshape})!"
             self.chunk_shape = chunk_shape
         if buffer_shape is None:
-            self._set_buffer_shape(buffer_gb=buffer_gb)
+            self.buffer_shape = self._set_buffer_shape(buffer_gb=buffer_gb)
         else:
-            array_buffer_shape = np.array(buffer_shape)
-            assert all(
-                array_buffer_shape <= self.maxshape
-            ), f"Some dimensions of buffer_shape ({self.buffer_shape}) exceed the data dimensions ({self.maxshape})!"
-            assert all(
-                array_buffer_shape >= self.chunk_shape
-            ), f"Some dimensions of chunk_shape ({self.chunk_shape}) exceed the manual buffer shape ({buffer_shape})!"
-            assert all(array_buffer_shape % self.chunk_shape == 0), (
-                f"Some dimensions of chunk_shape ({self.chunk_shape}) do not "
-                f"evenly divide the manual buffer shape ({buffer_shape})!"
-            )
             self.buffer_shape = buffer_shape
+            buffer_gb = np.prod(self.buffer_shape) * np.dtype(self._dtype).itemsize / 1e9
 
-        self.num_buffers = np.ceil(np.array(self.maxshape) / self.buffer_shape).astype(int)
-        self.buffer_index_generator = product(*[range(x) for x in self.num_buffers])
-        self.chunk_selection_in_buffer_generator = iter(())  # So first call to next() fills buffer
+        array_chunk_shape = np.array(self.chunk_shape)
+        array_buffer_shape = np.array(self.buffer_shape)
+        assert buffer_gb > 0, f"buffer_gb ({buffer_gb}) must be greater than zero!"
+        assert (
+            buffer_gb < psutil.virtual_memory().available / 1e9
+        ), f"Not enough memory in system handle buffer_gb of {buffer_gb}!"
+        assert all(array_chunk_shape > 0), f"Some dimensions of chunk_shape ({self.chunk_shape}) are less than zero!"
+        assert all(array_buffer_shape > 0), f"Some dimensions of buffer_shape ({self.buffer_shape}) are less than zero!"
+        assert all(
+            array_buffer_shape <= self.maxshape
+        ), f"Some dimensions of buffer_shape ({self.buffer_shape}) exceed the data dimensions ({self.maxshape})!"
+        assert all(
+            array_chunk_shape <= array_buffer_shape
+        ), f"Some dimensions of chunk_shape ({self.chunk_shape}) exceed the manual buffer shape ({self.buffer_shape})!"
+        assert all(array_buffer_shape % array_chunk_shape == 0), (
+            f"Some dimensions of chunk_shape ({self.chunk_shape}) do not "
+            f"evenly divide the buffer shape ({self.buffer_shape})!"
+        )
+
+        self.buffer_selection_generator = (
+            tuple([slice(lower_bound, upper_bound) for lower_bound, upper_bound in zip(lower_bounds, upper_bounds)])
+            for lower_bounds, upper_bounds in zip(
+                product(
+                    *[
+                        range(0, max_shape_axis, buffer_shape_axis)
+                        for max_shape_axis, buffer_shape_axis in zip(self.maxshape, self.buffer_shape)
+                    ]
+                ),
+                product(
+                    *[
+                        chain(range(buffer_shape_axis, max_shape_axis, buffer_shape_axis), [max_shape_axis])
+                        for max_shape_axis, buffer_shape_axis in zip(self.maxshape, self.buffer_shape)
+                    ]
+                ),
+            )
+        )
 
     def recommended_chunk_shape(self) -> tuple:
         return self.chunk_shape
@@ -125,96 +147,13 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
     def __iter__(self):
         return self
 
-    def _buffer_map(self, buffer_index: tuple) -> Iterable[slice]:
-        """Map the buffer_index (permutations starting with all axes zero) to the slice selection of the full shape."""
-        return tuple(
-            [
-                slice(n * self.buffer_shape[j], min((n + 1) * self.buffer_shape[j], self.maxshape[j]))
-                for j, n in enumerate(buffer_index)
-            ]
-        )
-
-    def _chunk_map(
-        self, chunk_selection_in_buffer: Iterable[slice], buffer_selection: Iterable[slice]
-    ) -> Iterable[slice]:
-        """Map the chunk selection within the buffer to the full shape by shifting by the current buffer selection."""
-        return tuple(
-            [
-                slice(buffer_axis.start + chunk_axis.start, buffer_axis.start + chunk_axis.stop)
-                for chunk_axis, buffer_axis in zip(chunk_selection_in_buffer, buffer_selection)
-            ]
-        )
-
-    def _fill_buffer(self):
-        """Fill the data into the buffer using _get_data."""
-        buffer_index = next(self.buffer_index_generator)
-        self.buffer_selection = self._buffer_map(buffer_index=buffer_index)
-        self.buffer_data = np.array(self._get_data(selection=self.buffer_selection))
-        if any(np.array(buffer_index) + 1 == self.num_buffers):
-            this_buffer_shape = [buffer_axis.stop - buffer_axis.start for buffer_axis in self.buffer_selection]
-            self.chunk_selection_in_buffer_generator = (
-                tuple(
-                    [
-                        slice(start_axis, min(start_axis + chunk_axis, buffer_axis))
-                        for start_axis, buffer_axis, chunk_axis in zip(
-                            slice_starts, this_buffer_shape, self.chunk_shape
-                        )
-                    ]
-                )
-                for slice_starts in product(
-                    *[
-                        range(0, buffer_axis, chunk_axis)
-                        for buffer_axis, chunk_axis in zip(this_buffer_shape, self.chunk_shape)
-                    ]
-                )
-            )
-            # TODO - technically, even this reduction of the min call can be improved by using itertools.chain
-            # to couple an efficient generator similar to below for all chunks not on the boundary with
-            # another generator just for the edges. Wouldn't even need calls to min in that case.
-            # Also, the same logic applies to how we generate buffer selections of interior vs. boundary buffers.
-            # If buffer_shape is fairly small, then the repeated operations of min in _buffer_map and above boundary
-            # checking logical could be a slowdown. Would be faster to pre-compute with chains and zip together.
-        else:
-            self.chunk_selection_in_buffer_generator = (
-                tuple(
-                    [
-                        slice(start_axis, start_axis + chunk_axis)
-                        for start_axis, chunk_axis in zip(slice_starts, self.chunk_shape)
-                    ]
-                )
-                for slice_starts in product(
-                    *[
-                        range(0, buffer_axis, chunk_axis)
-                        for buffer_axis, chunk_axis in zip(self.buffer_shape, self.chunk_shape)
-                    ]
-                )
-            )
-
-    def _get_chunk_from_buffer(self) -> (np.ndarray, tuple):
-        """Retrieve the data and selection from a chunk within the buffer."""
-        try:
-            chunk_selection_in_buffer = next(self.chunk_selection_in_buffer_generator)
-        except StopIteration:
-            try:
-                self._fill_buffer()
-                chunk_selection_in_buffer = next(self.chunk_selection_in_buffer_generator)
-            except StopIteration:
-                self.buffer_data = None
-                self.buffer_selection = None
-                raise StopIteration
-        return self.buffer_data[chunk_selection_in_buffer], chunk_selection_in_buffer
-
     def __next__(self) -> DataChunk:
         """Retrieve the next DataChunk object from the buffer, refilling the buffer if necessary."""
-        chunk_data, chunk_selection_in_buffer = self._get_chunk_from_buffer()
-        chunk_selection = self._chunk_map(
-            chunk_selection_in_buffer=chunk_selection_in_buffer, buffer_selection=self.buffer_selection
-        )
-        data_chunk = DataChunk(data=chunk_data, selection=chunk_selection)
-        return data_chunk
+        buffer_selection = next(self.buffer_selection_generator)
+        return DataChunk(data=self._get_data(selection=buffer_selection), selection=buffer_selection)
 
     @abstractmethod
-    def _get_data(self, selection: Tuple[slice]) -> np.ndarray:
+    def _get_data(self, selection: Iterable[slice]) -> np.ndarray:
         """
         Retrieve the data specified by the selection using minimal I/O.
 

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -29,7 +29,7 @@ except ImportError:
 #   ecephys: https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
 #   ophys: TODO
 #   icephys: TODO
-LOCAL_PATH = Path("/home/jovyan")  # Must be set to "." for CI - temporarily override for local testing
+LOCAL_PATH = Path(".")  # Must be set to "." for CI - temporarily override for local testing
 DATA_PATH = LOCAL_PATH / "ephy_testing_data"
 HAVE_DATA = DATA_PATH.exists()
 

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -29,7 +29,7 @@ except ImportError:
 #   ecephys: https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
 #   ophys: TODO
 #   icephys: TODO
-LOCAL_PATH = Path(".")  # Must be set to "." for CI - temporarily override for local testing
+LOCAL_PATH = Path("/home/jovyan")  # Must be set to "." for CI - temporarily override for local testing
 DATA_PATH = LOCAL_PATH / "ephy_testing_data"
 HAVE_DATA = DATA_PATH.exists()
 
@@ -92,7 +92,7 @@ if HAVE_PARAMETERIZED and HAVE_DATA:
 
         @parameterized.expand(parameterized_recording_list)
         def test_convert_recording_extractor_to_nwb(self, recording_interface, interface_kwargs):
-            nwbfile_path = self.savedir / f"{recording_interface.__name__}.nwb"
+            nwbfile_path = str(self.savedir / f"{recording_interface.__name__}.nwb")
 
             class TestConverter(NWBConverter):
                 data_interface_classes = dict(TestRecording=recording_interface)
@@ -105,7 +105,9 @@ if HAVE_PARAMETERIZED and HAVE_DATA:
             check_recordings_equal(RX1=recording, RX2=nwb_recording, check_times=False, return_scaled=True)
             # Technically, check_recordings_equal only tests a snippet of data. Above tests are for metadata mostly.
             # For GIN test data, sizes should be OK to load all into RAM even on CI
-            npt.assert_array_equal(x=recording.get_traces(), y=nwb_recording.get_traces())
+            npt.assert_array_equal(
+                x=recording.get_traces(return_scaled=False), y=nwb_recording.get_traces(return_scaled=False)
+            )
 
         @parameterized.expand(
             [
@@ -120,7 +122,7 @@ if HAVE_PARAMETERIZED and HAVE_DATA:
             ]
         )
         def test_convert_sorting_extractor_to_nwb(self, sorting_interface, interface_kwargs):
-            nwbfile_path = self.savedir / f"{sorting_interface.__name__}.nwb"
+            nwbfile_path = str(self.savedir / f"{sorting_interface.__name__}.nwb")
 
             class TestConverter(NWBConverter):
                 data_interface_classes = dict(TestSorting=sorting_interface)

--- a/tests/test_gin.py
+++ b/tests/test_gin.py
@@ -1,6 +1,7 @@
 import tempfile
 import unittest
 from pathlib import Path
+import numpy.testing as npt
 
 from spikeextractors import NwbRecordingExtractor, NwbSortingExtractor
 from spikeextractors.testing import check_recordings_equal, check_sortings_equal
@@ -102,6 +103,9 @@ if HAVE_PARAMETERIZED and HAVE_DATA:
             nwb_recording = NwbRecordingExtractor(file_path=nwbfile_path)
             check_recordings_equal(RX1=recording, RX2=nwb_recording, check_times=False, return_scaled=False)
             check_recordings_equal(RX1=recording, RX2=nwb_recording, check_times=False, return_scaled=True)
+            # Technically, check_recordings_equal only tests a snippet of data. Above tests are for metadata mostly.
+            # For GIN test data, sizes should be OK to load all into RAM even on CI
+            npt.assert_array_equal(x=recording.get_traces(), y=nwb_recording.get_traces())
 
         @parameterized.expand(
             [


### PR DESCRIPTION
## Motivation

Moderate performance increase and massive code simplification based on suggestions by @bendichter. Pending other suggestions, this will also be the form of the class I'll submit upstream to `hdmf`. It's come a long way from the first versions and now that it's pared down to basics, I can't think of anything left that would increase performance from this side of things.

Performance test on a 957.5s SpikeGLX example file (384 channels) using default chunk/buffer sizes (1MB/1GB, respectively)...

- New method: ~592s
- Previous method (master branch):  ~624s

This raises the speed efficiency to ~161% of relative recording length for Neuropixels, meaning we can write a minute of such data in around ~37s.

Details from top to bottom;

1. Updated default shape setters to return their values rather than set the attribute, to be more consistent in `__init__` with the attribute setting from argument specification. Also changes their names to reflect this. Changes are intended mostly for readability.
2. Updated docstring to emphasize the distinction of chunk (HDF5 handled) vs. buffer (what this class operates with, ideally spans multiple chunks).
3.  Moved assertions to also apply to whatever gets generated from default shape methods; but mathematically, they are guaranteed to pass. Just holding my own methods equally accountable as a user's manual specification.
4. Massive code simplification to selection mapping. Chunks are no longer extracted by us, and the buffer is expressly passed.
5. Also managed to solve the remaining 'to-do' optimization that's been hanging around related to application of the `min` function to safely constrain the upper bound of the buffer slices. I've always known that was a slow down, and knew of a potential way around it using `itertools.chain`, but couldn't figure out the multinomial form of it when applied after the `itertools.product` under the previous method. Instead, refactoring the generator to cover actual lower/upper bounds instead of the permutation indices actually allows the `itertools.chain` to be added prior to `itertools.product`, which saves this complexity. This new method is much more efficient and compacts all details of the mapping process into a single generator created at `__init__`, and that's all that is ever used to perform selections.

## How to test the behavior?
```
pytest
```

Updated `test_gin` to test entire equality of data array rather than just the snippet from inside `check_recordings_equal`. Mostly for verification that the `GenericDataChunkIterator` handles endcaps correctly.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
