### PR TITLE
Testing SpikeExtractors latest version pin

### DIFF
--- a/.github/workflows/testing-linux.yml
+++ b/.github/workflows/testing-linux.yml
@@ -1,5 +1,5 @@
 name: Minimal and full tests on Linux
-on: pull_request
+on: push
 jobs:
   run:
     name: Minimal and full tests on Linux with Python ${{ matrix.python-version }}

--- a/.github/workflows/testing-linux.yml
+++ b/.github/workflows/testing-linux.yml
@@ -1,5 +1,5 @@
 name: Minimal and full tests on Linux
-on: push
+on: pull_request
 jobs:
   run:
     name: Minimal and full tests on Linux with Python ${{ matrix.python-version }}

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -10,7 +10,7 @@ jsonschema==3.2.0
 psutil==5.8.0
 lxml==4.6.5
 opencv-python==4.5.1.48
-spikeextractors @ git+https://github.com/SpikeInterface/spikeextractors.git@48a86a048a4e6c5b9d669fd4f3bbf58caa97583a
+spikeextractors==0.9.9
 spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@7ce6aa585f602919e3d922baae44a3bd16e9eb77
 neo==0.10.0
 roiextractors==0.3.1

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -9,7 +9,7 @@ PyYAML>=5.4
 jsonschema>=3.2.0
 psutil>=5.8.0
 lxml>=4.6.5
-spikeextractors>=0.9.7
+spikeextractors>=0.9.9
 spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@master
 neo>=0.9.0
 roiextractors>=0.3.1

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -9,7 +9,8 @@ PyYAML==5.4
 jsonschema==3.2.0
 psutil==5.8.0
 lxml==4.6.5
-spikeextractors==0.9.7
+spikeextractors==0.9.9
+spikeinterface==0.92.0
 neo==0.9.0
 roiextractors==0.3.1
 myst_parser==0.13.5


### PR DESCRIPTION
## Motivation

Only two things we need to iron out before doing a new release of `nwb-conversion-tools` is (a) pin to newest release of SE and make sure everything works (lots of various bug fixes there for certain extractors), and (b) get a new release of SpikeInterface and pin to that (lots of bug fixes for new API usage and `old_to_new` API utils).

## Checklist

- [X] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
