### PR TITLE
Test python versions

### DIFF
--- a/.github/workflows/full-tests-linux.yml
+++ b/.github/workflows/full-tests-linux.yml
@@ -1,5 +1,5 @@
 name: Full tests on Linux
-on: push
+on: pull_request
 jobs:
   run:
     name: Full tests on Linux

--- a/.github/workflows/full-tests-linux.yml
+++ b/.github/workflows/full-tests-linux.yml
@@ -1,18 +1,20 @@
 name: Full tests on Linux
-on: pull_request
+on: push
 jobs:
   run:
     name: Full tests on Linux
     runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow --tags
-    - name: Setup Python
+    - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python-version }}
     - name: Install this package and pytest, on development mode
       env:
           NWB_CONVERSION_INSTALL_MODE: development

--- a/.github/workflows/full-tests-linux.yml
+++ b/.github/workflows/full-tests-linux.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow --tags

--- a/.github/workflows/full-tests-mac-windows.yml
+++ b/.github/workflows/full-tests-mac-windows.yml
@@ -8,13 +8,14 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macos-latest", "windows-latest"]
+        python-version: [3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow --tags
-    - name: Setup Python
+    - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python-version }}
     - name: Install this package and pytest, on development mode
       env:
           NWB_CONVERSION_INSTALL_MODE: development


### PR DESCRIPTION
fix #305 

## Motivation
Currently, we hard-require Python 3.7 on all devices. This is beginning to be a bit harsh, so investigating how much needs to be done to loosen it.

As seen from the first run, linux works fine on 3.8 but begins running into installation problems in 3.9: https://github.com/catalystneuro/nwb-conversion-tools/runs/4373195033?check_suite_focus=true

Will investigate to see if this can be easily reconciled by basic version bumps on dependencies, or if Python version-specific requirements are the way to go.

## How to test the behavior?
Adjusted main linux workflow to expand a matrix over Python versions. Will adjust others as well pending some investigation into merging codecov reports, since some of our tests are now spanning multiple workflow runs.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [X] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
