### PR TITLE
Restoring remapping of input keys

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
@@ -13,21 +13,21 @@ class SpikeGadgetsRecordingInterface(BaseRecordingExtractorInterface):
     @classmethod
     def get_source_schema(cls):
         source_schema = super().get_source_schema()
-        source_schema["properties"]["filename"].update(description="Path to SpikeGadgets (.rec) file.")
+        source_schema["properties"]["file_path"].update(description="Path to SpikeGadgets (.rec) file.")
         source_schema["properties"]["probe_file_path"].update(
             description="Optional path to a probe (.prb) file describing electrode features."
         )
         return source_schema
 
     def __init__(
-        self, filename: FilePathType, gains: OptionalArrayType = None, probe_file_path: OptionalFilePathType = None
+        self, file_path: FilePathType, gains: OptionalArrayType = None, probe_file_path: OptionalFilePathType = None
     ):
         """
         Recording Interface for the SpikeGadgets Format.
 
         Parameters
         ----------
-        filename : FilePathType
+        file_path : FilePathType
             Path to the .rec file.
         gains : ArrayType, optional
             The early versions of SpikeGadgest do not automatically record the conversion factor ('gain') of the
@@ -37,7 +37,8 @@ class SpikeGadgetsRecordingInterface(BaseRecordingExtractorInterface):
             Set channel properties and geometry through a .prb file.
             See https://github.com/SpikeInterface/probeinterface for more information.
         """
-        super().__init__(filename=filename)
+        super().__init__(filename=file_path)
+        self.source_data = dict(file_path=file_path)
         if gains is not None:
             if len(gains) == 1:
                 gains = [gains[0]] * self.recording_extractor.get_num_channels()

--- a/nwb_conversion_tools/datainterfaces/ecephys/spikeinterface/sipickledatainterfaces.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/spikeinterface/sipickledatainterfaces.py
@@ -11,10 +11,10 @@ class SIPickleRecordingExtractorInterface(BaseRecordingExtractorInterface):
 
     RX = None
 
-    def __init__(self, pkl_file: FilePathType):
-        self.recording_extractor = load_extractor_from_pickle(pkl_file=pkl_file)
+    def __init__(self, file_path: FilePathType):
+        self.recording_extractor = load_extractor_from_pickle(pkl_file=file_path)
         self.subset_channels = None
-        self.source_data = dict(pkl_file=pkl_file)
+        self.source_data = dict(file_path=file_path)
 
 
 class SIPickleSortingExtractorInterface(BaseSortingExtractorInterface):
@@ -22,6 +22,6 @@ class SIPickleSortingExtractorInterface(BaseSortingExtractorInterface):
 
     SX = None
 
-    def __init__(self, pkl_file: FilePathType):
-        self.sorting_extractor = load_extractor_from_pickle(pkl_file=pkl_file)
-        self.source_data = dict(pkl_file=pkl_file)
+    def __init__(self, file_path: FilePathType):
+        self.sorting_extractor = load_extractor_from_pickle(pkl_file=file_path)
+        self.source_data = dict(file_path=file_path)

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -10,7 +10,7 @@ jsonschema==3.2.0
 psutil==5.8.0
 lxml==4.6.5
 opencv-python==4.5.1.48
-spikeextractors==0.9.7
+spikeextractors@ git+https://github.com/SpikeInterface/spikeextractors.git
 neo==0.10.0
 roiextractors==0.3.1
 ndx-events==0.2.0

--- a/tests/test_internals/test_interfaces.py
+++ b/tests/test_internals/test_interfaces.py
@@ -103,8 +103,8 @@ def test_pkl_interface():
         )
 
     source_data = dict(
-        Recording=dict(pkl_file=str(test_dir / "test_pkl" / "test_recording.pkl")),
-        Sorting=dict(pkl_file=str(test_dir / "test_pkl" / "test_sorting.pkl")),
+        Recording=dict(file_path=str(test_dir / "test_pkl" / "test_recording.pkl")),
+        Sorting=dict(file_path=str(test_dir / "test_pkl" / "test_sorting.pkl")),
     )
     converter = SpikeInterfaceTestNWBConverter(source_data=source_data)
     converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True)

--- a/tests/test_on_data/test_gin.py
+++ b/tests/test_on_data/test_gin.py
@@ -73,7 +73,7 @@ class TestNwbConversions(unittest.TestCase):
         ),
         param(
             recording_interface=BlackrockRecordingExtractorInterface,
-            interface_kwargs=dict(filename=str(DATA_PATH / "blackrock" / "FileSpec2.3001.ns5")),
+            interface_kwargs=dict(file_path=str(DATA_PATH / "blackrock" / "FileSpec2.3001.ns5")),
         ),
     ]
     for suffix in ["rhd", "rhs"]:
@@ -85,7 +85,7 @@ class TestNwbConversions(unittest.TestCase):
         )
     for file_name, num_channels in zip(["20210225_em8_minirec2_ac", "W122_06_09_2019_1_fromSD"], [512, 128]):
         for gains in [None, [0.195], [0.385] * num_channels]:
-            interface_kwargs = dict(filename=str(DATA_PATH / "spikegadgets" / f"{file_name}.rec"))
+            interface_kwargs = dict(file_path=str(DATA_PATH / "spikegadgets" / f"{file_name}.rec"))
             if gains is not None:
                 interface_kwargs.update(gains=gains)
             parameterized_recording_list.append(
@@ -111,6 +111,11 @@ class TestNwbConversions(unittest.TestCase):
             data_interface_classes = dict(TestRecording=recording_interface)
 
         converter = TestConverter(source_data=dict(TestRecording=dict(interface_kwargs)))
+        for interface_kwarg in interface_kwargs:
+            if interface_kwarg in ["file_path", "folder_path"]:
+                self.assertIn(
+                    member=interface_kwarg, container=converter.data_interface_objects["TestRecording"].source_data
+                )
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True)
         recording = converter.data_interface_objects["TestRecording"].recording_extractor
         nwb_recording = NwbRecordingExtractor(file_path=nwbfile_path)
@@ -130,7 +135,7 @@ class TestNwbConversions(unittest.TestCase):
             ),
             param(
                 sorting_interface=BlackrockSortingExtractorInterface,
-                interface_kwargs=dict(filename=str(DATA_PATH / "blackrock" / "FileSpec2.3001.nev")),
+                interface_kwargs=dict(file_path=str(DATA_PATH / "blackrock" / "FileSpec2.3001.nev")),
             ),
         ],
     )


### PR DESCRIPTION
## Motivation

Restores input mapping of `file_path` type arguments to the single standard.

## How to test the behavior?

Tests are properly adjusted to refer to new `file_path` convention, but follow up PR still needs to restore certain interface tests.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
