### PR TITLE
Template issue for internal discussion

### DIFF
--- a/.github/ISSUE_TEMPLATE/discussion.yml
+++ b/.github/ISSUE_TEMPLATE/discussion.yml
@@ -1,0 +1,23 @@
+name: Internal Discussion
+description: General internal discussion for developers
+title: "[Discussion]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: Discussion
+    attributes:
+      label: Statement of the point to discuss
+      description: |
+      Description
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/catalystneuro/nwb-conversion-tools/blob/main/.github/CODE_OF_CONDUCT.rst)
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/catalystneuro/nwb-conversion-tools/blob/main/.github/CODE_OF_CONDUCT.rst)
+          required: true
+        - label: Have you ensured this bug was not already [reported](https://github.com/catalystneuro/nwb-conversion-tools/issues)?
+          required: true


### PR DESCRIPTION
## Motivation
While filling the issue in #429 I thought that the current templates seem more oriented for normal users. While a more rigid form might grant us more structured feedback from general users, it feels to me that we can benefit from a more flexible template for internal discussion. I see two main benefits

1) Reduced boilerplate which makes for a quicker writing of an issue.
2) No need to fit the problem in the categories of bug or feature request or documentation when they don't fall cleanly into it. 

This PR is for discussing this and I wrote a draft about how such template could look like. 

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
