### PR TITLE
Version pin dev versions of spikeextractors and spikeinterface

### DIFF
--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -10,8 +10,8 @@ jsonschema==3.2.0
 psutil==5.8.0
 lxml==4.6.5
 opencv-python==4.5.1.48
-spikeextractors @ git+https://github.com/SpikeInterface/spikeextractors.git
-spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git
+spikeextractors @ git+https://github.com/SpikeInterface/spikeextractors.git@8a8a7a131614676e32093c5a928a470f4eed7063
+spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@628f7fbad370d445d22aaaf126e3e75aaeab09e8
 neo==0.10.0
 roiextractors==0.3.1
 ndx-events==0.2.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -10,6 +10,6 @@ jsonschema>=3.2.0
 psutil>=5.8.0
 lxml>=4.6.5
 spikeextractors>=0.9.7
-spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git
+spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@628f7fbad370d445d22aaaf126e3e75aaeab09e8
 neo>=0.9.0
 roiextractors>=0.3.1


### PR DESCRIPTION
## Motivation

Some recent changes to the master branch of `spikeinterface/spikeextractors` broke the Intan interfaces; not only for PR #370 , but also on `nwb-conversion-tools/main`. Instead of listing unreleased requirements as pointing to branches (which can change), updating them to point to specific hashes; specifically, those before the offending changes were merged.

Attn: @alejoe91 - If you could look into fixing this ASAP so not only #370 works, but so that this bug doesn't continue further into future hash updates and even releases. See https://github.com/catalystneuro/nwb-conversion-tools/runs/4844537233?check_suite_focus=true for traceback reference. I also reproduced in a fresh environment with current `spikeextractors` master.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
