### PR TITLE
Add example YAML conversion specification instance

### DIFF
--- a/tests/test_on_data/GIN_converter_specification.yml
+++ b/tests/test_on_data/GIN_converter_specification.yml
@@ -1,0 +1,59 @@
+metadata:
+  NWBFile:
+    lab: My Lab
+    institution: My Institution
+data_interfaces:
+  - SpikeGLXLFPInterface
+
+experiments:
+  ymaze:
+    metadata:
+      NWBFile:
+        session_description: Subject navigating a Y-shaped maze.
+
+    sessions:
+      - nwbfile_name: example_converter_spec_1
+        data_interfaces:
+          - SpikeGLXRecordingInterface
+        source_data:
+          SpikeGLXRecordingInterface:
+            file_path: spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/Noise4Sam_g0_t0.imec0.ap.bin
+        conversion_options:
+          SpikeGLXRecordingInterface:
+            stub_test: True  # Required for all SpikeGLX here. File on GIN is still huge
+        metadata:
+          NWBFile:
+            session_start_time: "2020-10-09T21:19:09+00:00"
+          Subject:
+            subject_id: "1"
+      - nwbfile_name: example_converter_spec_2
+        metadata:
+          NWBFile:
+            session_start_time: "2020-10-10T21:19:09+00:00"
+          Subject:
+            subject_id: "002"
+        conversion_options:
+          SpikeGLXLFPInterface:
+            stub_test: True  # Required for all SpikeGLX here. File on GIN is still huge
+        source_data:
+          SpikeGLXLFPInterface:
+            file_path: spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/Noise4Sam_g0_t0.imec0.lf.bin
+
+  open_explore:
+    sessions:
+      - nwbfile_name: example_converter_spec_3
+        data_interfaces:
+          - PhySortingInterface
+        source_data:
+          SpikeGLXLFPInterface:
+            file_path: spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/Noise4Sam_g0_t0.imec0.lf.bin
+          PhySortingInterface:
+            folder_path: phy/phy_example_0/
+        metadata:
+          NWBFile:
+            session_start_time: "2020-10-11T21:19:09+00:00"
+          Subject:
+            subject_id: Subject Name
+        conversion_options:
+          SpikeGLXLFPInterface:
+            stub_test: True  # Required for all SpikeGLX here. File on GIN is still huge

--- a/tests/test_on_data/test_yaml_conversion_specification.py
+++ b/tests/test_on_data/test_yaml_conversion_specification.py
@@ -1,0 +1,52 @@
+import unittest
+import os
+from pathlib import Path
+from tempfile import mkdtemp
+from shutil import rmtree
+from jsonschema import validate, RefResolver
+
+import pytest
+
+from nwb_conversion_tools.utils.json_schema import load_dict_from_file
+
+# Path to dataset downloaded from https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+#   ecephys: https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+#   ophys: TODO
+#   icephys: TODO
+if os.getenv("CI"):
+    LOCAL_PATH = Path(".")  # Must be set to "." for CI
+    print("Running GIN tests on Github CI!")
+else:
+    LOCAL_PATH = Path("/home/jovyan/")  # Override this on personal device for local testing
+    print("Running GIN tests locally!")
+
+DATA_PATH = LOCAL_PATH / "ephy_testing_data"
+HAVE_DATA = DATA_PATH.exists()
+
+if not HAVE_DATA:
+    pytest.fail(f"No ephy_testing_data folder found in location: {DATA_PATH}!")
+
+
+class TestYAMLConversionSpecification(unittest.TestCase):
+    def setUp(self):
+        self.test_folder = Path(mkdtemp())
+
+    def tearDown(self):
+        rmtree(path=self.test_folder)
+
+    def test_validate_example_specification(self):
+        path_to_test_gin_file = Path(__file__)
+        yaml_file_path = path_to_test_gin_file.parent / "GIN_converter_specification.yml"
+        schema_folder = path_to_test_gin_file.parent.parent.parent / "nwb_conversion_tools" / "schemas"
+        specification_schema = load_dict_from_file(
+            file_path=schema_folder / "yaml_conversion_specification_schema.json"
+        )
+        validate(
+            instance=load_dict_from_file(file_path=yaml_file_path),
+            schema=load_dict_from_file(file_path=schema_folder / "yaml_conversion_specification_schema.json"),
+            resolver=RefResolver(base_uri="file://" + str(schema_folder) + "/", referrer=specification_schema),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Another simple pre-PR for the YAML conversion specification. In particular, this includes the actual example YAML file we use in the main PR for running a full conversion

## How to test the behavior?

The primary test here is if the defined YAML specification schema is valid and compatible with our example file, or vice versa.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
