### PR TITLE
modify conda_env_to_track the setup file

### DIFF
--- a/make_env.yml
+++ b/make_env.yml
@@ -4,5 +4,7 @@ channels:
 - anaconda
 - conda-forge
 dependencies:
-- python=3.7
+- python>=3.7
 - pip
+- pip:
+  - -e .  # This calls the setup and therefore requirements minimal


### PR DESCRIPTION
## Motivation

Small changes to make the conda environment file `make_env.yml` track the setup file and therefore minimal-requirements.txt.
## How to test the behavior?
Follow the installation instructions for conda in the readme and that should provide an environment with the minimal installation.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
