### PR TITLE
use movie functions without context manager

### DIFF
--- a/nwb_conversion_tools/datainterfaces/behavior/movie/movie_utils.py
+++ b/nwb_conversion_tools/datainterfaces/behavior/movie/movie_utils.py
@@ -22,7 +22,7 @@ def get_movie_timestamps(movie_file: PathType):
     movie_file : PathType
     """
     cap = cv2.VideoCapture(str(movie_file))
-    timestamps = [cap.get(cv2.CAP_PROP_POS_MSEC)]
+    timestamps = []
     success, frame = cap.read()
     while success:
         timestamps.append(cap.get(cv2.CAP_PROP_POS_MSEC))
@@ -60,3 +60,62 @@ def get_frame_shape(movie_file: PathType):
     success, frame = cap.read()
     cap.release()
     return frame.shape
+
+
+def get_movie_frame_count(movie_file: PathType):
+    """
+    Return the total number of frames for a movie file.
+
+    """
+    cap = cv2.VideoCapture(str(movie_file))
+    if int(cv2.__version__.split(".")[0]) < 3:
+        count = cap.get(cv2.cv.CV_CAP_PROP_FRAME_COUNT)
+    else:
+        count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+    cap.release()
+    return int(count)
+
+
+def get_frame_no(movie_file: PathType, frame_no: int=0):
+    """
+    Retrive the frame no from a movie and return as array
+    Parameters
+    ----------
+    movie_file: PathType
+    frame_no: int
+    Returns
+    -------
+    frame: np.array
+    """
+    assert frame_no < get_movie_frame_count(movie_file), "frame number is greater than length of movie"
+    cap = cv2.VideoCapture(str(movie_file))
+    if int(cv2.__version__.split(".")[0]) < 3:
+        set_arg = cv2.cv.CV_CAP_PROP_POS_FRAMES
+    else:
+        set_arg = cv2.CAP_PROP_POS_FRAMES
+    set_value = cap.set(set_arg, frame_no)
+    if not set_value:
+        return
+    success, frame = cap.read()
+    if success:
+        return frame
+
+
+def get_movie_frames(movie_file: PathType, count_max: int=None):
+    """
+    Returns a generator that returns sequential movie frames
+    Parameters
+    ----------
+    movie_file: PathType
+
+    Returns
+    -------
+    frame: np.array
+    """
+    no_frames = get_movie_frame_count(movie_file)
+    count_max = no_frames if count_max is None else count_max
+    for frame_no in range(count_max):
+        cap = cv2.VideoCapture(str(movie_file))
+        success, frame = cap.read()
+        yield frame
+    cap.release()

--- a/nwb_conversion_tools/datainterfaces/behavior/movie/movie_utils.py
+++ b/nwb_conversion_tools/datainterfaces/behavior/movie/movie_utils.py
@@ -76,7 +76,7 @@ def get_movie_frame_count(movie_file: PathType):
     return int(count)
 
 
-def get_frame_no(movie_file: PathType, frame_no: int=0):
+def get_frame_no(movie_file: PathType, frame_no: int = 0):
     """
     Retrive the frame no from a movie and return as array
     Parameters
@@ -101,7 +101,7 @@ def get_frame_no(movie_file: PathType, frame_no: int=0):
         return frame
 
 
-def get_movie_frames(movie_file: PathType, count_max: int=None):
+def get_movie_frames(movie_file: PathType, count_max: int = None):
     """
     Returns a generator that returns sequential movie frames
     Parameters

--- a/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
@@ -14,13 +14,7 @@ from tqdm import tqdm
 from ....basedatainterface import BaseDataInterface
 from ....utils.conversion_tools import check_regular_timestamps, get_module
 from ....utils.json_schema import get_schema_from_hdmf_class, get_base_schema
-from .movie_utils import (
-    get_movie_fps,
-    get_movie_timestamps,
-    get_frame_shape,
-    get_movie_frames,
-    get_movie_frame_count
-)
+from .movie_utils import get_movie_fps, get_movie_timestamps, get_frame_shape, get_movie_frames, get_movie_frame_count
 
 try:
     import cv2

--- a/tests/test_internals/test_interfaces.py
+++ b/tests/test_internals/test_interfaces.py
@@ -1,21 +1,16 @@
-import numpy as np
+from pathlib import Path
 from platform import python_version
 from sys import platform
-from packaging import version
 from tempfile import mkdtemp
-from shutil import rmtree
-from pathlib import Path
-from itertools import product
 
 import pytest
 import spikeextractors as se
-from spikeextractors.testing import check_recordings_equal, check_sortings_equal
-from pynwb import NWBHDF5IO
 from hdmf.testing import TestCase
+from packaging import version
+from spikeextractors.testing import check_recordings_equal, check_sortings_equal
 
 from nwb_conversion_tools import (
     NWBConverter,
-    MovieInterface,
     RecordingTutorialInterface,
     SortingTutorialInterface,
     SIPickleRecordingExtractorInterface,
@@ -117,106 +112,3 @@ def test_pkl_interface():
     check_recordings_equal(RX1=toy_data[0], RX2=nwb_recording)
     check_recordings_equal(RX1=toy_data[0], RX2=nwb_recording, return_scaled=False)
     check_sortings_equal(SX1=toy_data[1], SX2=nwb_sorting)
-
-
-def test_movie_interface():
-    if HAVE_OPENCV:
-        test_dir = Path(mkdtemp())
-        movie_file = test_dir / "test1.avi"
-        nwbfile_path = str(test_dir / "test1.nwb")
-        (nf, nx, ny) = (50, 640, 480)
-        writer = cv2.VideoWriter(
-            filename=str(movie_file),
-            apiPreference=None,
-            fourcc=cv2.VideoWriter_fourcc("M", "J", "P", "G"),
-            fps=25,
-            frameSize=(ny, nx),
-            params=None,
-        )
-        for k in range(nf):
-            writer.write(np.random.randint(0, 255, (nx, ny, 3)).astype("uint8"))
-        writer.release()
-
-        class MovieTestNWBConverter(NWBConverter):
-            data_interface_classes = dict(Movie=MovieInterface)
-
-        source_data = dict(Movie=dict(file_paths=[movie_file]))
-        converter = MovieTestNWBConverter(source_data)
-        metadata = converter.get_metadata()
-
-        # Default usage
-        converter.run_conversion(metadata=metadata, nwbfile_path=nwbfile_path, overwrite=True)
-
-        # This conversion option operates independently of all others
-        converter.run_conversion(
-            metadata=metadata,
-            nwbfile_path=nwbfile_path,
-            overwrite=True,
-            conversion_options=dict(Movie=dict(starting_times=[123.0])),
-        )
-
-        # These conversion options do not operate independently, so test them jointly
-        conversion_options_testing_matrix = [
-            dict(Movie=dict(external_mode=False, stub_test=x, chunk_data=y))
-            for x, y in product([True, False], repeat=2)
-        ]
-        for conversion_options in conversion_options_testing_matrix:
-            converter.run_conversion(
-                metadata=metadata, nwbfile_path=nwbfile_path, overwrite=True, conversion_options=conversion_options
-            )
-
-        module_name = "TestModule"
-        module_description = "This is a test module."
-        nwbfile = converter.run_conversion(metadata=metadata, save_to_file=False)
-        assert f"Video: {Path(movie_file).stem}" in nwbfile.acquisition
-        nwbfile = converter.run_conversion(
-            metadata=metadata,
-            save_to_file=False,
-            nwbfile=nwbfile,
-            conversion_options=dict(Movie=dict(module_name=module_name)),
-        )
-        assert module_name in nwbfile.modules
-        nwbfile = converter.run_conversion(
-            metadata=metadata,
-            save_to_file=False,
-            conversion_options=dict(Movie=dict(module_name=module_name, module_description=module_description)),
-        )
-        assert module_name in nwbfile.modules and nwbfile.modules[module_name].description == module_description
-
-        metadata.update(
-            Behavior=dict(
-                Movies=[
-                    dict(
-                        name="CustomName",
-                        description="CustomDescription",
-                        unit="CustomUnit",
-                        resolution=12.3,
-                        comments="CustomComments",
-                    )
-                ]
-            )
-        )
-        converter.run_conversion(metadata=metadata, nwbfile_path=nwbfile_path, overwrite=True)
-        with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
-            nwbfile = io.read()
-            custom_name = metadata["Behavior"]["Movies"][0]["name"]
-            assert custom_name in nwbfile.acquisition
-            assert metadata["Behavior"]["Movies"][0]["description"] == nwbfile.acquisition[custom_name].description
-            assert metadata["Behavior"]["Movies"][0]["comments"] == nwbfile.acquisition[custom_name].comments
-
-        converter.run_conversion(
-            metadata=metadata,
-            nwbfile_path=nwbfile_path,
-            overwrite=True,
-            conversion_options=dict(Movie=dict(external_mode=False, stub_test=True)),
-        )
-        with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
-            nwbfile = io.read()
-            custom_name = metadata["Behavior"]["Movies"][0]["name"]
-            assert custom_name in nwbfile.acquisition
-            assert metadata["Behavior"]["Movies"][0]["description"] == nwbfile.acquisition[custom_name].description
-            assert metadata["Behavior"]["Movies"][0]["unit"] == nwbfile.acquisition[custom_name].unit
-            assert metadata["Behavior"]["Movies"][0]["resolution"] == nwbfile.acquisition[custom_name].resolution
-            assert metadata["Behavior"]["Movies"][0]["comments"] == nwbfile.acquisition[custom_name].comments
-
-        rmtree(test_dir)

--- a/tests/test_internals/test_movie_interface.py
+++ b/tests/test_internals/test_movie_interface.py
@@ -1,0 +1,126 @@
+import shutil
+import unittest
+import tempfile
+import numpy as np
+from pynwb import NWBHDF5IO
+import os
+from nwb_conversion_tools import NWBConverter, MovieInterface
+
+try:
+    import cv2
+
+    skip_test = False
+except ImportError:
+    skip_test = True
+
+
+@unittest.skipIf(skip_test, "cv2 not installed")
+class TestMovieInterface(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_dir = tempfile.mkdtemp()
+        self.movie_files = self.create_movies()
+        self.nwb_converter = self.create_movie_converter()
+        self.nwbfile_path = os.path.join(self.test_dir, "movie_test.nwb")
+
+    def create_movies(self):
+        movie_file1 = os.path.join(self.test_dir, "test1.avi")
+        movie_file2 = os.path.join(self.test_dir, "test2.avi")
+        (nf, nx, ny) = (10, 640, 480)
+        writer1 = cv2.VideoWriter(
+            filename=movie_file1,
+            apiPreference=None,
+            fourcc=cv2.VideoWriter_fourcc("M", "J", "P", "G"),
+            fps=25,
+            frameSize=(ny, nx),
+            params=None,
+        )
+        writer2 = cv2.VideoWriter(
+            filename=movie_file2,
+            apiPreference=None,
+            fourcc=cv2.VideoWriter_fourcc("M", "J", "P", "G"),
+            fps=25,
+            frameSize=(ny, nx),
+            params=None,
+        )
+
+        for k in range(nf):
+            writer1.write(np.random.randint(0, 255, (nx, ny, 3)).astype("uint8"))
+            writer2.write(np.random.randint(0, 255, (nx, ny, 3)).astype("uint8"))
+        writer1.release()
+        writer2.release()
+        return [movie_file1, movie_file2]
+
+    def create_movie_converter(self):
+        class MovieTestNWBConverter(NWBConverter):
+            data_interface_classes = dict(Movie=MovieInterface)
+
+        source_data = dict(Movie=dict(file_paths=self.movie_files))
+        return MovieTestNWBConverter(source_data)
+
+    def test_movie_starting_times(self):
+        starting_times = [np.float(np.random.randint(200)) for i in range(len(self.movie_files))]
+        conversion_opts = dict(Movie=dict(starting_times=starting_times, external_mode=False))
+        self.nwb_converter.run_conversion(
+            nwbfile_path=self.nwbfile_path, overwrite=True, conversion_options=conversion_opts
+        )
+        with NWBHDF5IO(path=self.nwbfile_path, mode="r") as io:
+            nwbfile = io.read()
+            mod = nwbfile.acquisition
+            metadata = self.nwb_converter.get_metadata()
+            for no in range(len(metadata["Behavior"]["Movies"])):
+                movie_interface_name = metadata["Behavior"]["Movies"][no]["name"]
+                assert movie_interface_name in mod
+                assert starting_times[no] == mod[movie_interface_name].starting_time
+
+    def test_movie_custom_module(self):
+        starting_times = [np.float(np.random.randint(200)) for i in range(len(self.movie_files))]
+        module_name = "TestModule"
+        module_description = "This is a test module."
+        conversion_opts = dict(
+            Movie=dict(
+                starting_times=starting_times,
+                external_mode=False,
+                module_name=module_name,
+                module_description=module_description,
+            )
+        )
+        self.nwb_converter.run_conversion(
+            nwbfile_path=self.nwbfile_path, overwrite=True, conversion_options=conversion_opts
+        )
+        with NWBHDF5IO(path=self.nwbfile_path, mode="r") as io:
+            nwbfile = io.read()
+            assert module_name in nwbfile.processing
+            assert module_description == nwbfile.processing[module_name].description
+
+    def test_movie_chunking(self):
+        starting_times = [np.float(np.random.randint(200)) for i in range(len(self.movie_files))]
+        conv_ops = dict(
+            Movie=dict(external_mode=False, stub_test=True, starting_times=starting_times, chunk_data=False)
+        )
+        self.nwb_converter.run_conversion(nwbfile_path=self.nwbfile_path, overwrite=True, conversion_options=conv_ops)
+
+        with NWBHDF5IO(path=self.nwbfile_path, mode="r") as io:
+            nwbfile = io.read()
+            mod = nwbfile.acquisition
+            metadata = self.nwb_converter.get_metadata()
+            for no in range(len(metadata["Behavior"]["Movies"])):
+                movie_interface_name = metadata["Behavior"]["Movies"][no]["name"]
+                assert mod[movie_interface_name].data.chunks is not None  # TODO retrive storage_layout of hdf5 dataset
+
+    def test_movie_external_mode(self):
+        starting_times = [np.float(np.random.randint(200)) for i in range(len(self.movie_files))]
+        conversion_opts = dict(Movie=dict(starting_times=starting_times, external_mode=True))
+        self.nwb_converter.run_conversion(
+            nwbfile_path=self.nwbfile_path, overwrite=True, conversion_options=conversion_opts
+        )
+        with NWBHDF5IO(path=self.nwbfile_path, mode="r") as io:
+            nwbfile = io.read()
+            mod = nwbfile.acquisition
+            metadata = self.nwb_converter.get_metadata()
+            for no in range(len(metadata["Behavior"]["Movies"])):
+                movie_interface_name = metadata["Behavior"]["Movies"][no]["name"]
+                assert mod[movie_interface_name].external_file[0] == self.movie_files[no]
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.test_dir)
+        del self.nwb_converter


### PR DESCRIPTION
## Motivation

#372 in which we add a context class is throwing segmentation faults when creating a context class inheriting from `cv2.VideoCapture`. In the mean time, its better to skip using the context manager and use independent methods for retrieving various info from movie files like: no_frames, timestamps, fps, frames arrays. 
Once we merge this PR then then re-adding the MovieDataChunkIterator can be initiated. 

## How to test the behavior?
Have setup a separate file for that [here](https://github.com/catalystneuro/nwb-conversion-tools/blob/cbc0d343e6ac461c405a67574a86861d35a1f8fd/tests/test_internals/test_movie_interface.py)

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
