### PR TITLE
Add ElectricalSeries starting_time control

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -33,6 +33,7 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
         nwbfile: NWBFile,
         metadata: dict = None,
         stub_test: bool = False,
+        starting_time: Optional[float] = None,
         use_times: bool = False,
         save_path: OptionalFilePathType = None,
         overwrite: bool = False,
@@ -52,6 +53,9 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
             metadata info for constructing the nwb file (optional).
             Should be of the format
                 metadata['Ecephys']['ElectricalSeries'] = dict(name=my_name, description=my_description)
+        starting_time: float (optional)
+            Sets the starting time of the ElectricalSeries to a manually set value.
+            Increments timestamps if use_times is True.
         use_times: bool
             If True, the times are saved to the nwb file using recording.frame_to_time(). If False (default),
             the sampling rate is used.
@@ -89,6 +93,7 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
             recording=recording,
             nwbfile=nwbfile,
             metadata=metadata,
+            starting_time=starting_time,
             use_times=use_times,
             write_as="lfp",
             es_key="ElectricalSeries_lfp",

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -100,6 +100,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         nwbfile: NWBFile,
         metadata: dict = None,
         stub_test: bool = False,
+        starting_time: Optional[float] = None,
         use_times: bool = False,
         save_path: OptionalFilePathType = None,
         overwrite: bool = False,
@@ -121,6 +122,9 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
             metadata info for constructing the nwb file (optional).
             Should be of the format
                 metadata['Ecephys']['ElectricalSeries'] = dict(name=my_name, description=my_description)
+        starting_time: float (optional)
+            Sets the starting time of the ElectricalSeries to a manually set value.
+            Increments timestamps if use_times is True.
         use_times: bool
             If True, the times are saved to the nwb file using recording.frame_to_time(). If False (default),
             the sampling rate is used.
@@ -162,6 +166,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
             recording=recording,
             nwbfile=nwbfile,
             metadata=metadata,
+            starting_time=starting_time,
             use_times=use_times,
             write_as=write_as,
             es_key=es_key,

--- a/tests/test_on_data/test_gin.py
+++ b/tests/test_on_data/test_gin.py
@@ -251,6 +251,26 @@ class TestNwbConversions(unittest.TestCase):
         # A subrecording extractor is a very simple class, input output (you can use the recorder above 'recording in 229')
         # [The two things that you can do is to subest time [that is frames] or channels so maybe a combination of those uses.
 
+    def test_neuroscope_starting_time(self):
+        nwbfile_path = str(self.savedir / "testing_start_time.nwb")
+
+        class TestConverter(NWBConverter):
+            data_interface_classes = dict(TestRecording=NeuroscopeRecordingInterface)
+
+        converter = TestConverter(
+            source_data=dict(TestRecording=dict(file_path=str(DATA_PATH / "neuroscope" / "test1" / "test1.dat")))
+        )
+        starting_time = 123.0
+        converter.run_conversion(
+            nwbfile_path=nwbfile_path,
+            overwrite=True,
+            conversion_options=dict(TestRecording=dict(starting_time=starting_time)),
+        )
+
+        with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
+            nwbfile = io.read()
+            self.assertEqual(first=starting_time, second=nwbfile.acquisition["ElectricalSeries_raw"].starting_time)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation
Requested by @bendichter for the DataJoint project; this allows manual control over the starting_time field when adding an ElectricalSeries from a `RecordingExtractor` through `add_electrical_series` (lowest level) and has been propagated up to the interfaces via conversion options.

## How to test the behavior?
Also added a test (using Neuroscope) to ensure it winds up in the output NWBFile.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
