### PR TITLE
Modify neuroscope to use spike interface

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -95,7 +95,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         if isinstance(self.recording_extractor, se.RecordingExtractor):
             recording_extractor = se.SubRecordingExtractor(self.recording_extractor, **kwargs)
         elif isinstance(self.recording_extractor, si.BaseRecording):
-            recording_extractor = si.FrameSliceRecording(self.recording_extractor, end_frame=end_frame)
+            recording_extractor = self.recording_extractor.frame_slice(start_frame=0, end_frame=end_frame)
         else:
             raise f"{self.recording_extractor} should be either se.RecordingExtractor or si.BaseRecording"
 

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -97,7 +97,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         elif isinstance(self.recording_extractor, si.BaseRecording):
             recording_extractor = self.recording_extractor.frame_slice(start_frame=0, end_frame=end_frame)
         else:
-            raise f"{self.recording_extractor} should be either se.RecordingExtractor or si.BaseRecording"
+            raise TypeError(f"{self.recording_extractor} should be either se.RecordingExtractor or si.BaseRecording")
 
         return recording_extractor
 

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -99,8 +99,6 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         else:
             raise f"{self.recording_extractor} should be either se.RecordingExtractor or si.BaseRecording"
 
-        print("Passing by here")
-
         return recording_extractor
 
     def run_conversion(

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -4,6 +4,8 @@ from typing import Optional
 import numpy as np
 
 import spikeextractors as se
+import spikeinterface as si
+
 from pynwb import NWBFile
 from pynwb.device import Device
 from pynwb.ecephys import ElectrodeGroup
@@ -90,7 +92,15 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         if self.subset_channels is not None:
             kwargs.update(channel_ids=self.subset_channels)
 
-        recording_extractor = se.SubRecordingExtractor(self.recording_extractor, **kwargs)
+        if isinstance(self.recording_extractor, se.RecordingExtractor):
+            recording_extractor = se.SubRecordingExtractor(self.recording_extractor, **kwargs)
+        elif isinstance(self.recording_extractor, si.BaseRecording):
+            recording_extractor = si.FrameSliceRecording(self.recording_extractor, end_frame=end_frame)
+        else:
+            raise f"{self.recording_extractor} should be either se.RecordingExtractor or si.BaseRecording"
+
+        print("Passing by here")
+
         return recording_extractor
 
     def run_conversion(

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import spikeextractors as se
+import spikeinterface as si
 from spikeinterface.core.old_api_utils import OldToNewRecording
 
 from pynwb.ecephys import ElectricalSeries

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -31,6 +31,7 @@ def subset_shank_channels(
     else:
         recording = recording_extractor
     shank_channels = get_shank_channels(xml_file_path=xml_file_path)
+    
     if shank_channels is not None:
         channel_ids = [channel_id for group in shank_channels for channel_id in group]
         sub_recording = recording.channel_slice(channel_ids)

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -1,8 +1,10 @@
 """Authors: Cody Baker and Ben Dichter."""
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import spikeextractors as se
+import spikeinterface as si
+
 from pynwb.ecephys import ElectricalSeries
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
@@ -20,16 +22,20 @@ except ImportError:
 INSTALL_MESSAGE = "Please install lxml to use this interface!"
 
 
-def subset_shank_channels(recording_extractor: se.RecordingExtractor, xml_file_path: str) -> se.SubRecordingExtractor:
+def subset_shank_channels(
+    recording_extractor: Union[se.RecordingExtractor, si.BaseRecording], xml_file_path: str
+) -> si.BaseRecording:
     """Attempt to create a SubRecordingExtractor containing only channels related to neural data."""
+    if isinstance(recording_extractor, se.RecordingExtractor):
+        recording = si.core.old_api_utils.OldToNewRecording(recording_extractor)
+    else:
+        recording = recording_extractor
     shank_channels = get_shank_channels(xml_file_path=xml_file_path)
     if shank_channels is not None:
-        sub_recording = se.SubRecordingExtractor(
-            parent_recording=recording_extractor,
-            channel_ids=[channel_id for group in shank_channels for channel_id in group],
-        )
+        channel_ids = [channel_id for group in shank_channels for channel_id in group]
+        sub_recording = recording.channel_slice(channel_ids)
     else:
-        sub_recording = recording_extractor
+        sub_recording = recording
     return sub_recording
 
 
@@ -43,7 +49,8 @@ def add_recording_extractor_properties(recording_extractor: se.RecordingExtracto
     group_electrode_numbers = [x for channels in channel_groups for x, _ in enumerate(channels)]
     group_nums = [n + 1 for n, channels in enumerate(channel_groups) for _ in channels]
     group_names = [f"Group{n}" for n in group_nums]
-    for channel_id in recording_extractor.get_channel_ids():
+
+    for channel_id in channel_map.keys():
         recording_extractor.set_channel_groups(channel_ids=[channel_id], groups=group_nums[channel_map[channel_id]])
         recording_extractor.set_channel_property(
             channel_id=channel_id, property_name="group_name", value=group_names[channel_map[channel_id]]
@@ -105,10 +112,12 @@ class NeuroscopeRecordingInterface(BaseRecordingExtractorInterface):
         if xml_file_path is None:
             xml_file_path = get_xml_file_path(data_file_path=file_path)
         super().__init__(file_path=file_path, gain=gain, xml_file_path=xml_file_path)
+
+        # Add the properties
+        add_recording_extractor_properties(recording_extractor=self.recording_extractor, xml_file_path=xml_file_path)
         self.recording_extractor = subset_shank_channels(
             recording_extractor=self.recording_extractor, xml_file_path=xml_file_path
         )
-        add_recording_extractor_properties(recording_extractor=self.recording_extractor, xml_file_path=xml_file_path)
 
     def get_metadata_schema(self):
         metadata_schema = super().get_metadata_schema()
@@ -204,10 +213,11 @@ class NeuroscopeLFPInterface(BaseLFPExtractorInterface):
         if xml_file_path is None:
             xml_file_path = get_xml_file_path(data_file_path=file_path)
         super().__init__(file_path=file_path, gain=gain, xml_file_path=xml_file_path)
+
+        add_recording_extractor_properties(recording_extractor=self.recording_extractor, xml_file_path=xml_file_path)
         self.recording_extractor = subset_shank_channels(
             recording_extractor=self.recording_extractor, xml_file_path=xml_file_path
         )
-        add_recording_extractor_properties(recording_extractor=self.recording_extractor, xml_file_path=xml_file_path)
 
     def get_metadata(self):
         session_path = Path(self.source_data["file_path"]).parent

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import spikeextractors as se
-import spikeinterface as si
+from spikeinterface.core.old_api_utils import OldToNewRecording
 
 from pynwb.ecephys import ElectricalSeries
 

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -31,7 +31,7 @@ def subset_shank_channels(
     else:
         recording = recording_extractor
     shank_channels = get_shank_channels(xml_file_path=xml_file_path)
-    
+
     if shank_channels is not None:
         channel_ids = [channel_id for group in shank_channels for channel_id in group]
         sub_recording = recording.channel_slice(channel_ids)

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -27,7 +27,7 @@ def subset_shank_channels(
 ) -> si.BaseRecording:
     """Attempt to create a SubRecordingExtractor containing only channels related to neural data."""
     if isinstance(recording_extractor, se.RecordingExtractor):
-        recording = si.core.old_api_utils.OldToNewRecording(recording_extractor)
+        recording = OldToNewRecording(oldapi_recording_extractor=recording_extractor)
     else:
         recording = recording_extractor
     shank_channels = get_shank_channels(xml_file_path=xml_file_path)

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -7,7 +7,7 @@ import numpy as np
 import numpy.testing as npt
 
 import pytest
-from spikeinterface.core.old_api_utils import OldToNewRecording
+from spikeinterface.core.old_api_utils import OldToNewRecording, BaseRecording
 from spikeextractors import NwbRecordingExtractor, NwbSortingExtractor, RecordingExtractor
 from spikeextractors.testing import check_recordings_equal, check_sortings_equal
 from spikeinterface.core.testing import check_recordings_equal as check_recordings_equal_si
@@ -188,7 +188,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
                 ]
             )
 
-        if isinstance(recording, si.BaseRecording):
+        if isinstance(recording, BaseRecording):
             nwb_recording = OldToNewRecording(oldapi_recording_extractor=nwb_recording)
 
         if isinstance(recording, RecordingExtractor):

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -7,7 +7,7 @@ import numpy as np
 import numpy.testing as npt
 
 import pytest
-import spikeinterface as si
+from spikeinterface.core.old_api_utils import OldToNewRecording
 from spikeextractors import NwbRecordingExtractor, NwbSortingExtractor, RecordingExtractor
 from spikeextractors.testing import check_recordings_equal, check_sortings_equal
 from spikeinterface.core.testing import check_recordings_equal as check_recordings_equal_si

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -203,7 +203,9 @@ class TestEcephysNwbConversions(unittest.TestCase):
 
         else:
             check_recordings_equal_si(RX1=recording, RX2=nwb_recording, return_scaled=False)
-            check_recordings_equal_si(RX1=recording, RX2=nwb_recording, return_scaled=True)
+            # This can only be tested if both gain and offest are present
+            if recording.has_scaled_traces() and nwb_recording.has_scaled_traces():
+                check_recordings_equal_si(RX1=recording, RX2=nwb_recording, return_scaled=True)
 
     @parameterized.expand(
         input=[

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -189,7 +189,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
             )
 
         if isinstance(recording, si.BaseRecording):
-            nwb_recording = si.core.old_api_utils.OldToNewRecording(nwb_recording)
+            nwb_recording = OldToNewRecording(oldapi_recording_extractor=nwb_recording)
 
         if isinstance(recording, RecordingExtractor):
             check_recordings_equal(RX1=recording, RX2=nwb_recording, check_times=False, return_scaled=False)

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -7,8 +7,12 @@ import numpy as np
 import numpy.testing as npt
 
 import pytest
-from spikeextractors import NwbRecordingExtractor, NwbSortingExtractor
+import spikeinterface as si
+from spikeextractors import NwbRecordingExtractor, NwbSortingExtractor, RecordingExtractor
 from spikeextractors.testing import check_recordings_equal, check_sortings_equal
+from spikeinterface.core.testing import check_recordings_equal as check_recordings_equal_si
+
+
 from pynwb import NWBHDF5IO
 
 from nwb_conversion_tools import (
@@ -175,6 +179,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True)
         recording = converter.data_interface_objects["TestRecording"].recording_extractor
         nwb_recording = NwbRecordingExtractor(file_path=nwbfile_path)
+
         if "offset_to_uV" in nwb_recording.get_shared_channel_property_names():
             nwb_recording.set_channel_offsets(
                 offsets=[
@@ -182,13 +187,23 @@ class TestEcephysNwbConversions(unittest.TestCase):
                     for channel_id in nwb_recording.get_channel_ids()
                 ]
             )
-        check_recordings_equal(RX1=recording, RX2=nwb_recording, check_times=False, return_scaled=False)
-        check_recordings_equal(RX1=recording, RX2=nwb_recording, check_times=False, return_scaled=True)
-        # Technically, check_recordings_equal only tests a snippet of data. Above tests are for metadata mostly.
-        # For GIN test data, sizes should be OK to load all into RAM even on CI
-        npt.assert_array_equal(
-            x=recording.get_traces(return_scaled=False), y=nwb_recording.get_traces(return_scaled=False)
-        )
+
+        if isinstance(recording, si.BaseRecording):
+            nwb_recording = si.core.old_api_utils.OldToNewRecording(nwb_recording)
+
+        if isinstance(recording, RecordingExtractor):
+            check_recordings_equal(RX1=recording, RX2=nwb_recording, check_times=False, return_scaled=False)
+            check_recordings_equal(RX1=recording, RX2=nwb_recording, check_times=False, return_scaled=True)
+
+            # Technically, check_recordings_equal only tests a snippet of data. Above tests are for metadata mostly.
+            # For GIN test data, sizes should be OK to load all into RAM even on CI
+            npt.assert_array_equal(
+                x=recording.get_traces(return_scaled=False), y=nwb_recording.get_traces(return_scaled=False)
+            )
+
+        else:
+            check_recordings_equal_si(RX1=recording, RX2=nwb_recording, return_scaled=False)
+            check_recordings_equal_si(RX1=recording, RX2=nwb_recording, return_scaled=True)
 
     @parameterized.expand(
         input=[


### PR DESCRIPTION
## Motivation
This should fix #382

As discussed in the issue there is a shape mismatch between gains when the spikeinterface transforms a spikeextractor object to a spikeinterface one. The mismatch occurs when some of the channels are subset and the example in the issue was for neuroscope.

I was discussed with @bendichter yesterday and he mentioned that it would be a good idea to just change fully to `spikeinterface` for neuroscope as we intend to do it anyway at some point. This pull request is the first attempt in this direction and I start by implementing @alejoe91 suggestion in the issue to showcase some problems, discuss and get your feedback.

There are three modifications in the diff:
1) As per @alejoe91  suggestion the `subset_shank_channels` method in the neuroscope interface has been modified to transform the recorder and use the `channel_slice` method instead of subrecording.

2) To keep the changes minimal, the function `add_recording_extractor_properties` in `neuroscopedatainterface` is now called before the sub-recording as the `channel_slice` machinery includes functionality to copy the properties. Though, we change the SX attribute to the corresponding. spikeinterface we will need to modified the `add_recording_extractor_properties` consequently. 

3) As a consequence the method that creates stubs in `baserecordinginterface` has been modified to account for possible `si.BaseRecording` objects as input.

I converted some files with this and the error indeed disappears. I am going to move ahead and change the `SX` attribute to a new itnterface object to see if this still work. Any advice on pits to look for in this direciton @CodyCBakerPhD ?

## Problems
1) The data-type of the nwb files for both the raw data and the lfp is still a float after using this. I was under the wrong impression that the latest version of `nwb-conversion-tools` would avoid this.

2) For some reason there is one test failing and I could not pin it down: `test_converter_recording_extractor_to_nwb` is failing. The problem is that for neuroscope the `NWBRecordingExtractor.get_traces()` method seems to return the data transposed as in time is not the first dimension. This seems strange to me as the files that I produced do have the right dimension: `(stub_time, n_channels)`

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
