### PR TITLE
Progress bars for recording iterators

### DIFF
--- a/nwb_conversion_tools/utils/genericdatachunkiterator.py
+++ b/nwb_conversion_tools/utils/genericdatachunkiterator.py
@@ -102,7 +102,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             self.progress_bar_options = progress_bar_options
         else:
             self.progress_bar_options = dict()
-        progress_bar_defaults = dict(disable=True, position=0, leave=False)
+        progress_bar_defaults = dict(disable=True, leave=False)
         for default_key, default_value in progress_bar_defaults.items():
             if default_key not in self.progress_bar_options:
                 self.progress_bar_options.update({default_key: default_value})
@@ -147,7 +147,6 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             try:
                 from tqdm import tqdm
 
-                print(self.progress_bar_options)
                 self.progress_bar = tqdm(total=self.num_buffers, **self.progress_bar_options)
             except ImportError:
                 warn(

--- a/nwb_conversion_tools/utils/genericdatachunkiterator.py
+++ b/nwb_conversion_tools/utils/genericdatachunkiterator.py
@@ -1,9 +1,11 @@
 """Authors: Cody Baker, Saksham Sharda, and Oliver Ruebel."""
+import sys
 from typing import Iterable, Tuple, Optional
 import numpy as np
 import psutil
 from abc import abstractmethod
 from itertools import product, chain
+from tqdm import tqdm
 
 from hdmf.data_utils import AbstractDataChunkIterator, DataChunk
 
@@ -123,6 +125,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             f"evenly divide the buffer shape ({self.buffer_shape})!"
         )
 
+        self.num_buffers = np.prod(np.ceil(array_maxshape / array_buffer_shape))
         self.buffer_selection_generator = (
             tuple([slice(lower_bound, upper_bound) for lower_bound, upper_bound in zip(lower_bounds, upper_bounds)])
             for lower_bounds, upper_bounds in zip(

--- a/nwb_conversion_tools/utils/recordingextractordatachunkiterator.py
+++ b/nwb_conversion_tools/utils/recordingextractordatachunkiterator.py
@@ -1,5 +1,6 @@
 """Authors: Cody Baker and Saksham Sharda."""
 from typing import Tuple, Iterable
+from tqdm import tqdm
 
 from spikeextractors import RecordingExtractor
 
@@ -16,9 +17,13 @@ class RecordingExtractorDataChunkIterator(GenericDataChunkIterator):
         buffer_shape: tuple = None,
         chunk_mb: float = None,
         chunk_shape: tuple = None,
+        display_progress: bool = True,
     ):
         self.recording = recording
+        self.display_progress = display_progress
         self.channel_ids = recording.get_channel_ids()
+        if self.display_progress:
+            self.progress_bar = tqdm(total=self.num_buffers, position=0, leave=False)
         super().__init__(buffer_gb=buffer_gb, buffer_shape=buffer_shape, chunk_mb=chunk_mb, chunk_shape=chunk_shape)
 
     def _get_data(self, selection: Tuple[slice]) -> Iterable:
@@ -34,3 +39,13 @@ class RecordingExtractorDataChunkIterator(GenericDataChunkIterator):
 
     def _get_maxshape(self):
         return (self.recording.get_num_frames(), self.recording.get_num_channels())
+
+    def __next__(self):
+        if self.display_progress:
+            self.progress_bar.update(n=1)
+        try:
+            super().__next__()
+        except StopIteration:
+            if self.display_progress:
+                self.progress_bar.write("\n")  # Allows text to be written to new lines after completion
+            raise StopIteration

--- a/nwb_conversion_tools/utils/recordingextractordatachunkiterator.py
+++ b/nwb_conversion_tools/utils/recordingextractordatachunkiterator.py
@@ -1,6 +1,5 @@
 """Authors: Cody Baker and Saksham Sharda."""
-from typing import Tuple, Iterable
-from tqdm import tqdm
+from typing import Tuple, Iterable, Optional
 
 from spikeextractors import RecordingExtractor
 
@@ -17,14 +16,17 @@ class RecordingExtractorDataChunkIterator(GenericDataChunkIterator):
         buffer_shape: tuple = None,
         chunk_mb: float = None,
         chunk_shape: tuple = None,
-        display_progress: bool = True,
+        progress_bar_options: Optional[dict] = None,
     ):
         self.recording = recording
-        self.display_progress = display_progress
         self.channel_ids = recording.get_channel_ids()
-        if self.display_progress:
-            self.progress_bar = tqdm(total=self.num_buffers, position=0, leave=False)
-        super().__init__(buffer_gb=buffer_gb, buffer_shape=buffer_shape, chunk_mb=chunk_mb, chunk_shape=chunk_shape)
+        super().__init__(
+            buffer_gb=buffer_gb,
+            buffer_shape=buffer_shape,
+            chunk_mb=chunk_mb,
+            chunk_shape=chunk_shape,
+            progress_bar_options=progress_bar_options,
+        )
 
     def _get_data(self, selection: Tuple[slice]) -> Iterable:
         return self.recording.get_traces(
@@ -39,13 +41,3 @@ class RecordingExtractorDataChunkIterator(GenericDataChunkIterator):
 
     def _get_maxshape(self):
         return (self.recording.get_num_frames(), self.recording.get_num_channels())
-
-    def __next__(self):
-        if self.display_progress:
-            self.progress_bar.update(n=1)
-        try:
-            super().__next__()
-        except StopIteration:
-            if self.display_progress:
-                self.progress_bar.write("\n")  # Allows text to be written to new lines after completion
-            raise StopIteration


### PR DESCRIPTION
## Motivation

As a part of the DJ project, @bendichter requested built-in progress bars for the various inheritors of `GenericDataChunkIterators` with `tqdm` so one can visualize the rate of conversion speed for those hefty data. The `MovieDataInterface` with non-external file mode has always supported this.

I doubt the `hdmf` would want that added to the core upstream version of this since it would require yet another addition to their minimal requirements, so I just added it into our own locally defined instances.

Anyway, this solution invokes a progress bar in both the classical iterator context
```
for buffer in RecordingExtractorDataChunkIterator(recording=my_recording):
    print(buffer.shape)
```
as well as in our primary usage
```
class MyConverter(NWBConverter):
    data_interface_classes = dict(SpikeGLX=SpikeGLXRecordingInterface)
my_converter = MyConverter(source_data=dict(SpikeGLX=dict(file_path=".../my_recording_file.ap.bin")))
my_converter.run_conversion(nwbfile_path=".../my_nwbfile.nwb")
```

## How to test the behavior?
I have no idea how to test `tqdm` output to a console. Anyone have any ideas? 

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
