### PR TITLE
Update lxml version

### DIFF
--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -8,7 +8,7 @@ h5py==2.10.0
 PyYAML==5.4
 jsonschema==3.2.0
 psutil==5.8.0
-lxml==4.6.3
+lxml==4.6.5
 opencv-python==4.5.1.48
 spikeextractors@git+https://github.com/SpikeInterface/spikeextractors.git
 spikeinterface@git+https://github.com/SpikeInterface/spikeinterface.git

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -8,7 +8,7 @@ h5py>=2.10.0
 PyYAML>=5.4
 jsonschema>=3.2.0
 psutil>=5.8.0
-lxml>=4.6.3
+lxml>=4.6.5
 spikeinterface@git+https://github.com/SpikeInterface/spikeinterface.git
 spikeextractors>=0.9.7
 spikesorters>=0.4.4

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -8,7 +8,7 @@ h5py==2.10.0
 PyYAML==5.4
 jsonschema==3.2.0
 psutil==5.8.0
-lxml==4.6.3
+lxml==4.6.5
 spikeextractors==0.9.7
 spikeinterface@git+https://github.com/SpikeInterface/spikeinterface.git
 spikesorters==0.4.4


### PR DESCRIPTION
## Motivation

GitHub alerted a security issue within `lxml`, which we use for the Neuroscope interfaces. Simple fix is to bump version on `lxml`.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
