### PR TITLE
Remove old speed tests

### DIFF
--- a/nwb_conversion_tools/utils/conversion_tools.py
+++ b/nwb_conversion_tools/utils/conversion_tools.py
@@ -1,17 +1,11 @@
 """Authors: Cody Baker, Alessio Buccino."""
-from pathlib import Path
 import numpy as np
 import uuid
 from datetime import datetime
 from warnings import warn
-from tempfile import mkdtemp
-from shutil import rmtree
-from time import perf_counter
-from typing import Optional
 
 from pynwb import NWBFile
 from pynwb.file import Subject
-from spikeextractors import RecordingExtractor, SubRecordingExtractor
 
 from .json_schema import dict_deep_update
 
@@ -73,49 +67,3 @@ def check_regular_timestamps(ts):
     time_tol_decimals = 9
     uniq_diff_ts = np.unique(np.diff(ts).round(decimals=time_tol_decimals))
     return len(uniq_diff_ts) == 1
-
-
-# TODO update this to handle with different types
-# def estimate_recording_conversion_time(
-#     recording: RecordingExtractor, mb_threshold: float = 100.0, write_kwargs: Optional[dict] = None
-# ) -> (float, float):
-#     """
-#     Test the write speed of recording data to NWB on this system.
-#
-#     recording : RecordingExtractor
-#         The recording object to be written.
-#     mb_threshold : float
-#         Maximum amount of data to test with. Defaults to 100, which is just over 2 seconds of standard SpikeGLX data.
-#
-#     Returns
-#     -------
-#     total_time : float
-#         Estimate of total time (in minutes) to write all data based on speed estimate and known total data size.
-#     speed : float
-#         Speed of the conversion in MB/s.
-#     """
-#     if write_kwargs is None:
-#         write_kwargs = dict()
-#
-#     temp_dir = Path(mkdtemp())
-#     test_nwbfile_path = temp_dir / "recording_speed_test.nwb"
-#
-#     num_channels = recording.get_num_channels()
-#     itemsize = recording.get_dtype().itemsize
-#     total_mb = recording.get_num_frames() * num_channels * itemsize / 1e6
-#     if total_mb > mb_threshold:
-#         truncation = np.floor(mb_threshold * 1e6 / (num_channels * itemsize))
-#         test_recording = SubRecordingExtractor(parent_recording=recording, end_frame=truncation)
-#     else:
-#         test_recording = recording
-#
-#     actual_test_mb = test_recording.get_num_frames() * num_channels * itemsize / 1e6
-#     start = perf_counter()
-#     write_recording(recording=test_recording, save_path=test_nwbfile_path, overwrite=True, **write_kwargs)
-#     end = perf_counter()
-#     delta = end - start
-#     speed = actual_test_mb / delta
-#     total_time = (total_mb / speed) / 60
-#
-#     rmtree(temp_dir)
-#     return total_time, speed

--- a/tests/test_internals/test_tools.py
+++ b/tests/test_internals/test_tools.py
@@ -1,8 +1,6 @@
-from unittest import TestCase, skip
-import numpy as np
+from unittest import TestCase
 
 from pynwb.base import ProcessingModule
-from spikeextractors import NumpyRecordingExtractor
 
 from nwb_conversion_tools.utils.conversion_tools import check_regular_timestamps, get_module, make_nwbfile_from_metadata
 
@@ -29,16 +27,3 @@ class TestConversionTools(TestCase):
         assert isinstance(mod_2, ProcessingModule)
         assert mod_2.description == description_2
         self.assertWarns(UserWarning, get_module, **dict(nwbfile=nwbfile, name=name_1, description=description_2))
-
-    @skip("to be implemented")
-    def test_estimate_recording_conversion_time(self):
-        num_channels = 4
-        sampling_frequency = 30000
-        num_frames = sampling_frequency * 1
-        timeseries = np.random.randint(low=-32768, high=32767, size=[num_channels, num_frames], dtype=np.dtype("int16"))
-        recording = NumpyRecordingExtractor(timeseries=timeseries, sampling_frequency=sampling_frequency)
-
-        estimated_write_time, estimated_write_speed = estimate_recording_conversion_time(recording=recording)
-        estimated_write_time, estimated_write_speed = estimate_recording_conversion_time(
-            recording=recording, write_kwargs=dict(compression=None)
-        )


### PR DESCRIPTION
## Motivation

@Saksham20 It's fine by me if you want to just remove these old functions; the new progress bar feature in the Iterators basically fulfills the same function without the extra infrastructure here.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?