### PR TITLE
Remove gain correction for old SI

### DIFF
--- a/nwb_conversion_tools/utils/spike_interface.py
+++ b/nwb_conversion_tools/utils/spike_interface.py
@@ -120,10 +120,6 @@ def add_devices(recording: SpikeInterfaceRecording, nwbfile=None, metadata: dict
             ]
         Missing keys in an element of metadata['Ecephys']['Device'] will be auto-populated with defaults.
     """
-    if isinstance(recording, RecordingExtractor):
-        checked_recording = OldToNewRecording(oldapi_recording_extractor=recording)
-    else:
-        checked_recording = recording
     if nwbfile is not None:
         assert isinstance(nwbfile, pynwb.NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
 
@@ -524,27 +520,7 @@ def add_electrical_series(
     whenever possible.
     """
     if isinstance(recording, RecordingExtractor):
-        # If the object is a SubRecording, we recover the gains either the first parent with non-default gains, or the
-        # highest level parent.
-        channel_conversion = recording.get_channel_gains()
-        default_channel_conversion = np.ones_like(channel_conversion)
-        channel_offset = recording.get_channel_offsets()
-        temp_recording = recording
-        while isinstance(temp_recording, SubRecordingExtractor):
-            parent_recording = temp_recording._parent_recording
-            channel_conversion = parent_recording.get_channel_gains()
-            channel_offset = parent_recording.get_channel_offsets()
-
-            default_channel_conversion = np.ones_like(channel_conversion)
-            if np.any(channel_conversion != default_channel_conversion):
-                break
-            else:
-                temp_recording = parent_recording
         checked_recording = OldToNewRecording(oldapi_recording_extractor=recording)
-        if np.any(channel_conversion != default_channel_conversion):
-            checked_recording.set_channel_gains(gains=channel_conversion)
-        if np.any(channel_offset != np.zeros_like(channel_offset)):
-            checked_recording.set_channel_offsets(offsets=channel_offset)
     else:
         checked_recording = recording
     if nwbfile is not None:

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -10,8 +10,8 @@ jsonschema==3.2.0
 psutil==5.8.0
 lxml==4.6.5
 opencv-python==4.5.1.48
-spikeextractors @ git+https://github.com/SpikeInterface/spikeextractors.git@8a8a7a131614676e32093c5a928a470f4eed7063
-spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@628f7fbad370d445d22aaaf126e3e75aaeab09e8
+spikeextractors @ git+https://github.com/SpikeInterface/spikeextractors.git@48a86a048a4e6c5b9d669fd4f3bbf58caa97583a
+spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@dd9272622184683235277f959d318daa98adf382
 neo==0.10.0
 roiextractors==0.3.1
 ndx-events==0.2.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -10,6 +10,6 @@ jsonschema>=3.2.0
 psutil>=5.8.0
 lxml>=4.6.5
 spikeextractors>=0.9.7
-spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@628f7fbad370d445d22aaaf126e3e75aaeab09e8
+spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git
 neo>=0.9.0
 roiextractors>=0.3.1


### PR DESCRIPTION
Fix https://github.com/catalystneuro/nwb-conversion-tools/issues/369

## Motivation

Remove unused code and code to retrieve correct gains and offsets for old extractors as now it's done in the `OldToNewRecording` (https://github.com/SpikeInterface/spikeinterface/pull/462)

## How to test the behavior?
```
import spikeextractors as se
from nwb_conversion_tools import write_recording

rec, sort = se.example_datasets.toy_example()
rec.set_channel_gains(0.1)
rec_sub = se.SubRecordingExtractor(end_frame=100)

write_recording(rec_sub, save_path="test_gains.nwb")
# the gain is correctly set to 0.1 in the nwb file
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
