### PR TITLE
Save output from GIN tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,7 @@ for `ophys` data.
 
 Once the data is downloaded to your system, you must manually modify the `test_gin_{modality}.py` files ([line #43 for ecehys](https://github.com/catalystneuro/nwb-conversion-tools/blob/main/tests/test_on_data/test_gin_ecephys.py#L43) and [line #34 for ophys](https://github.com/catalystneuro/nwb-conversion-tools/blob/main/tests/test_on_data/test_gin_ophys.py#L34)) to point to the correct folder on your system that contains the dataset folder (e.g., `ephy_testing_data` for testing `ecephys`). The code will automatically detect that the tests are being run locally, so all you need to do ensure the path is correct to your specific system.
 
+The output of these tests is, by default, stored in a temporary directory that is then cleaned after the tests finish running. To examine these files for quality assessment purposes, set the flag `SAVE_OUTPUTS=True` and modify the local `OUTPUT_PATH` if necessary.
+
 ## Rebuilding on Read the Docs
 As a maintainer, once the changes to the documentation are on the master branch, go to [https://readthedocs.org/projects/nwb-conversion-tools/](https://readthedocs.org/projects/nwb-conversion-tools/) and click "Build version". Check the console output and its log for any errors.

--- a/tests/test_on_data/test_gin.py
+++ b/tests/test_on_data/test_gin.py
@@ -48,6 +48,13 @@ else:
 DATA_PATH = LOCAL_PATH / "ephy_testing_data"
 HAVE_DATA = DATA_PATH.exists()
 
+SAVE_OUTPUTS = True
+if SAVE_OUTPUTS:
+    OUTPUT_PATH = LOCAL_PATH / "example_nwb_output"
+    OUTPUT_PATH.mkdir(exist_ok=True)
+else:
+    OUTPUT_PATH = Path(tempfile.mkdtemp())
+
 if not HAVE_PARAMETERIZED:
     pytest.fail("parameterized module is not installed! Please install (`pip install parameterized`).")
 
@@ -63,7 +70,7 @@ def custom_name_func(testcase_func, param_num, param):
 
 
 class TestNwbConversions(unittest.TestCase):
-    savedir = Path(tempfile.mkdtemp())
+    savedir = OUTPUT_PATH
 
     parameterized_lfp_list = [
         param(

--- a/tests/test_on_data/test_gin.py
+++ b/tests/test_on_data/test_gin.py
@@ -48,7 +48,7 @@ else:
 DATA_PATH = LOCAL_PATH / "ephy_testing_data"
 HAVE_DATA = DATA_PATH.exists()
 
-SAVE_OUTPUTS = True
+SAVE_OUTPUTS = False
 if SAVE_OUTPUTS:
     OUTPUT_PATH = LOCAL_PATH / "example_nwb_output"
     OUTPUT_PATH.mkdir(exist_ok=True)

--- a/tests/test_on_data/test_gin_ophys.py
+++ b/tests/test_on_data/test_gin_ophys.py
@@ -38,6 +38,13 @@ else:
 OPHYS_DATA_PATH = LOCAL_PATH / "ophys_testing_data"
 HAVE_OPHYS_DATA = OPHYS_DATA_PATH.exists()
 
+SAVE_OUTPUTS = False
+if SAVE_OUTPUTS:
+    OUTPUT_PATH = LOCAL_PATH / "example_nwb_output"
+    OUTPUT_PATH.mkdir(exist_ok=True)
+else:
+    OUTPUT_PATH = Path(tempfile.mkdtemp())
+
 if not HAVE_PARAMETERIZED:
     pytest.fail("parameterized module is not installed! Please install (`pip install parameterized`).")
 
@@ -53,7 +60,7 @@ def custom_name_func(testcase_func, param_num, param):
 
 
 class TestOphysNwbConversions(unittest.TestCase):
-    savedir = Path(tempfile.mkdtemp())
+    savedir = OUTPUT_PATH
 
     imaging_interface_list = [
         param(


### PR DESCRIPTION
## Motivation
Allows the output of GIN tests to be saved to a non-temporary folder (should be disabled by default on `main`, and only recommended for these kinds of review purposes).

I've uploaded the output from the most up-to-date version to slack (GitHub won't let me do it here).

## How to test the behavior?
In `test_gin.py`, simply flip the flag `SAVE_OUTPUTS` and adjust the `OUTPUT_PATH` as desired.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
