### PR TITLE
Remove convert_data() deprecation warning

### DIFF
--- a/nwb_conversion_tools/basedatainterface.py
+++ b/nwb_conversion_tools/basedatainterface.py
@@ -1,23 +1,27 @@
 """Authors: Cody Baker and Ben Dichter."""
 from abc import abstractmethod, ABC
-import warnings
 
-from .utils.json_schema import get_base_schema, get_schema_from_method_signature, fill_defaults
+from .utils.json_schema import get_base_schema, get_schema_from_method_signature
 
 
 class BaseDataInterface(ABC):
+    """Abstract class defining the structure of all DataInterfaces."""
+
     @classmethod
     def get_source_schema(cls):
+        """Infer the JSON schema for the source_data from the method signature (annotation typing)."""
         return get_schema_from_method_signature(cls.__init__, exclude=["source_data"])
 
     @classmethod
     def get_conversion_options_schema(cls):
+        """Infer the JSON schema for the conversion options from the method signature (annotation typing)."""
         return get_schema_from_method_signature(cls.run_conversion, exclude=["nwbfile", "metadata"])
 
     def __init__(self, **source_data):
         self.source_data = source_data
 
     def get_metadata_schema(self):
+        """Retrieve JSON schema for metadata."""
         metadata_schema = get_base_schema(
             id_="metadata.schema.json",
             root=True,
@@ -28,20 +32,14 @@ class BaseDataInterface(ABC):
         return metadata_schema
 
     def get_metadata(self):
-        """Child DataInterface classes should override this to match their metadata"""
+        """Child DataInterface classes should override this to match their metadata."""
         return dict()
 
     def get_conversion_options(self):
-        """Child DataInterface classes should override this to match their conversion options"""
+        """Child DataInterface classes should override this to match their conversion options."""
         return dict()
 
     @abstractmethod
     def run_conversion(self, nwbfile_path: str, metadata: dict, **conversion_options):
+        """Child DataInterface classes should override this to perform their conversion."""
         pass
-
-    def convert_data(self, nwbfile_path, metadata, **conversion_options):
-        warnings.warn(
-            "The convert_data method should now be renamed to run_conversion " "as of nwb-conversion-tools v0.6.0",
-            DeprecationWarning,
-        )
-        self.run_conversion(nwbfile_path, metadata, **conversion_options)


### PR DESCRIPTION
## Motivation
A long time ago, we renamed `convert_data` to `run_conversion` to match the syntax between `DataInterfaces` and the `NWBConverter`. We provided a deprecation warning for this change for at least six months, and with the new major version so much else is changing we might as well get around to actually removing this.

Also added some missing docstrings while I was working in that class.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
