### PR TITLE
Restore deep dictionary changes and tests

### DIFF
--- a/nwb_conversion_tools/utils/json_schema.py
+++ b/nwb_conversion_tools/utils/json_schema.py
@@ -1,12 +1,14 @@
-"""Authors: Luiz Tauffer, Cody Baker, and Ben Dichter."""
+"""Authors: Luiz Tauffer, Cody Baker, Saksham Sharda and Ben Dichter."""
 import collections.abc
 import inspect
-import numpy as np
+import warnings
+from copy import deepcopy
 from datetime import datetime
-from typing import TypeVar
 from pathlib import Path
 from typing import Optional, Union
+from typing import TypeVar
 
+import numpy as np
 import pynwb
 
 FilePathType = TypeVar("FilePathType", str, Path)
@@ -23,41 +25,110 @@ def exist_dict_in_list(d, ls):
     return any([d == i for i in ls])
 
 
-def append_replace_dict_in_list(d, ls, k):
+def append_replace_dict_in_list(ls, d, compare_key, list_dict_deep_update: bool = True, remove_repeats: bool = True):
     """
-    Append a dictionary to a list of dictionaries.
-
-    If some dictionary already contains the same value as d[k], it gets replaced by the new dict.
+    Correctly updates the list ls with the dict d.
+    Cases:
+    1.  If d is a dict and ls a list of dicts and ints/str, then for a given compare key, if for any element of ls
+        (which is a dict) say: ls[3][compare_key] == d[compare_key], then it will dict_deep_update these instead of appending d
+        to list ls. Only if compare_key is not present in any of dicts in the list ls, then d is simply appended
+        to ls.
+    2.  If d is of immutable types like str, int etc, the ls is either appended with d or not.
+        This depends on the value of remove_repeats. If remove_repeats is False, then ls is always appended with d.
+        If remove_repeats is True, then if value d is present then its not appended else it is.
+    Parameters
+    ----------
+    ls: list
+        list of a dicts or int/str or a combination. This is the object to update
+    d: list/str/int
+        this is the object from which ls is updated.
+    compare_key: str
+        name of the key for which to check the presence of dicts in ls which need dict_deep_update
+    list_dict_deep_update: bool
+        whether to update a dict in ls with compare_key present OR simply replace it.
+    remove_repeats: bool
+        keep repeated values in the updated ls
+    Returns
+    -------
+    ls: list
+        updated list
     """
-    if k in d and len(ls) > 0:
-        # Index where the value dictionary[k] exists in the list of dicts
-        ind = np.where([d[k] == i[k] for i in ls])[0]
-        if len(ind) > 0:
-            ls[ind[0]] = d
+    if not isinstance(ls, list):
+        return d
+    if isinstance(d, collections.abc.Mapping):
+        indxs = np.where(
+            [d.get(compare_key, None) == i[compare_key] for i in ls if isinstance(i, collections.abc.Mapping)]
+        )[0]
+        if len(indxs) > 0:
+            for idx in indxs:
+                if list_dict_deep_update:
+                    ls[idx] = dict_deep_update(ls[idx], d)
+                else:
+                    ls[idx] = d
         else:
             ls.append(d)
-    else:
+    elif not (d in ls and remove_repeats):
         ls.append(d)
     return ls
 
 
-def dict_deep_update(d: dict, u: dict, append_list: bool = True, remove_repeats: bool = True) -> dict:
-    """Perform an update to all nested keys of dictionary d from dictionary u."""
+def dict_deep_update(
+    d: collections.abc.Mapping,
+    u: collections.abc.Mapping,
+    append_list: bool = True,
+    remove_repeats: bool = True,
+    copy: bool = True,
+    compare_key: str = "name",
+    list_dict_deep_update: bool = True,
+) -> collections.abc.Mapping:
+    """
+    Perform an update to all nested keys of dictionary d(input) from dictionary u(updating dict).
+    Parameters
+    ----------
+    d: dict
+        dictionary to update
+    u: dict
+        dictionary to update from
+    append_list: bool
+        if the item to update is a list, whether to append the lists or replace the list in d
+        eg. d = dict(key1=[1,2,3]), u = dict(key1=[3,4,5]).
+        If True then updated dictionary d=dict(key1=[1,2,3,4,5]) else d=dict(key1=[3,4,5])
+    remove_repeats: bool
+        for updating list in d[key] with list in u[key]: if true then remove repeats: list(set(ls))
+    copy: bool
+        whether to deepcopy the input dict d
+    compare_key: str
+        the key that is used to compare dicts (and perform update op) and update d[key] when it is a list if dicts.
+        example:
+            >>> d = {'input': [{'name':'timeseries1', 'desc':'desc1 of d', 'starting_time':0.0}, {'name':'timeseries2', 'desc':'desc2'}]}
+            >>> u = ['input': {'name':'timeseries1', 'desc':'desc2 of u', 'unit':'n.a.'}]
+            >>> # if compre_key='name' output is below
+            >>> output = ['input': {'name':'timeseries1', 'desc':'desc2 of u', 'starting_time':0.0, 'unit':'n.a.'}, {'name':'timeseries2', 'desc':'desc2'}]
+            >>> # else the output is:
+            >>> # dict with the same key will be updated instead of being appended to the list
+            >>> output = ['input': {'name':'timeseries1', 'desc':'desc1 of d', 'starting_time': 0.0}, {'name':'timeseries2', 'desc':'desc2'}, {'name':'timeseries1', 'desc':'desc2 of u', 'unit':'n.a.'}]
+    list_dict_deep_update: bool
+        for back compatibility, if False, this would work as before:
+        example: if True then for the compare_key example, the output would be:
+            >>> output = ['input': {'name':'timeseries1', 'desc':'desc2 of u', 'starting_time':0.0, 'unit':'n.a.'}, {'name':'timeseries2', 'desc':'desc2'}]
+            >>> # if False:
+            >>> output = ['input': {'name':'timeseries1', 'desc':'desc2 of u', 'starting_time':0.0}, {'name':'timeseries2', 'desc':'desc2'}]# unit key is absent since its a replacement
+    Returns
+    -------
+    d: dict
+        return the updated dictionary
+    """
+    if not isinstance(d, collections.abc.Mapping):
+        warnings.warn("input to update should be a dict, returning output")
+        return u
+    if copy:
+        d = deepcopy(d)
     for k, v in u.items():
         if isinstance(v, collections.abc.Mapping):
-            d[k] = dict_deep_update(d.get(k, {}), v, append_list=append_list, remove_repeats=remove_repeats)
+            d[k] = dict_deep_update(d.get(k, None), v, append_list=append_list, remove_repeats=remove_repeats)
         elif append_list and isinstance(v, list):
-            if len(v) > 0 and isinstance(v[0], dict):
-                for vv in v:
-                    d[k] = append_replace_dict_in_list(d=vv, ls=d.get(k, []), k="name")
-                    # add dict only if not repeated
-                    # if not exist_dict_in_list(vv, d.get(k, [])):
-                    # d[k] = d.get(k, []) + [vv]
-            else:
-                d[k] = d.get(k, []) + v
-                # Remove repeated items if they exist
-                if remove_repeats and len(d[k]) > 0:
-                    d[k] = list(set(d[k]))
+            for vv in v:
+                d[k] = append_replace_dict_in_list(d.get(k, []), vv, compare_key, list_dict_deep_update, remove_repeats)
         else:
             d[k] = v
     return d
@@ -79,7 +150,6 @@ def get_base_schema(tag=None, root=False, id_=None, **kwargs) -> dict:
 def get_schema_from_method_signature(class_method: classmethod, exclude: list = None) -> dict:
     """
     Take a class method and return a json-schema of the input args.
-
     Parameters
     ----------
     class_method: function
@@ -150,7 +220,6 @@ def get_schema_from_method_signature(class_method: classmethod, exclude: list = 
 def fill_defaults(schema: dict, defaults: dict, overwrite: bool = True):
     """
     Insert the values of the defaults dict as default values in the schema in place.
-
     Parameters
     ----------
     schema: dict
@@ -169,7 +238,6 @@ def fill_defaults(schema: dict, defaults: dict, overwrite: bool = True):
 def unroot_schema(schema: dict):
     """
     Modify a json-schema dictionary to make it not root.
-
     Parameters
     ----------
     schema: dict


### PR DESCRIPTION
## How to test the behavior?

Restoring `deep_dict_update` changes for handling list appending, and accompanying tests.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
