### PR TITLE
Adding reading matlab new format capabilities to the CellExplorerInterface

### DIFF
--- a/tests/test_on_data/test_gin.py
+++ b/tests/test_on_data/test_gin.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 import numpy.testing as npt
 import os
+from nwb_conversion_tools.datainterfaces.ecephys.cellexplorer.cellexplorerdatainterface import CellExplorerSortingInterface
 
 import pytest
 from spikeextractors import NwbRecordingExtractor, NwbSortingExtractor
@@ -146,6 +147,14 @@ class TestNwbConversions(unittest.TestCase):
             (
                 BlackrockSortingExtractorInterface,
                 dict(file_path=str(DATA_PATH / "blackrock" / "FileSpec2.3001.nev")),
+            ),
+            param(
+                sorting_interface=CellExplorerSortingInterface,
+                interface_kwargs=dict(folder_path=str(DATA_PATH / "phy" / "phy_example_0")),  # We will find out about the location later
+            ),
+             param(
+                sorting_interface=CellExplorerSortingInterface,
+                interface_kwargs=dict(folder_path=str(DATA_PATH / "phy" / "phy_example_0")),  # point to the matlab file in the other format
             ),
         ]
     )

--- a/tests/test_on_data/test_gin.py
+++ b/tests/test_on_data/test_gin.py
@@ -3,7 +3,9 @@ import unittest
 from pathlib import Path
 import numpy.testing as npt
 import os
-from nwb_conversion_tools.datainterfaces.ecephys.cellexplorer.cellexplorerdatainterface import CellExplorerSortingInterface
+from nwb_conversion_tools.datainterfaces.ecephys.cellexplorer.cellexplorerdatainterface import (
+    CellExplorerSortingInterface,
+)
 
 import pytest
 from spikeextractors import NwbRecordingExtractor, NwbSortingExtractor
@@ -150,11 +152,15 @@ class TestNwbConversions(unittest.TestCase):
             ),
             param(
                 sorting_interface=CellExplorerSortingInterface,
-                interface_kwargs=dict(folder_path=str(DATA_PATH / "phy" / "phy_example_0")),  # We will find out about the location later
+                interface_kwargs=dict(
+                    folder_path=str(DATA_PATH / "phy" / "phy_example_0")
+                ),  # We will find out about the location later
             ),
-             param(
+            param(
                 sorting_interface=CellExplorerSortingInterface,
-                interface_kwargs=dict(folder_path=str(DATA_PATH / "phy" / "phy_example_0")),  # point to the matlab file in the other format
+                interface_kwargs=dict(
+                    folder_path=str(DATA_PATH / "phy" / "phy_example_0")
+                ),  # point to the matlab file in the other format
             ),
         ]
     )


### PR DESCRIPTION
fix #318  

## Motivation
Newer versions of matlab can only be opened with `hdf5storage` instead of `scipy.io`. The purpose of this pull is to allow `CellExplorerInterface` to read the two types of formats. Moreover,  an optional file_path for both `sessionInfo` and `spikes.Info` files will be added. 

## How to test the behavior?
This PR will include tests for both formats as soon as they are available on gin.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [X] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
