### PR TITLE
remove channels' slicing in stub

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -128,7 +128,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         es_key: str (optional)
             Key in metadata dictionary containing metadata info for the specific electrical series
         """
-        if stub_test or self.subset_channels is not None:
+        if stub_test:
             self.subset_recording()
 
         conversion_opts = default_export_ops()

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -30,7 +30,6 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         super().__init__(**source_data)
         self.recording_extractor = self.RX(**source_data)
         self.writer_class = map_si_object_to_writer(self.recording_extractor)(self.recording_extractor)
-        self.subset_channels = None
         self.source_data = source_data
 
     def get_metadata_schema(self):
@@ -90,7 +89,6 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         self.writer_class = map_si_object_to_writer(self.recording_extractor)(
             self.recording_extractor,
             stub=True,
-            stub_channels=self.subset_channels,
         )
 
     def run_conversion(

--- a/nwb_conversion_tools/utils/basenwbephyswriter.py
+++ b/nwb_conversion_tools/utils/basenwbephyswriter.py
@@ -26,10 +26,9 @@ from .nwbephyswriterdatachunkiterator import NwbEphysWriterDataChunkIterator
 
 
 class BaseNwbEphysWriter(ABC):
-    def __init__(self, object_to_write, stub, stub_channels):
+    def __init__(self, object_to_write, stub):
         self.object_to_write = object_to_write
         self.stub = stub
-        self.stub_channels = stub_channels
         self.dt_column_defaults = DynamicTableSupportedDtypes
         self.nwbfile = None
         self._conversion_ops = dict()

--- a/nwb_conversion_tools/utils/basesinwbephyswriter.py
+++ b/nwb_conversion_tools/utils/basesinwbephyswriter.py
@@ -8,9 +8,9 @@ from .basenwbephyswriter import BaseNwbEphysWriter
 
 
 class BaseSINwbEphysWriter(BaseNwbEphysWriter, ABC):
-    def __init__(self, object_to_write, stub, stub_channels):
+    def __init__(self, object_to_write, stub):
         self.recording, self.sorting, self.waveforms, self.event = None, None, None, None
-        BaseNwbEphysWriter.__init__(self, object_to_write, stub=stub, stub_channels=stub_channels)
+        BaseNwbEphysWriter.__init__(self, object_to_write, stub=stub)
 
     def _get_sampling_frequency(self):
         return self.recording.get_sampling_frequency()

--- a/nwb_conversion_tools/utils/ephys_writer.py
+++ b/nwb_conversion_tools/utils/ephys_writer.py
@@ -39,7 +39,6 @@ def export_ecephys_to_nwb(
     nwbfile=None,
     metadata=None,
     stub=False,
-    stub_channels=None,
     **kwargs,
 ):
     """
@@ -65,8 +64,6 @@ def export_ecephys_to_nwb(
     metadata: dict
     stub: bool
         whether to write a subset of recording
-    stub_channels: list
-        channel ids to write to nwbfile
     kwargs:
         use_times (False): True then use timestamps array, else use starting time and rate for TimeSeries object
             in nwbfile
@@ -119,7 +116,7 @@ def export_ecephys_to_nwb(
         nwbfile = converter.run_conversion(metadata=metadata, save_to_file=False)
 
     writer_class = map_si_object_to_writer(object_to_write)
-    writer = writer_class(object_to_write, stub=stub, stub_channels=stub_channels)
+    writer = writer_class(object_to_write, stub=stub)
     writer.add_to_nwb(nwbfile=nwbfile, metadata=metadata, **conversion_ops)
 
     # handle modes and overwrite

--- a/nwb_conversion_tools/utils/neonwbephyswriter.py
+++ b/nwb_conversion_tools/utils/neonwbephyswriter.py
@@ -25,14 +25,12 @@ class NEONwbEphysWriter(BaseNwbEphysWriter):
     object_to_write: neo.RawIO or neo.IO
     stub: bool
         whether to write a subset of recording extractor traces array as electrical series in nwbfile
-    stub_channels: list
-        channels to include when writing as stub
     """
 
-    def __init__(self, object_to_write, stub=False, stub_channels=None):
+    def __init__(self, object_to_write, stub=False):
         assert HAVE_NEO
         self.recording, self.sorting, self.event = None, None, None
-        BaseNwbEphysWriter.__init__(self, object_to_write, stub=stub, stub_channels=stub_channels)
+        BaseNwbEphysWriter.__init__(self, object_to_write, stub=stub)
 
     @staticmethod
     def supported_types():

--- a/nwb_conversion_tools/utils/si013nwbephyswriter.py
+++ b/nwb_conversion_tools/utils/si013nwbephyswriter.py
@@ -24,13 +24,11 @@ class SI013NwbEphysWriter(BaseSINwbEphysWriter):
     object_to_write: se.RecordingExtractor or se.SortingExtractor
     stub: bool
         whether to write a subset of recording extractor traces array as electrical series in nwbfile
-    stub_channels: list
-        channels to include when writing as stub
     """
 
-    def __init__(self, object_to_write, stub=False, stub_channels=None):
+    def __init__(self, object_to_write, stub=False):
         assert HAVE_SI013, "spikeextractors 0.13 version not installed"
-        BaseSINwbEphysWriter.__init__(self, object_to_write, stub=stub, stub_channels=stub_channels)
+        BaseSINwbEphysWriter.__init__(self, object_to_write, stub=stub)
         if isinstance(self.object_to_write, se.RecordingExtractor):
             self.recording = self.object_to_write
             if self.stub:
@@ -41,13 +39,8 @@ class SI013NwbEphysWriter(BaseSINwbEphysWriter):
                 self._make_sorting_stub()
 
     def _make_recording_stub(self):
-        if self.stub_channels is not None:
-            channel_stub = self.stub_channels
-        else:
-            num_channels = min(10, self.recording.get_num_channels())
-            channel_stub = self.recording.get_channel_ids()[:num_channels]
         frame_stub = min(100, self.recording.get_num_frames())
-        self.recording = se.SubRecordingExtractor(self.recording, channel_ids=channel_stub, end_frame=frame_stub)
+        self.recording = se.SubRecordingExtractor(self.recording, end_frame=frame_stub)
 
     def _make_sorting_stub(self):
         max_min_spike_time = max(

--- a/nwb_conversion_tools/utils/si090nwbephyswriter.py
+++ b/nwb_conversion_tools/utils/si090nwbephyswriter.py
@@ -25,13 +25,11 @@ class SI090NwbEphysWriter(BaseSINwbEphysWriter):
     object_to_write: si.BaseRecording, si.BaseSorting, si.BaseEvent, si.WaveformExtractor
     stub: bool
         whether to write a subset of recording extractor traces array as electrical series in nwbfile
-    stub_channels: list
-        channels to include when writing as stub
     """
 
-    def __init__(self, object_to_write, stub=False, stub_channels=None):
+    def __init__(self, object_to_write, stub=False):
         assert HAVE_SI_090
-        BaseSINwbEphysWriter.__init__(self, object_to_write, stub=stub, stub_channels=stub_channels)
+        BaseSINwbEphysWriter.__init__(self, object_to_write, stub=stub)
         if isinstance(self.object_to_write, si.BaseRecording):
             self.recording = self.object_to_write
             if self.stub:
@@ -51,13 +49,7 @@ class SI090NwbEphysWriter(BaseSINwbEphysWriter):
                 self._make_recording_stub()
 
     def _make_recording_stub(self):
-        if self.stub_channels is not None:
-            channel_stub = self.stub_channels
-        else:
-            num_channels = min(10, self.recording.get_num_channels())
-            channel_stub = self.recording.get_channel_ids()[:num_channels]
         frame_stub = min(100, self.recording.get_num_frames())
-        self.recording = si.ChannelSliceRecording(self.recording, channel_ids=channel_stub)
         self.recording = si.FrameSliceRecording(self.recording, end_frame=frame_stub)
 
     def _make_sorting_stub(self):

--- a/nwb_conversion_tools/utils/si090nwbephyswriter.py
+++ b/nwb_conversion_tools/utils/si090nwbephyswriter.py
@@ -56,7 +56,7 @@ class SI090NwbEphysWriter(BaseSINwbEphysWriter):
         max_min_spike_time = max(
             [min(x) for y in self.sorting.get_unit_ids() for x in [self.sorting.get_unit_spike_train(y)] if any(x)]
         )
-        self.sorting = si.FrameSliceSorting(start_frame=0, end_frame=1.1 * max_min_spike_time)
+        self.sorting = si.FrameSliceSorting(self.sorting, start_frame=0, end_frame=1.1 * max_min_spike_time)
 
     @staticmethod
     def supported_types():

--- a/tests/test_internals/test_si013.py
+++ b/tests/test_internals/test_si013.py
@@ -28,6 +28,26 @@ class TestExtractors(unittest.TestCase):
         del self.RX, self.RX2, self.RX3, self.SX, self.SX2, self.SX3
         shutil.rmtree(self.test_dir)
 
+    def test_write_recording_stub(self):
+        path = self.test_dir + "/test.nwb"
+        export_ecephys_to_nwb(self.RX, path, stub=True)
+        RX_nwb = se.NwbRecordingExtractor(path)
+        # the stub is the trimmed recording in time dimension.
+        frame_stub = min(100, self.RX.get_num_frames())
+        rx_stub = se.SubRecordingExtractor(self.RX, end_frame=frame_stub)
+        check_recordings_equal(rx_stub, RX_nwb)
+
+    def test_write_sorting_stub(self):
+        path = self.test_dir + "/test.nwb"
+        export_ecephys_to_nwb(self.SX, path, stub=True)
+        sf = self.RX.get_sampling_frequency()
+        SX_nwb = se.NwbSortingExtractor(path, sampling_frequency=sf)
+        max_min_spike_time = max(
+            [min(x) for y in self.SX.get_unit_ids() for x in [self.SX.get_unit_spike_train(y)] if any(x)]
+        )
+        sx_stub = se.SubSortingExtractor(self.SX, start_frame=0, end_frame=1.1*max_min_spike_time)
+        check_sortings_equal(sx_stub, SX_nwb)
+
     def test_write_recording(self):
         path = self.test_dir + "/test.nwb"
 

--- a/tests/test_internals/test_si013.py
+++ b/tests/test_internals/test_si013.py
@@ -45,7 +45,7 @@ class TestExtractors(unittest.TestCase):
         max_min_spike_time = max(
             [min(x) for y in self.SX.get_unit_ids() for x in [self.SX.get_unit_spike_train(y)] if any(x)]
         )
-        sx_stub = se.SubSortingExtractor(self.SX, start_frame=0, end_frame=1.1*max_min_spike_time)
+        sx_stub = se.SubSortingExtractor(self.SX, start_frame=0, end_frame=1.1 * max_min_spike_time)
         check_sortings_equal(sx_stub, SX_nwb)
 
     def test_write_recording(self):

--- a/tests/test_internals/test_si090.py
+++ b/tests/test_internals/test_si090.py
@@ -43,7 +43,7 @@ class TestExtractors(unittest.TestCase):
         max_min_spike_time = max(
             [min(x) for y in self.SX.get_unit_ids() for x in [self.SX.get_unit_spike_train(y)] if any(x)]
         )
-        sx_stub = FrameSliceSorting(self.SX, start_frame=0, end_frame=1.1*max_min_spike_time)
+        sx_stub = FrameSliceSorting(self.SX, start_frame=0, end_frame=1.1 * max_min_spike_time)
         check_sortings_equal(sx_stub, SX_nwb)
 
     def test_write_recording(self):


### PR DESCRIPTION
fix #320

## Motivation

Change the behavior of `stub=True` slicing in channels dimension. Now it only slices in the time dimension. 


## Checklist

- [ ] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [ ] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
