### PR TITLE
deep_dict_update list appending bug fix in default converter

### DIFF
--- a/nwb_conversion_tools/utils/json_schema.py
+++ b/nwb_conversion_tools/utils/json_schema.py
@@ -133,9 +133,7 @@ def dict_deep_update(
             d[k] = dict_deep_update(d.get(k, None), v, append_list=append_list, remove_repeats=remove_repeats)
         elif append_list and isinstance(v, list):
             for vv in v:
-                d[k] = append_replace_dict_in_list(
-                    d.get(k, []), vv, compare_key, list_dict_deep_update, remove_repeats
-                )
+                d[k] = append_replace_dict_in_list(d.get(k, []), vv, compare_key, list_dict_deep_update, remove_repeats)
         else:
             d[k] = v
     return d

--- a/nwb_conversion_tools/utils/json_schema.py
+++ b/nwb_conversion_tools/utils/json_schema.py
@@ -134,7 +134,7 @@ def dict_deep_update(
         elif append_list and isinstance(v, list):
             for vv in v:
                 d[k] = append_replace_dict_in_list(
-                    d.get(k, None), vv, compare_key, list_dict_deep_update, remove_repeats
+                    d.get(k, []), vv, compare_key, list_dict_deep_update, remove_repeats
                 )
         else:
             d[k] = v

--- a/tests/test_json_schema_utils.py
+++ b/tests/test_json_schema_utils.py
@@ -86,19 +86,19 @@ def test_dict_deep_update_3():
     b2 = dict(a=3, b="compare", c=b1)
 
     a3 = dict(a2, ls1=[1, 2, "test"])
-    b3 = dict(b2, ls1=[3, 1, "test2"])
+    b3 = dict(b2, ls1=[3, 1, "test2"], ls3=[2,3,'test4'])
     # test whether repeated values are not removed
     result3_1 = dict_deep_update(a3, b3, remove_repeats=False)
-    correct_result = dict(dict_deep_update(a2, b2), ls1=[1, 1, 2, 3, "test", "test2"])
+    correct_result = dict(dict_deep_update(a2, b2), ls1=[1, 1, 2, 3, "test", "test2"], ls3=[2,3,'test4'])
     compare_dicts(result3_1, correct_result)
     # test removing repeats
     result3_1 = dict_deep_update(a3, b3)
-    correct_result = dict(dict_deep_update(a2, b2), ls1=[1, 2, 3, "test", "test2"])
+    correct_result = dict(dict_deep_update(a2, b2), ls1=[1, 2, 3, "test", "test2"], ls3=[2,3,'test4'])
     compare_dicts(result3_1, correct_result)
 
     # 3.2 test without append: in this case ls1 would be overwritten
     result3_2 = dict_deep_update(a3, b3, append_list=False)
-    correct_result = dict(dict_deep_update(a2, b2), ls1=b3["ls1"])
+    correct_result = dict(dict_deep_update(a2, b2), ls1=b3["ls1"], ls3=[2,3,'test4'])
     compare_dicts(result3_2, correct_result)
 
 

--- a/tests/test_json_schema_utils.py
+++ b/tests/test_json_schema_utils.py
@@ -86,19 +86,19 @@ def test_dict_deep_update_3():
     b2 = dict(a=3, b="compare", c=b1)
 
     a3 = dict(a2, ls1=[1, 2, "test"])
-    b3 = dict(b2, ls1=[3, 1, "test2"], ls3=[2,3,'test4'])
+    b3 = dict(b2, ls1=[3, 1, "test2"], ls3=[2, 3, "test4"])
     # test whether repeated values are not removed
     result3_1 = dict_deep_update(a3, b3, remove_repeats=False)
-    correct_result = dict(dict_deep_update(a2, b2), ls1=[1, 1, 2, 3, "test", "test2"], ls3=[2,3,'test4'])
+    correct_result = dict(dict_deep_update(a2, b2), ls1=[1, 1, 2, 3, "test", "test2"], ls3=[2, 3, "test4"])
     compare_dicts(result3_1, correct_result)
     # test removing repeats
     result3_1 = dict_deep_update(a3, b3)
-    correct_result = dict(dict_deep_update(a2, b2), ls1=[1, 2, 3, "test", "test2"], ls3=[2,3,'test4'])
+    correct_result = dict(dict_deep_update(a2, b2), ls1=[1, 2, 3, "test", "test2"], ls3=[2, 3, "test4"])
     compare_dicts(result3_1, correct_result)
 
     # 3.2 test without append: in this case ls1 would be overwritten
     result3_2 = dict_deep_update(a3, b3, append_list=False)
-    correct_result = dict(dict_deep_update(a2, b2), ls1=b3["ls1"], ls3=[2,3,'test4'])
+    correct_result = dict(dict_deep_update(a2, b2), ls1=b3["ls1"], ls3=[2, 3, "test4"])
     compare_dicts(result3_2, correct_result)
 
 


### PR DESCRIPTION
## Motivation

Fix #314 
This PR fixes the bug found in updating two dicts (dict a, b) when there is a non existing key in dict a but dict b has the value of the key as a list. 

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
