### PR TITLE
Solve gin test config tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,8 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
-*.json
+gin_test_config_local.json 
+# *.json
 
 # Translations
 *.mo

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup, find_packages
 from codecs import open
 import os
+from pathlib import Path
+from shutil import copy
 
 path = os.path.abspath(os.path.dirname(__file__))
 
@@ -12,6 +14,12 @@ with open(os.path.join(path, "requirements-full.txt")) as f:
     full_dependencies = f.readlines()
 testing_suite_dependencies = ["pytest", "pytest-cov", "ndx-events==0.2.0", "parameterized==0.8.1"]
 extras_require = dict(full=full_dependencies, test=testing_suite_dependencies)
+
+# Create a local-folder for gin data tests configuration
+gin_config_file_base = "./tests/test_on_data/gin_test_config.json"
+gin_config_file_local = "./tests/test_on_data/gin_test_config_local.json"
+copy(src=gin_config_file_base, dst=gin_config_file_local)
+
 setup(
     name="nwb-conversion-tools",
     version="0.11.3",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(os.path.join(path, "requirements-full.txt")) as f:
 testing_suite_dependencies = ["pytest", "pytest-cov", "ndx-events==0.2.0", "parameterized==0.8.1"]
 extras_require = dict(full=full_dependencies, test=testing_suite_dependencies)
 
-# Create a local-folder for gin data tests configuration
+# Create a local folder for gin data tests configuration
 gin_config_file_base = "./tests/test_on_data/gin_test_config.json"
 gin_config_file_local = "./tests/test_on_data/gin_test_config_local.json"
 copy(src=gin_config_file_base, dst=gin_config_file_local)

--- a/tests/test_on_data/test_YAML_conversion_specification.py
+++ b/tests/test_on_data/test_YAML_conversion_specification.py
@@ -12,7 +12,7 @@ from nwb_conversion_tools import run_conversion_from_yaml
 from nwb_conversion_tools.utils import load_dict_from_file
 
 # Load the configuration for the data tests
-test_config_dict = load_dict_from_file(Path(__file__).parent / "gin_test_config.json")
+test_config_dict = load_dict_from_file(Path(__file__).parent / "gin_test_config_local.json")
 print(test_config_dict)
 
 # GIN dataset: https://gin.g-node.org/NeuralEnsemble/ephy_testing_data

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -38,7 +38,7 @@ from nwb_conversion_tools.utils import load_dict_from_file
 
 
 # Load the configuration for the data tests
-test_config_dict = load_dict_from_file(Path(__file__).parent / "gin_test_config.json")
+test_config_dict = load_dict_from_file(Path(__file__).parent / "gin_test_config_local.json")
 
 # GIN dataset: https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
 if os.getenv("CI"):

--- a/tests/test_on_data/test_gin_ophys.py
+++ b/tests/test_on_data/test_gin_ophys.py
@@ -23,7 +23,7 @@ from nwb_conversion_tools.utils import load_dict_from_file
 
 
 # Load the configuration for the data tests
-test_config_dict = load_dict_from_file(Path(__file__).parent / "gin_test_config.json")
+test_config_dict = load_dict_from_file(Path(__file__).parent / "gin_test_config_local.json")
 
 #  GIN dataset: https://gin.g-node.org/CatalystNeuro/ophys_testing_data
 if os.getenv("CI"):


### PR DESCRIPTION
## Motivation

So, we consolidated our configuration for our gin tests in a single file. However, the problem is that if we want to keep that file in github it won't be ignored by version control (i.e. `gitignore`) and therefore we still have local changes to the config file being marked as untracked by git and just plain annoying. Reading around a bit most folks suggest that this problem can be avoiding by having setup create a local copy of a master file that then can be modified by the user -us- without messing with version control.