### PR TITLE
II Refactor of add electrodes

### DIFF
--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -721,18 +721,25 @@ class TestAddElectrodes(TestCase):
 
         values_dic.update(id=21, channel_name="d", property1="value1_d")
         self.nwbfile.add_electrode(**values_dic)
+        
+        values_dic.update(id=22, channel_name="f", property1="value1_f")
+        self.nwbfile.add_electrode(**values_dic)
+        
+        property1_values = ["value1_a", "value1_b", "x", "y"]
+        self.recording_1.set_property(key="property1", values=property1_values)
 
-        property_values = ["value2_a", "value2_b", "value2_c", "value2_d"]
-        self.recording_1.set_property(key="property2", values=property_values)
+        property2_values = ["value2_a", "value2_b", "value2_c", "value2_d"]
+        self.recording_1.set_property(key="property2", values=property2_values)
+
         add_electrodes(recording=self.recording_1, nwbfile=self.nwbfile)
 
-        expected_ids = [20, 21, 2, 3]
-        expected_names = ["c", "d", "a", "b"]
+        expected_ids = [20, 21, 22, 3, 4]
+        expected_names = ["c", "d", "f", "a", "b"]
         self.assertListEqual(list(self.nwbfile.electrodes.id.data), expected_ids)
         self.assertListEqual(list(self.nwbfile.electrodes["channel_name"].data), expected_names)
 
-        expected_property_values1 = ["value1_c", "value1_d", "", ""]
-        expected_property_values2 = ["value2_c", "value2_d", "value2_a", "value2_b"]
+        expected_property_values1 = ["value1_c", "value1_d", "value1_f", "value1_a", "value1_b"]
+        expected_property_values2 = ["value2_c", "value2_d", "", "value2_a", "value2_b"]
         self.assertListEqual(list(self.nwbfile.electrodes["property1"].data), expected_property_values1)
         self.assertListEqual(list(self.nwbfile.electrodes["property2"].data), expected_property_values2)
 


### PR DESCRIPTION
## Motivation
I stooped midway with the refactor of our `add_electrodes` function in #406 because we were working on adding support for non integer channels #415 and I wanted to see how the final design would look like. This PR is the final refactor. 

What has been changed?
* Separate the logic of the function in three parts: 1) [data extraction](https://github.com/catalystneuro/nwb-conversion-tools/blob/f2bb36e5d8f17747d5fcb11dc1533f0a4e8b976b/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py#L295-L302), 2) [data preparation](https://github.com/catalystneuro/nwb-conversion-tools/blob/f2bb36e5d8f17747d5fcb11dc1533f0a4e8b976b/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py#L311-L359) and 3) electrode table construction by [rows](https://github.com/catalystneuro/nwb-conversion-tools/blob/f2bb36e5d8f17747d5fcb11dc1533f0a4e8b976b/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py#L401-L406) and [columns](https://github.com/catalystneuro/nwb-conversion-tools/blob/f2bb36e5d8f17747d5fcb11dc1533f0a4e8b976b/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py#L433-L449) clearly (separation of concerns). The logic of those processes were mixed. Two examples of this are:
 1) The creation of missing groups was previously done during the addition of rows to the electrodes table: https://github.com/catalystneuro/nwb-conversion-tools/blob/c3a1713958cdd3c756c5ddc9e5aadfd339a5ee0b/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py#L380-L409
2)  Processing of extracted properties was previously done during the extraction of the data from the recorder:
https://github.com/catalystneuro/nwb-conversion-tools/blob/c3a1713958cdd3c756c5ddc9e5aadfd339a5ee0b/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py#L312-L330

In these two examples, the mixing of the logic resulted in a complicated control flow structure as you can see by the depth of the control flow structure (meaning if and for directives here) in those two previous examples. As you can see in the diff the resulting structure is way flatter. 
* For adding information to the electrodes table, some information is added as rows and some information is added as columns. Before this refactor, which properties went to each of the streams was decided by popping information from a giant dic data structure that contain all the extracted properties from the spikeinterface recorder. This flow is now implemented with set data structure logic that should make it clear which properties are going to be added in what way:
https://github.com/catalystneuro/nwb-conversion-tools/blob/f2bb36e5d8f17747d5fcb11dc1533f0a4e8b976b/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py#L376-L380
* Modified a test case to include handling of missing property.
* Unified and simplified variable naming through the function for consistency and clarity.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
