### PR TITLE
change from np.float to float

### DIFF
--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -365,7 +365,7 @@ def add_electrodes(recording: se.RecordingExtractor, nwbfile=None, metadata: dic
                             found_property_types[prop] = proptype[0]
                             # cast as float if any number:
                             if found_property_types[prop] == Real:
-                                chan_data = np.float(chan_data)
+                                chan_data = float(chan_data)
                             # update data if wrong datatype items filled prior:
                             if len(data) > 0 and not isinstance(data[-1], found_property_types[prop]):
                                 data = [channel_property_defaults[found_property_types[prop]]] * len(data)


### PR DESCRIPTION
## Motivation

from warning:

>  /home/runner/work/nwb-conversion-tools/nwb-conversion-tools/nwb_conversion_tools/utils/spike_interface.py:368: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    chan_data = np.float(chan_data)
