### PR TITLE
Removed 

### DIFF
--- a/docs/using_nwb_conversion_tools.rst
+++ b/docs/using_nwb_conversion_tools.rst
@@ -76,14 +76,15 @@ combining those multiple read/write operations. An example of how to define
 a ``NWBConverter`` would be::
 
     from nwb_conversion_tools import (
+        NWBConverter,
         BlackrockRecordingExtractorInterface,
-        KlustaSortingExtractorInterface
+        PhySortingInterface
     )
 
     class ExampleNWBConverter(NWBConverter):
         data_interface_classes = dict(
             BlackrockRecording=BlackrockRecordingExtractorInterface,
-            KlustaSorting=KlustaSortingExtractorInterface
+            PhySorting=PhySortingInterface
         )
 
 :py:class:`.NWBConverter` classes define a :py:attr:`.data_interface_classes` dictionary, a class
@@ -93,11 +94,11 @@ input data to each ``DataInterface``. The keys to this dictionary are arbitrary,
 but must match between ``data_interface_classes`` and the ``source_data``::
 
     source_data = dict(
-        BlackrockRecordingExtractorInterface=dict(
-            filename="raw_dataset_path"
+        BlackrockRecording=dict(
+            file_path="raw_dataset_path"
         ),
-        KlustaSortingExtractoreInterface=dict(
-            file_or_folder_path="sorted_dataset_path"
+        PhySorting=dict(
+            folder_path="sorted_dataset_path"
         )
     )
 


### PR DESCRIPTION
## Motivation

Simple PR to remove an import call to `KlustaSortingExtractorInterface` from the documentation as it is no longer working. I substituted it for `PhySortingInterface`. 

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
