### PR TITLE
re-adding UnitProperties to metadata schema in SortingExtractorInterface

### DIFF
--- a/nwb_conversion_tools/utils/basenwbephyswriter.py
+++ b/nwb_conversion_tools/utils/basenwbephyswriter.py
@@ -505,9 +505,6 @@ class BaseNwbEphysWriter(ABC):
         if fs is None:
             raise ValueError("Writing a SortingExtractor to an NWBFile requires a known sampling frequency!")
 
-        if "units" not in self.metadata:
-            self.metadata["units"] = []
-
         if self._conversion_ops["unit_property_descriptions"] is None:
             property_descriptions = dict(_default_sorting_property_descriptions)
         else:
@@ -542,12 +539,6 @@ class BaseNwbEphysWriter(ABC):
                         set(self.nwbfile.electrodes.id.data)
                     ), "sorting and recording extractor should be for the same data"
                     unit_columns[prop].update(table=self.nwbfile.electrodes)
-
-        # 2. fill with provided custom descriptions
-        for x in self.metadata["units"]:
-            if x["name"] not in list(unit_columns):
-                raise ValueError(f'"{x["name"]}" not a property of sorting object, set it first and rerun')
-            unit_columns[x["name"]]["description"] = x["description"]
 
         # 3. For existing electrodes table, add the additional columns and fill with default data:
         add_properties_to_dynamictable(self.nwbfile, "units", unit_columns, defaults)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -31,6 +31,7 @@ from nwb_conversion_tools.utils import create_si013_example, export_ecephys_to_n
 from nwb_conversion_tools.datainterfaces.ecephys.basesortingextractorinterface import BaseSortingExtractorInterface
 from nwb_conversion_tools.utils.conversion_tools import get_default_nwbfile_metadata
 
+
 @pytest.mark.parametrize("data_interface", interface_list)
 def test_interface_source_schema(data_interface):
     schema = data_interface.get_source_schema()
@@ -233,14 +234,13 @@ def test_sorting_extractor_interface():
 
         def __init__(self):
             super(TempSortingInterface, self).__init__()
-            self.sorting_extractor.load_from_extractor(sortingextractor,
-                                                       copy_unit_properties=True,
-                                                       copy_unit_spike_features=True)
+            self.sorting_extractor.load_from_extractor(
+                sortingextractor, copy_unit_properties=True, copy_unit_spike_features=True
+            )
 
         def get_metadata(self):
             metadata = super(TempSortingInterface, self).get_metadata()
-            metadata["Ecephys"] = dict(UnitProperties=[dict(name="custom_prop",
-                                                            description="custom description")])
+            metadata["Ecephys"] = dict(UnitProperties=[dict(name="custom_prop", description="custom description")])
             return metadata
 
     class TempSortingNWBConverter(NWBConverter):
@@ -250,13 +250,13 @@ def test_sorting_extractor_interface():
     converter = TempSortingNWBConverter(source_data)
 
     # make custom metadata with UnitProperties:
-    nwbfile_path = Path(mkdtemp())/"test_sorting_extractor.nwb"
+    nwbfile_path = Path(mkdtemp()) / "test_sorting_extractor.nwb"
     converter.run_conversion(nwbfile_path=str(nwbfile_path), overwrite=True)
 
     with NWBHDF5IO(path=str(nwbfile_path), mode="r") as io:
         nwbfile = io.read()
         assert "custom_prop" in nwbfile.units.colnames
-        assert nwbfile.units['custom_prop'].description == "custom description"
-        np.testing.assert_array_equal(nwbfile.units["custom_prop"].data[()],
-                                      np.zeros(len(sortingextractor.get_unit_ids())))
-
+        assert nwbfile.units["custom_prop"].description == "custom description"
+        np.testing.assert_array_equal(
+            nwbfile.units["custom_prop"].data[()], np.zeros(len(sortingextractor.get_unit_ids()))
+        )

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -27,6 +27,9 @@ from nwb_conversion_tools import (
     interface_list,
 )
 
+from nwb_conversion_tools.utils import create_si013_example, export_ecephys_to_nwb
+from nwb_conversion_tools.datainterfaces.ecephys.basesortingextractorinterface import BaseSortingExtractorInterface
+from nwb_conversion_tools.utils.conversion_tools import get_default_nwbfile_metadata
 
 @pytest.mark.parametrize("data_interface", interface_list)
 def test_interface_source_schema(data_interface):
@@ -217,3 +220,43 @@ def test_movie_interface():
             assert metadata["Behavior"]["Movies"][0]["comments"] == nwbfile.acquisition[custom_name].comments
 
         rmtree(test_dir)
+
+
+def test_sorting_extractor_interface():
+    output = create_si013_example(seed=0)
+    sortingextractor = output[3]
+    for unit_id in sortingextractor.get_unit_ids():
+        sortingextractor.set_unit_property(unit_id, "custom_prop", 0)
+
+    class TempSortingInterface(BaseSortingExtractorInterface):
+        SX = se.NumpySortingExtractor
+
+        def __init__(self):
+            super(TempSortingInterface, self).__init__()
+            self.sorting_extractor.load_from_extractor(sortingextractor,
+                                                       copy_unit_properties=True,
+                                                       copy_unit_spike_features=True)
+
+        def get_metadata(self):
+            metadata = super(TempSortingInterface, self).get_metadata()
+            metadata["Ecephys"] = dict(UnitProperties=[dict(name="custom_prop",
+                                                            description="custom description")])
+            return metadata
+
+    class TempSortingNWBConverter(NWBConverter):
+        data_interface_classes = dict(TempSortingInterface=TempSortingInterface)
+
+    source_data = dict(TempSortingInterface=dict())
+    converter = TempSortingNWBConverter(source_data)
+
+    # make custom metadata with UnitProperties:
+    nwbfile_path = Path(mkdtemp())/"test_sorting_extractor.nwb"
+    converter.run_conversion(nwbfile_path=str(nwbfile_path), overwrite=True)
+
+    with NWBHDF5IO(path=str(nwbfile_path), mode="r") as io:
+        nwbfile = io.read()
+        assert "custom_prop" in nwbfile.units.colnames
+        assert nwbfile.units['custom_prop'].description == "custom description"
+        np.testing.assert_array_equal(nwbfile.units["custom_prop"].data[()],
+                                      np.zeros(len(sortingextractor.get_unit_ids())))
+


### PR DESCRIPTION
## Motivation

The PR merge #230 did not take care of the ability to pass 'UnitProperty' metadata to any `sortingextractorinterface`. It was expecting any custom properties to exist in `self.metadata["units"]=dict(prop1='desc', prop2='desc2')`. The old way of doing this was `self.metadata["Ecephys"]["UnitProperties"]= dict(prop1='desc', prop2='desc2')`.
This PR adds this back. 

## How to test the behavior?
The below, should run with a specific `sortingextractorinterface`
```python
from jsonschema import validate

metadata = sortingextractorinterface.get_metadata()
metadata["Ecephys"] = dict(UnitProperties=[dict(name='prop_name1', description='description1'), 
                                           dict(name='prop_name1', description='description1')])
validate(instance= metadata, schema=sortingextractorinterface.get_metadata_schema()) # this should run fine
sortingextractorinterface.run_conversion(nwbfile, metadata=metadata)
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
