### PR TITLE
Add tests for Neuroscope dtype

### DIFF
--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -11,7 +11,7 @@ psutil==5.8.0
 lxml==4.6.5
 opencv-python==4.5.1.48
 spikeextractors @ git+https://github.com/SpikeInterface/spikeextractors.git@48a86a048a4e6c5b9d669fd4f3bbf58caa97583a
-spikeinterface @ git+https://github.com/catalystneuro/spikeinterface.git@Fix-old-to-new-recording-dtype
+spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@89270b7e8c707fdf6dfb81d95c13dd26316f2f1a
 neo==0.10.0
 roiextractors==0.3.1
 ndx-events==0.2.0

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -10,8 +10,8 @@ jsonschema==3.2.0
 psutil==5.8.0
 lxml==4.6.5
 opencv-python==4.5.1.48
-spikeinterface @ git+https://github.com/catalystneuro/spikeinterface.git@Fix-old-to-new-recording-dtype
 spikeextractors @ git+https://github.com/SpikeInterface/spikeextractors.git@48a86a048a4e6c5b9d669fd4f3bbf58caa97583a
+spikeinterface @ git+https://github.com/catalystneuro/spikeinterface.git@Fix-old-to-new-recording-dtype
 neo==0.10.0
 roiextractors==0.3.1
 ndx-events==0.2.0

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -10,8 +10,8 @@ jsonschema==3.2.0
 psutil==5.8.0
 lxml==4.6.5
 opencv-python==4.5.1.48
+spikeinterface @ git+https://github.com/catalystneuro/spikeinterface.git@Fix-old-to-new-recording-dtype
 spikeextractors @ git+https://github.com/SpikeInterface/spikeextractors.git@48a86a048a4e6c5b9d669fd4f3bbf58caa97583a
-spikeinterface @ git+https://github.com/catalystneuro/spikeinterface.git@e9a54b46005f26a910e375be3a65d1171891337d
 neo==0.10.0
 roiextractors==0.3.1
 ndx-events==0.2.0

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -11,7 +11,7 @@ psutil==5.8.0
 lxml==4.6.5
 opencv-python==4.5.1.48
 spikeextractors @ git+https://github.com/SpikeInterface/spikeextractors.git@48a86a048a4e6c5b9d669fd4f3bbf58caa97583a
-spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@dd9272622184683235277f959d318daa98adf382
+spikeinterface @ git+https://github.com/catalystneuro/spikeinterface.git@e9a54b46005f26a910e375be3a65d1171891337d
 neo==0.10.0
 roiextractors==0.3.1
 ndx-events==0.2.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -10,6 +10,6 @@ jsonschema>=3.2.0
 psutil>=5.8.0
 lxml>=4.6.5
 spikeextractors>=0.9.7
-spikeinterface @ git+https://github.com/catalystneuro/spikeinterface.git@Fix-old-to-new-recording-dtype
+spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@master
 neo>=0.9.0
 roiextractors>=0.3.1

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -10,6 +10,6 @@ jsonschema>=3.2.0
 psutil>=5.8.0
 lxml>=4.6.5
 spikeextractors>=0.9.7
-spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git
+spikeinterface @ git+https://github.com/catalystneuro/spikeinterface.git@Fix-old-to-new-recording-dtype
 neo>=0.9.0
 roiextractors>=0.3.1

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -276,7 +276,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, conversion_options=conversion_options)
 
         with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
-            nwbfile_in = io.read()
+            nwbfile = io.read()
             output_dtype = nwbfile_in.acquisition["ElectricalSeries_raw"].data.dtype
             self.assertEqual(first=output_dtype, second=np.dtype("int16"))
 

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -277,7 +277,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
 
         with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
             nwbfile = io.read()
-            output_dtype = nwbfile_in.acquisition["ElectricalSeries_raw"].data.dtype
+            output_dtype = nwbfile.acquisition["ElectricalSeries_raw"].data.dtype
             self.assertEqual(first=output_dtype, second=np.dtype("int16"))
 
     def test_neuroscope_starting_time(self):

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -235,34 +235,50 @@ class TestEcephysNwbConversions(unittest.TestCase):
     )
     def test_neuroscope_gains(self, name, conversion_options):
         input_gain = 2.0
-        data_interface = NeuroscopeRecordingInterface
         interface_kwargs = dict(file_path=str(DATA_PATH / "neuroscope" / "test1" / "test1.dat"), gain=input_gain)
 
-        nwbfile_path = str(self.savedir / f"{data_interface.__name__}-{name}.nwb")
+        nwbfile_path = str(self.savedir / f"test_neuroscope_gains_{name}.nwb")
 
         class TestConverter(NWBConverter):
-            data_interface_classes = dict(TestRecording=data_interface)
+            data_interface_classes = dict(TestRecording=NeuroscopeRecordingInterface)
 
         converter = TestConverter(source_data=dict(TestRecording=interface_kwargs))
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, conversion_options=conversion_options)
 
-        # nwb file check-test
-        io = NWBHDF5IO(nwbfile_path, "r")
-        nwbfile_in = io.read()
-        output_conversion = nwbfile_in.acquisition["ElectricalSeries_raw"].conversion
-        output_gain = output_conversion * 1e6
-        assert input_gain == pytest.approx(output_gain)
+        with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
+            nwbfile_in = io.read()
+            output_conversion = nwbfile_in.acquisition["ElectricalSeries_raw"].conversion
+            output_gain = output_conversion * 1e6
+            self.assertEqual(first=input_gain, second=output_gain)
 
-        # round-trip test with nwb extractor
-        nwb_recording = NwbRecordingExtractor(file_path=nwbfile_path)
-        nwb_recording_gains = nwb_recording.get_channel_gains()
-        npt.assert_almost_equal(input_gain * np.ones_like(nwb_recording_gains), nwb_recording_gains)
+            nwb_recording = NwbRecordingExtractor(file_path=nwbfile_path)
+            nwb_recording_gains = nwb_recording.get_channel_gains()
+            npt.assert_almost_equal(input_gain * np.ones_like(nwb_recording_gains), nwb_recording_gains)
 
-        # Other conditions, how this should interact with some intentional uses of subrecording extractor [we are not using stub_test]
-        # There should be a stub_test=True test.
+    @parameterized.expand(
+        input=[
+            param(
+                name="complete",
+                conversion_options=None,
+            ),
+            param(name="stub", conversion_options=dict(TestRecording=dict(stub_test=True))),
+        ]
+    )
+    def test_neuroscope_dtype(self, name, conversion_options):
+        interface_kwargs = dict(file_path=str(DATA_PATH / "neuroscope" / "test1" / "test1.dat"), gain=2.0)
 
-        # A subrecording extractor is a very simple class, input output (you can use the recorder above 'recording in 229')
-        # [The two things that you can do is to subest time [that is frames] or channels so maybe a combination of those uses.
+        nwbfile_path = str(self.savedir / f"test_neuroscope_dtype_{name}.nwb")
+
+        class TestConverter(NWBConverter):
+            data_interface_classes = dict(TestRecording=NeuroscopeRecordingInterface)
+
+        converter = TestConverter(source_data=dict(TestRecording=interface_kwargs))
+        converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, conversion_options=conversion_options)
+
+        with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
+            nwbfile_in = io.read()
+            output_dtype = nwbfile_in.acquisition["ElectricalSeries_raw"].data.dtype
+            self.assertEqual(first=output_dtype, second=np.dtype("int16"))
 
     def test_neuroscope_starting_time(self):
         nwbfile_path = str(self.savedir / "testing_start_time.nwb")

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -246,7 +246,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, conversion_options=conversion_options)
 
         with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
-            nwbfile_in = io.read()
+            nwbfile = io.read()
             output_conversion = nwbfile_in.acquisition["ElectricalSeries_raw"].conversion
             output_gain = output_conversion * 1e6
             self.assertEqual(first=input_gain, second=output_gain)

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -247,7 +247,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
 
         with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
             nwbfile = io.read()
-            output_conversion = nwbfile_in.acquisition["ElectricalSeries_raw"].conversion
+            output_conversion = nwbfile.acquisition["ElectricalSeries_raw"].conversion
             output_gain = output_conversion * 1e6
             self.assertEqual(first=input_gain, second=output_gain)
 


### PR DESCRIPTION
## Motivation

Recently discovered that when gains are set to an old RecordingExtractor, the newly refactored code for writing ElectricalSeries sometimes upcasts the data type to `float` due to a bug in the `OldToNewRecording` functions on spikeinterface. This PR adds explicit tests for this behavior and will point to a fix on SI to ensure it works.

Also attached some style suggestions for previous test written by @h-mayorquin 

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
