### PR TITLE
Add write_electrical_series option to write_recording

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -105,6 +105,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         save_path: OptionalFilePathType = None,
         overwrite: bool = False,
         write_as: str = "raw",
+        write_electrical_series: bool = True,
         es_key: str = None,
         compression: Optional[str] = "gzip",
         compression_opts: Optional[int] = None,
@@ -137,6 +138,9 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
             If True, will truncate the data to run the conversion faster and take up less memory.
         write_as: str (optional, defaults to 'raw')
             Options: 'raw', 'lfp' or 'processed'
+        write_electrical_series: bool (optional)
+            If True (default), electrical series are written in acquisition. If False, only device, electrode_groups,
+            and electrodes are written to NWB.
         es_key: str (optional)
             Key in metadata dictionary containing metadata info for the specific electrical series
         compression: str (optional, defaults to "gzip")
@@ -169,6 +173,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
             starting_time=starting_time,
             use_times=use_times,
             write_as=write_as,
+            write_electrical_series=write_electrical_series,
             es_key=es_key,
             save_path=save_path,
             overwrite=overwrite,

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -750,7 +750,7 @@ def add_epochs(recording: RecordingExtractor, nwbfile=None, metadata: dict = Non
                 )
 
 
-def add_device_electrode_info(recording: RecordingExtractor, nwbfile=None, metadata: dict = None):
+def add_electrodes_info(recording: RecordingExtractor, nwbfile=None, metadata: dict = None):
     """
     Adds device, electrode_groups, and electrodes info to the nwbfile
 
@@ -859,7 +859,7 @@ def add_all_to_nwbfile(
     if nwbfile is not None:
         assert isinstance(nwbfile, pynwb.NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
 
-    add_device_electrode_info(recording=recording, nwbfile=nwbfile, metadata=metadata)
+    add_electrodes_info(recording=recording, nwbfile=nwbfile, metadata=metadata)
 
     if write_electrical_series:
         add_electrical_series(

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -748,8 +748,8 @@ def add_epochs(recording: RecordingExtractor, nwbfile=None, metadata: dict = Non
                     stop_time=recording.frame_to_time(epoch["end_frame"]),
                     tags=epoch_name,
                 )
-                
-                
+
+
 def add_device_electrode_info(recording: RecordingExtractor, nwbfile=None, metadata: dict = None):
     """
     Adds device, electrode_groups, and electrodes info to the nwbfile
@@ -782,8 +782,7 @@ def add_device_electrode_info(recording: RecordingExtractor, nwbfile=None, metad
         possibly including the default, will occur.
     """
     add_devices(recording=recording, nwbfile=nwbfile, metadata=metadata)
-    add_electrode_groups(recording=recording,
-                         nwbfile=nwbfile, metadata=metadata)
+    add_electrode_groups(recording=recording, nwbfile=nwbfile, metadata=metadata)
     add_electrodes(
         recording=recording,
         nwbfile=nwbfile,
@@ -861,7 +860,7 @@ def add_all_to_nwbfile(
         assert isinstance(nwbfile, pynwb.NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
 
     add_device_electrode_info(recording=recording, nwbfile=nwbfile, metadata=metadata)
-    
+
     if write_electrical_series:
         add_electrical_series(
             recording=recording,

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -264,7 +264,7 @@ def add_electrodes(recording: SpikeInterfaceRecording, nwbfile=None, metadata: d
         Missing keys in an element of metadata['Ecephys']['ElectrodeGroup'] will be auto-populated with defaults
         whenever possible.
         If 'my_name' is set to one of the required fields for nwbfile
-        electrodes (id, x, y, z, imp, loccation, filtering, group_name),
+        electrodes (id, x, y, z, imp, location, filtering, group_name),
         then the metadata will override their default values.
         Setting 'my_name' to metadata field 'group' is not supported as the linking to
         nwbfile.electrode_groups is handled automatically; please specify the string 'group_name' in this case.
@@ -748,6 +748,47 @@ def add_epochs(recording: RecordingExtractor, nwbfile=None, metadata: dict = Non
                     stop_time=recording.frame_to_time(epoch["end_frame"]),
                     tags=epoch_name,
                 )
+                
+                
+def add_device_electrode_info(recording: RecordingExtractor, nwbfile=None, metadata: dict = None):
+    """
+    Adds device, electrode_groups, and electrodes info to the nwbfile
+
+    Parameters
+    ----------
+    recording: SpikeInterfaceRecording
+    nwbfile: NWBFile
+        nwb file to which the recording information is to be added
+    metadata: dict
+        metadata info for constructing the nwb file (optional).
+        Should be of the format
+            metadata['Ecephys']['Electrodes'] = [
+                {
+                    'name': my_name,
+                    'description': my_description
+                },
+                ...
+            ]
+        Note that data intended to be added to the electrodes table of the NWBFile should be set as channel
+        properties in the RecordingExtractor object.
+        Missing keys in an element of metadata['Ecephys']['ElectrodeGroup'] will be auto-populated with defaults
+        whenever possible.
+        If 'my_name' is set to one of the required fields for nwbfile
+        electrodes (id, x, y, z, imp, location, filtering, group_name),
+        then the metadata will override their default values.
+        Setting 'my_name' to metadata field 'group' is not supported as the linking to
+        nwbfile.electrode_groups is handled automatically; please specify the string 'group_name' in this case.
+        If no group information is passed via metadata, automatic linking to existing electrode groups,
+        possibly including the default, will occur.
+    """
+    add_devices(recording=recording, nwbfile=nwbfile, metadata=metadata)
+    add_electrode_groups(recording=recording,
+                         nwbfile=nwbfile, metadata=metadata)
+    add_electrodes(
+        recording=recording,
+        nwbfile=nwbfile,
+        metadata=metadata,
+    )
 
 
 def add_all_to_nwbfile(
@@ -819,13 +860,8 @@ def add_all_to_nwbfile(
     if nwbfile is not None:
         assert isinstance(nwbfile, pynwb.NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
 
-    add_devices(recording=recording, nwbfile=nwbfile, metadata=metadata)
-    add_electrode_groups(recording=recording, nwbfile=nwbfile, metadata=metadata)
-    add_electrodes(
-        recording=recording,
-        nwbfile=nwbfile,
-        metadata=metadata,
-    )
+    add_device_electrode_info(recording=recording, nwbfile=nwbfile, metadata=metadata)
+    
     if write_electrical_series:
         add_electrical_series(
             recording=recording,

--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -758,6 +758,7 @@ def add_all_to_nwbfile(
     metadata: dict = None,
     write_as: str = "raw",
     es_key: str = None,
+    write_electrical_series: bool = True,
     write_scaled: bool = False,
     compression: Optional[str] = "gzip",
     compression_opts: Optional[int] = None,
@@ -791,6 +792,9 @@ def add_all_to_nwbfile(
         - 'lfp' will save it as LFP, in a processing module
     es_key: str (optional)
         Key in metadata dictionary containing metadata info for the specific electrical series
+    write_electrical_series: bool (optional)
+        If True (default), electrical series are written in acquisition. If False, only device, electrode_groups,
+        and electrodes are written to NWB.
     write_scaled: bool (optional, defaults to True)
         If True, writes the scaled traces (return_scaled=True)
     compression: str (optional, defaults to "gzip")
@@ -822,20 +826,21 @@ def add_all_to_nwbfile(
         nwbfile=nwbfile,
         metadata=metadata,
     )
-    add_electrical_series(
-        recording=recording,
-        nwbfile=nwbfile,
-        starting_time=starting_time,
-        use_times=use_times,
-        metadata=metadata,
-        write_as=write_as,
-        es_key=es_key,
-        write_scaled=write_scaled,
-        compression=compression,
-        compression_opts=compression_opts,
-        iterator_type=iterator_type,
-        iterator_opts=iterator_opts,
-    )
+    if write_electrical_series:
+        add_electrical_series(
+            recording=recording,
+            nwbfile=nwbfile,
+            starting_time=starting_time,
+            use_times=use_times,
+            metadata=metadata,
+            write_as=write_as,
+            es_key=es_key,
+            write_scaled=write_scaled,
+            compression=compression,
+            compression_opts=compression_opts,
+            iterator_type=iterator_type,
+            iterator_opts=iterator_opts,
+        )
     if isinstance(recording, RecordingExtractor):
         add_epochs(recording=recording, nwbfile=nwbfile, metadata=metadata)
 
@@ -850,6 +855,7 @@ def write_recording(
     metadata: dict = None,
     write_as: str = "raw",
     es_key: str = None,
+    write_electrical_series: bool = True,
     write_scaled: bool = False,
     compression: Optional[str] = "gzip",
     compression_opts: Optional[int] = None,
@@ -921,6 +927,9 @@ def write_recording(
         - 'lfp' will save it as LFP, in a processing module
     es_key: str (optional)
         Key in metadata dictionary containing metadata info for the specific electrical series
+    write_electrical_series: bool (optional)
+        If True (default), electrical series are written in acquisition. If False, only device, electrode_groups,
+        and electrodes are written to NWB.
     write_scaled: bool (optional, defaults to True)
         If True, writes the scaled traces (return_scaled=True)
     compression: str (optional, defaults to "gzip")
@@ -987,6 +996,7 @@ def write_recording(
                 compression_opts=compression_opts,
                 iterator_type=iterator_type,
                 iterator_opts=iterator_opts,
+                write_electrical_series=write_electrical_series,
             )
             io.write(nwbfile)
     else:
@@ -1003,6 +1013,7 @@ def write_recording(
             compression_opts=compression_opts,
             iterator_type=iterator_type,
             iterator_opts=iterator_opts,
+            write_electrical_series=write_electrical_series,
         )
 
 

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -136,6 +136,16 @@ class TestExtractors(unittest.TestCase):
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
+        
+        # Test write_electrical_series=False
+        write_recording(recording=self.RX, save_path=path, overwrite=True, write_electrical_series=False)
+        with NWBHDF5IO(path, "r") as io:
+            nwbfile = io.read()
+            assert len(nwbfile.acquisition) == 0
+            assert len(nwbfile.devices) == 1
+            assert len(nwbfile.electrode_groups) == 1
+            assert len(nwbfile.electrodes) == self.RX.get_num_channels()
+
 
         # Writing multiple recordings using metadata
         metadata = get_default_nwbfile_metadata()

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -136,7 +136,7 @@ class TestExtractors(unittest.TestCase):
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
-        
+
         # Test write_electrical_series=False
         write_recording(recording=self.RX, save_path=path, overwrite=True, write_electrical_series=False)
         with NWBHDF5IO(path, "r") as io:
@@ -145,7 +145,6 @@ class TestExtractors(unittest.TestCase):
             assert len(nwbfile.devices) == 1
             assert len(nwbfile.electrode_groups) == 1
             assert len(nwbfile.electrodes) == self.RX.get_num_channels()
-
 
         # Writing multiple recordings using metadata
         metadata = get_default_nwbfile_metadata()


### PR DESCRIPTION
Fix https://github.com/catalystneuro/nwb-conversion-tools/pull/368

## Motivation

Add `write_electrical_series` option to `write_recording` to optionally avoid writing time series .

## How to test the behavior?
```
write_recording(..., write_electrical_series=False)
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
