### PR TITLE
Docstrings for RecordingExtractorDataChunkIterator

### DIFF
--- a/nwb_conversion_tools/utils/recordingextractordatachunkiterator.py
+++ b/nwb_conversion_tools/utils/recordingextractordatachunkiterator.py
@@ -23,28 +23,25 @@ class RecordingExtractorDataChunkIterator(GenericDataChunkIterator):
         Parameters
         ----------
         recording : RecordingExtractor
-            The RecordingExtractor object (from legacy spikeinterface/spikeextractors)
-            which handles the API for data transfer.
+            The RecordingExtractor object (from legacy spikeinterface/spikeextractors) which handles the data access.
         buffer_gb : float, optional
             The upper bound on size in gigabytes (GB) of each selection from the iteration.
             The buffer_shape will be set implicitly by this argument.
             Cannot be set if `buffer_shape` is also specified.
             The default is 1GB.
         buffer_shape : tuple, optional
-            If the user desires further control over the shaping of the buffer over all the axes, they may set this
-            explicitly as a tuple of the same length as the data shape indicating the desired shape of each selection.
+            Manual specification of buffer shape to return on each iteration.
+            Must be a multiple of chunk_shape along each axis.
             Cannot be set if `buffer_gb` is also specified.
             The default is None.
         chunk_mb : float, optional
-            The upper bound on size in megabytes (MB) of each internally set chunk for the HDF5 dataset.
+            The upper bound on size in megabytes (MB) of the internal chunk for the HDF5 dataset.
             The chunk_shape will be set implicitly by this argument.
             Cannot be set if `chunk_shape` is also specified.
             The default is 1MB, which is highly recommended by the HDF5 group. For more details, see
             https://support.hdfgroup.org/HDF5/doc/TechNotes/TechNote-HDF5-ImprovingIOPerformanceCompressedDatasets.pdf
         chunk_shape : tuple, optional
-            If the user desires further control over the shaping of the buffer over all the axes,
-            they may set this explicitly as a tuple of the same length as the data shape indicating the desired shape
-            of each selection.
+            Manual specification of the internal chunk shape for the HDF5 dataset.
             Cannot be set if `chunk_mb` is also specified.
             The default is None.
         """

--- a/nwb_conversion_tools/utils/recordingextractordatachunkiterator.py
+++ b/nwb_conversion_tools/utils/recordingextractordatachunkiterator.py
@@ -28,21 +28,24 @@ class RecordingExtractorDataChunkIterator(GenericDataChunkIterator):
         buffer_gb : float, optional
             The upper bound on size in gigabytes (GB) of each selection from the iteration.
             The buffer_shape will be set implicitly by this argument.
+            Cannot be set if `buffer_shape` is also specified.
             The default is 1GB.
         buffer_shape : tuple, optional
-            If the user desires further control over the shaping of the buffer over all the axes,
-            they may set this explicitly as a tuple of the same length as the data shape indicating the desired shape
-            of each selection.
+            If the user desires further control over the shaping of the buffer over all the axes, they may set this
+            explicitly as a tuple of the same length as the data shape indicating the desired shape of each selection.
+            Cannot be set if `buffer_gb` is also specified.
             The default is None.
         chunk_mb : float, optional
             The upper bound on size in megabytes (MB) of each internally set chunk for the HDF5 dataset.
             The chunk_shape will be set implicitly by this argument.
+            Cannot be set if `chunk_shape` is also specified.
             The default is 1MB, which is highly recommended by the HDF5 group. For more details, see
             https://support.hdfgroup.org/HDF5/doc/TechNotes/TechNote-HDF5-ImprovingIOPerformanceCompressedDatasets.pdf
         chunk_shape : tuple, optional
             If the user desires further control over the shaping of the buffer over all the axes,
             they may set this explicitly as a tuple of the same length as the data shape indicating the desired shape
             of each selection.
+            Cannot be set if `chunk_mb` is also specified.
             The default is None.
         """
         self.recording = recording

--- a/nwb_conversion_tools/utils/recordingextractordatachunkiterator.py
+++ b/nwb_conversion_tools/utils/recordingextractordatachunkiterator.py
@@ -38,7 +38,7 @@ class RecordingExtractorDataChunkIterator(GenericDataChunkIterator):
             The upper bound on size in megabytes (MB) of the internal chunk for the HDF5 dataset.
             The chunk_shape will be set implicitly by this argument.
             Cannot be set if `chunk_shape` is also specified.
-            The default is 1MB, which is highly recommended by the HDF5 group. For more details, see
+            The default is 1MB, as recommended by the HDF5 group. For more details, see
             https://support.hdfgroup.org/HDF5/doc/TechNotes/TechNote-HDF5-ImprovingIOPerformanceCompressedDatasets.pdf
         chunk_shape : tuple, optional
             Manual specification of the internal chunk shape for the HDF5 dataset.

--- a/nwb_conversion_tools/utils/recordingextractordatachunkiterator.py
+++ b/nwb_conversion_tools/utils/recordingextractordatachunkiterator.py
@@ -17,6 +17,34 @@ class RecordingExtractorDataChunkIterator(GenericDataChunkIterator):
         chunk_mb: float = None,
         chunk_shape: tuple = None,
     ):
+        """
+        Initialize an Iterable object which returns DataChunks with data and their selections on each iteration.
+
+        Parameters
+        ----------
+        recording : RecordingExtractor
+            The RecordingExtractor object (from legacy spikeinterface/spikeextractors)
+            which handles the API for data transfer.
+        buffer_gb : float, optional
+            The upper bound on size in gigabytes (GB) of each selection from the iteration.
+            The buffer_shape will be set implicitly by this argument.
+            The default is 1GB.
+        buffer_shape : tuple, optional
+            If the user desires further control over the shaping of the buffer over all the axes,
+            they may set this explicitly as a tuple of the same length as the data shape indicating the desired shape
+            of each selection.
+            The default is None.
+        chunk_mb : float, optional
+            The upper bound on size in megabytes (MB) of each internally set chunk for the HDF5 dataset.
+            The chunk_shape will be set implicitly by this argument.
+            The default is 1MB, which is highly recommended by the HDF5 group. For more details, see
+            https://support.hdfgroup.org/HDF5/doc/TechNotes/TechNote-HDF5-ImprovingIOPerformanceCompressedDatasets.pdf
+        chunk_shape : tuple, optional
+            If the user desires further control over the shaping of the buffer over all the axes,
+            they may set this explicitly as a tuple of the same length as the data shape indicating the desired shape
+            of each selection.
+            The default is None.
+        """
         self.recording = recording
         self.channel_ids = recording.get_channel_ids()
         super().__init__(buffer_gb=buffer_gb, buffer_shape=buffer_shape, chunk_mb=chunk_mb, chunk_shape=chunk_shape)


### PR DESCRIPTION
## Motivation

Enhancing docstrings for the `RecordingExtractorDataChunkIterator` class.

## How to test the behavior?

No change to behavior.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
