### PR TITLE
bgr to rgb

### DIFF
--- a/nwb_conversion_tools/datainterfaces/behavior/movie/movie_utils.py
+++ b/nwb_conversion_tools/datainterfaces/behavior/movie/movie_utils.py
@@ -94,7 +94,7 @@ class VideoCaptureContext:
             raise ValueError(f"Could not set frame number (received {frame_number}).")
 
     def get_movie_frame(self, frame_number: int):
-        """Return the specific frame from a movie."""
+        """Return the specific frame from a movie as an RGB colorspace."""
         assert self.isOpened(), self._movie_open_msg
         assert frame_number < self.get_movie_frame_count(), "frame number is greater than length of movie"
         initial_frame_number = self.current_frame

--- a/nwb_conversion_tools/datainterfaces/behavior/movie/movie_utils.py
+++ b/nwb_conversion_tools/datainterfaces/behavior/movie/movie_utils.py
@@ -101,7 +101,7 @@ class VideoCaptureContext:
         self.current_frame = frame_number
         success, frame = self.vc.read()
         self.current_frame = initial_frame_number
-        return frame
+        return np.flip(frame, 2)
 
     def get_movie_frame_dtype(self):
         """Return the dtype for frame in a movie file."""
@@ -124,7 +124,7 @@ class VideoCaptureContext:
             success, frame = self.vc.read()
             self._current_frame += 1
             if success:
-                return frame
+                return np.flip(frame, 2)
             else:
                 raise StopIteration
         else:

--- a/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
@@ -1,4 +1,4 @@
-"""Authors: Cody Baker and Ben Dichter."""
+"""Authors: Saksham Sharda, Cody Baker and Ben Dichter."""
 from pathlib import Path
 from typing import Optional
 from warnings import warn
@@ -79,12 +79,16 @@ class MovieInterface(BaseDataInterface):
     ):
         """
         Convert the movie data files to ImageSeries and write them in the NWBFile.
+        Data is written in the ImageSeries container as RGB. [times, x, y, 3-RGB]
 
         Parameters
         ----------
         nwbfile : NWBFile
         metadata : dict
             Dictionary of metadata information such as names and description of each video.
+            Metadata should be passed for each video file passed in the file_paths argument during __init__.
+            If storing as 'external mode', then provide duplicate metadata for video files that go in the
+            same ImageSeries container. len(metadata["Behavior"]["Movies"]==len(file_paths).
             Should be organized as follows:
                 metadata = dict(
                     Behavior=dict(
@@ -144,6 +148,22 @@ class MovieInterface(BaseDataInterface):
         )
 
         def _check_duplicates(image_series_kwargs_list):
+            """
+            Accumulates metadata for when multiple video files go in one ImageSeries container.
+
+            Parameters
+            ----------
+            image_series_kwargs_list: List[Dict]
+                metadata passed into run_conversion
+
+            Returns
+            -------
+            image_series_kwargs_list_unique: List[Dict]
+                if metadata has common names (case when the user intends to put multiple video files
+                under the same ImageSeries container), this removes the duplicate names.
+            file_paths_list: List[List[str]]
+                len(file_paths_list)==len(image_series_kwargs_list_unique)
+            """
             image_series_kwargs_list_keys = [i["name"] for i in image_series_kwargs_list]
             if len(set(image_series_kwargs_list_keys)) < len(image_series_kwargs_list_keys):
                 assert external_mode, "For multiple video files under the same ImageSeries name, use exernal_mode=True."

--- a/tests/test_internals/test_movie_utils.py
+++ b/tests/test_internals/test_movie_utils.py
@@ -73,14 +73,14 @@ class TestVideoContext(unittest.TestCase):
             number_of_frames = vcc.get_movie_frame_count()
             for no in range(number_of_frames):
                 frames.append(vcc.get_movie_frame(no))
-        assert_array_equal(frames, self.movie_frames)
+        assert_array_equal(frames, np.flip(self.movie_frames,3))
 
     def test_iterable(self):
         frames = []
         vcc = VideoCaptureContext(file_path=self.movie_loc)
         for frame in vcc:
             frames.append(frame)
-        assert_array_equal(np.array(frames), self.movie_frames)
+        assert_array_equal(np.array(frames), np.flip(self.movie_frames,3))
         self.assertFalse(vcc.vc.isOpened())
         vcc.release()
 
@@ -90,7 +90,7 @@ class TestVideoContext(unittest.TestCase):
             frames = []
             for frame in vcc:
                 frames.append(frame)
-        assert_array_equal(np.array(frames), self.movie_frames[:3, :, :])
+        assert_array_equal(np.array(frames), self.movie_frames[:3, :, :, [2,1,0]])
 
     def test_stub_frame(self):
         with VideoCaptureContext(self.movie_loc) as vcc:


### PR DESCRIPTION
## Motivation

Pointed out by @CodyCBakerPhD [here](https://github.com/catalystneuro/nwb-conversion-tools/pull/414#issuecomment-1059996959), opencv returns frame in BGR instead of RGB. This PR is a quick fix for this.

## How to test the behavior?
```python
import skvideo.io
from nwb_conversion_tools.datainterfaces.behavior.movie.movie_utils import VideoCaptureContext
import numpy.testing as npt

video_path = "path/video.mp4"

with VideoCaptureContext(file_path=video_path) as vw:
    frame0_bgr = vw.get_movie_frame(0)

reader = skvideo.io.FFmpegReader(video_path, inputdict=dict(), outputdict=dict())

for frame in reader.nextFrame():
    frame0_rgb = frame
    break

print(npt.assert_array_equal(frame0_rgb[:,:,0], frame0_bgr[:,:,0]))
print(npt.assert_array_equal(frame0_rgb[:,:,-1], frame0_bgr[:,:,0])) # without this fix
```
ground truth : `skvideo.io.FFmpegReader` reads as RGB http://www.scikit-video.org/stable/io.html
## Checklist

- [ ] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [ ] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
