### PR TITLE
removing subset_channels for stub

### DIFF
--- a/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -86,8 +86,8 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
                     Should be below 1 MB. Automatically calculates suitable chunk shape.
             If manual specification of buffer_shape and chunk_shape are desired, these may be specified as well.
         """
-        if stub_test or self.subset_channels is not None:
-            recording = self.subset_recording(stub_test=stub_test)
+        if stub_test:
+            recording = self.subset_recording()
         else:
             recording = self.recording_extractor
         write_recording(

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -27,7 +27,6 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
     def __init__(self, **source_data):
         super().__init__(**source_data)
         self.recording_extractor = self.RX(**source_data)
-        self.subset_channels = None
 
     def get_metadata_schema(self):
         """Compile metadata schema for the RecordingExtractor."""
@@ -73,7 +72,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         )
         return metadata
 
-    def subset_recording(self, stub_test: bool = False):
+    def subset_recording(self):
         """
         Subset a recording extractor according to stub and channel subset options.
 
@@ -82,13 +81,9 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         stub_test : bool, optional (default False)
         """
         kwargs = dict()
-
-        if stub_test:
-            num_frames = 100
-            end_frame = min([num_frames, self.recording_extractor.get_num_frames()])
-            kwargs.update(end_frame=end_frame)
-        if self.subset_channels is not None:
-            kwargs.update(channel_ids=self.subset_channels)
+        num_frames = 100
+        end_frame = min([num_frames, self.recording_extractor.get_num_frames()])
+        kwargs.update(end_frame=end_frame)
         if isinstance(self.recording_extractor, se.RecordingExtractor):
             recording_extractor = se.SubRecordingExtractor(self.recording_extractor, **kwargs)
         elif isinstance(self.recording_extractor, si.BaseRecording):
@@ -165,8 +160,8 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
                     Should be below 1 MB. Automatically calculates suitable chunk shape.
             If manual specification of buffer_shape and chunk_shape are desired, these may be specified as well.
         """
-        if stub_test or self.subset_channels is not None:
-            recording = self.subset_recording(stub_test=stub_test)
+        if stub_test:
+            recording = self.subset_recording()
         else:
             recording = self.recording_extractor
         write_recording(

--- a/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -75,10 +75,6 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
     def subset_recording(self):
         """
         Subset a recording extractor according to stub and channel subset options.
-
-        Parameters
-        ----------
-        stub_test : bool, optional (default False)
         """
         kwargs = dict()
         num_frames = 100

--- a/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -14,7 +14,6 @@ class NeuralynxRecordingInterface(BaseRecordingExtractorInterface):
     RX = MultiRecordingChannelExtractor
 
     def __init__(self, folder_path: FolderPathType):
-        self.subset_channels = None
         self.source_data = dict(folder_path=folder_path)
         neuralynx_files = natsorted([str(x) for x in Path(folder_path).iterdir() if ".ncs" in x.suffixes])
         extractors = [NeuralynxRecordingExtractor(filename=filename, seg_index=0) for filename in neuralynx_files]

--- a/nwb_conversion_tools/datainterfaces/ecephys/openephys/openephysdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/openephys/openephysdatainterface.py
@@ -27,11 +27,8 @@ class OpenEphysRecordingExtractorInterface(BaseRecordingExtractorInterface):
         folder_path: FolderPathType,
         experiment_id: Optional[int] = 0,
         recording_id: Optional[int] = 0,
-        stub_test: Optional[bool] = False,
     ):
         super().__init__(folder_path=folder_path, experiment_id=experiment_id, recording_id=recording_id)
-        if stub_test:
-            self.subset_channels = [0, 1]
 
     def get_metadata(self):
         """Auto-fill as much of the metadata as possible. Must comply with metadata schema."""

--- a/nwb_conversion_tools/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -43,10 +43,8 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["file_path"]["description"] = "Path to SpikeGLX file."
         return source_schema
 
-    def __init__(self, file_path: FilePathType, stub_test: Optional[bool] = False):
+    def __init__(self, file_path: FilePathType):
         super().__init__(file_path=str(file_path))
-        if stub_test:
-            self.subset_channels = [0, 1]
         # Set electrodes properties
         for ch in self.recording_extractor.get_channel_ids():
             self.recording_extractor.set_channel_property(
@@ -90,10 +88,8 @@ class SpikeGLXLFPInterface(BaseLFPExtractorInterface):
         source_schema["properties"]["file_path"]["description"] = "Path to SpikeGLX file."
         return source_schema
 
-    def __init__(self, file_path: FilePathType, stub_test: Optional[bool] = False):
+    def __init__(self, file_path: FilePathType):
         super().__init__(file_path=str(file_path))
-        if stub_test:
-            self.subset_channels = [0, 1]
         # Set electrodes properties
         for ch in self.recording_extractor.get_channel_ids():
             self.recording_extractor.set_channel_property(

--- a/nwb_conversion_tools/datainterfaces/ecephys/spikeinterface/sipickledatainterfaces.py
+++ b/nwb_conversion_tools/datainterfaces/ecephys/spikeinterface/sipickledatainterfaces.py
@@ -13,7 +13,6 @@ class SIPickleRecordingExtractorInterface(BaseRecordingExtractorInterface):
 
     def __init__(self, file_path: FilePathType):
         self.recording_extractor = load_extractor_from_pickle(pkl_file=file_path)
-        self.subset_channels = None
         self.source_data = dict(file_path=file_path)
 
 


### PR DESCRIPTION
## Motivation

I think, stub tests should only slice the recording in frames and not channels to be as realistic as possible. 

Thus the `subset_channels` attribute is unnecessary.
 In addition, the `BaseRecordingExtractorInterface.subset_recording()` is useful only when `stub_test=True` thus its unnecessary to have `stub_test` as argument to that. 

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [ ] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
