### PR TITLE
Not overwriting channel name if recording object has the property

### DIFF
--- a/src/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py
+++ b/src/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py
@@ -306,9 +306,12 @@ def add_electrodes(
 
     # Channel name logic
     channel_ids = checked_recording.get_channel_ids()
-    channel_name_array = channel_ids.astype("str", copy=False)
+    if "channel_name" in data_to_add:
+        channel_name_array = data_to_add["channel_name"]["data"]
+    else:
+        channel_name_array = channel_ids.astype("str", copy=False)
+        data_to_add["channel_name"].update(description="unique channel reference", data=channel_name_array, index=False)
 
-    data_to_add["channel_name"].update(description="unique channel reference", data=channel_name_array, index=False)
     # If the channel ids are integer keep the old behavior of asigning nwbfile.electrodes.id equal to channel_ids
     if np.issubdtype(channel_ids.dtype, np.integer):
         data_to_add["id"].update(data=channel_ids, index=False)
@@ -443,8 +446,8 @@ def add_electrodes(
         cols_args["data"] = extended_data
         nwbfile.add_electrode_column(property, **cols_args)
 
-    if (len(rows_to_add) > 0) or (len(properties_to_add_by_columns) > 0):
-        warnings.warn(f"No information added to the table")
+    if (len(rows_to_add) == 0) and (len(properties_to_add_by_columns) == 0):
+        warnings.warn(f"No information added to the electrodes table")
 
 
 def add_electrical_series(

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -740,7 +740,7 @@ class TestAddElectrodes(TestCase):
 
         # Remaining ids are filled positionally.
         expected_ids = [20, 21, 22, 3, 4]
-        # Properties are matched by channel name. 
+        # Properties are matched by channel name.
         expected_names = ["c", "d", "f", "a", "b"]
         expected_property_values = ["value_c", "value_d", "value_f", "value_a", "value_b"]
 
@@ -755,7 +755,7 @@ class TestAddElectrodes(TestCase):
         """
         values_dic = self.defaults
         self.nwbfile.add_electrode_column(name="channel_name", description="a string reference for the channel")
-        
+
         values_dic.update(id=20, channel_name="c")
         self.nwbfile.add_electrode(**values_dic)
 
@@ -764,7 +764,7 @@ class TestAddElectrodes(TestCase):
 
         values_dic.update(id=22, channel_name="f")
         self.nwbfile.add_electrode(**values_dic)
-        
+
         property_values = ["value_a", "value_b", "value_c", "value_d"]
         self.recording_1.set_property(key="property", values=property_values)
 
@@ -772,14 +772,13 @@ class TestAddElectrodes(TestCase):
 
         # Remaining ids are filled positionally.
         expected_ids = [20, 21, 22, 3, 4]
-        # Properties are matched by channel name. 
+        # Properties are matched by channel name.
         expected_names = ["c", "d", "f", "a", "b"]
         expected_property_values = ["value_c", "value_d", "", "value_a", "value_b"]
 
         self.assertListEqual(list(self.nwbfile.electrodes.id.data), expected_ids)
         self.assertListEqual(list(self.nwbfile.electrodes["channel_name"].data), expected_names)
         self.assertListEqual(list(self.nwbfile.electrodes["property"].data), expected_property_values)
-
 
     def test_assertion_for_id_collision(self):
         """

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -782,8 +782,7 @@ class TestAddElectrodes(TestCase):
 
     def test_assertion_for_id_collision(self):
         """
-        Add some rows to the electrode tables before using the add_electrodes function.
-        In this case there is with some common ids between the manually added rows and the recorder which causes collisions.
+        Keep the old logic of not allowing integer channel_ids to match electrodes.table.ids
         """
 
         values_dic = self.defaults

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -644,6 +644,16 @@ class TestAddElectrodes(TestCase):
         actual_channel_names_in_electrodes_table = list(self.nwbfile.electrodes["channel_name"].data)
         self.assertListEqual(actual_channel_names_in_electrodes_table, expected_channel_names_in_electrodes_table)
 
+    def test_non_overwriting_channel_names_property(self):
+        "add_electrodes function should not overwrite the recording object channel name property"
+        channel_names = ["name a", "name b", "name c", "name d"]
+        self.recording_1.set_property(key="channel_name", values=channel_names)
+        add_electrodes(recording=self.recording_1, nwbfile=self.nwbfile)
+
+        expected_channel_names_in_electrodes_table = channel_names
+        channel_names_in_electrodes_table = list(self.nwbfile.electrodes["channel_name"].data)
+        self.assertListEqual(channel_names_in_electrodes_table, expected_channel_names_in_electrodes_table)
+
     def test_common_property_extension(self):
         """Add a property for a first recording that is then extended by a second recording."""
         self.recording_1.set_property(key="common_property", values=["value_1"] * self.num_channels)
@@ -705,45 +715,73 @@ class TestAddElectrodes(TestCase):
         self.assertListEqual(list(self.nwbfile.electrodes.id.data), expected_ids)
         self.assertListEqual(list(self.nwbfile.electrodes["channel_name"].data), expected_names)
 
-    def test_manual_row_adition_before_add_electrodes_function_and_channel_name_collision(self):
+    def test_row_matching_by_channel_name_with_existing_property(self):
         """
-        Add some rows to the electrode tables before using the add_electrodes function.
-        In this case there is with some common channel names between the previously added rows and the recroder
-        which causes collisions.
+        Adding new electrodes to an already existing electrode table should match
+        properties and information by channel name.
         """
-
         values_dic = self.defaults
         self.nwbfile.add_electrode_column(name="channel_name", description="a string reference for the channel")
-        self.nwbfile.add_electrode_column(name="property1", description="property_added_before")
+        self.nwbfile.add_electrode_column(name="property", description="exisiting property")
 
-        values_dic.update(id=20, channel_name="c", property1="value1_c")
+        values_dic.update(id=20, channel_name="c", property="value_c")
         self.nwbfile.add_electrode(**values_dic)
 
-        values_dic.update(id=21, channel_name="d", property1="value1_d")
+        values_dic.update(id=21, channel_name="d", property="value_d")
         self.nwbfile.add_electrode(**values_dic)
 
-        values_dic.update(id=22, channel_name="f", property1="value1_f")
+        values_dic.update(id=22, channel_name="f", property="value_f")
         self.nwbfile.add_electrode(**values_dic)
 
-        property1_values = ["value1_a", "value1_b", "x", "y"]
-        self.recording_1.set_property(key="property1", values=property1_values)
-
-        property2_values = ["value2_a", "value2_b", "value2_c", "value2_d"]
-        self.recording_1.set_property(key="property2", values=property2_values)
+        property_values = ["value_a", "value_b", "x", "y"]
+        self.recording_1.set_property(key="property", values=property_values)
 
         add_electrodes(recording=self.recording_1, nwbfile=self.nwbfile)
 
+        # Remaining ids are filled positionally.
         expected_ids = [20, 21, 22, 3, 4]
+        # Properties are matched by channel name. 
         expected_names = ["c", "d", "f", "a", "b"]
+        expected_property_values = ["value_c", "value_d", "value_f", "value_a", "value_b"]
+
         self.assertListEqual(list(self.nwbfile.electrodes.id.data), expected_ids)
         self.assertListEqual(list(self.nwbfile.electrodes["channel_name"].data), expected_names)
+        self.assertListEqual(list(self.nwbfile.electrodes["property"].data), expected_property_values)
 
-        expected_property_values1 = ["value1_c", "value1_d", "value1_f", "value1_a", "value1_b"]
-        expected_property_values2 = ["value2_c", "value2_d", "", "value2_a", "value2_b"]
-        self.assertListEqual(list(self.nwbfile.electrodes["property1"].data), expected_property_values1)
-        self.assertListEqual(list(self.nwbfile.electrodes["property2"].data), expected_property_values2)
+    def test_row_matching_by_channel_name_with_new_property(self):
+        """
+        Adding new electrodes to an already existing electrode table should match
+        properties and information by channel name.
+        """
+        values_dic = self.defaults
+        self.nwbfile.add_electrode_column(name="channel_name", description="a string reference for the channel")
+        
+        values_dic.update(id=20, channel_name="c")
+        self.nwbfile.add_electrode(**values_dic)
 
-    def test_manually_added_before_recording_id_collision(self):
+        values_dic.update(id=21, channel_name="d")
+        self.nwbfile.add_electrode(**values_dic)
+
+        values_dic.update(id=22, channel_name="f")
+        self.nwbfile.add_electrode(**values_dic)
+        
+        property_values = ["value_a", "value_b", "value_c", "value_d"]
+        self.recording_1.set_property(key="property", values=property_values)
+
+        add_electrodes(recording=self.recording_1, nwbfile=self.nwbfile)
+
+        # Remaining ids are filled positionally.
+        expected_ids = [20, 21, 22, 3, 4]
+        # Properties are matched by channel name. 
+        expected_names = ["c", "d", "f", "a", "b"]
+        expected_property_values = ["value_c", "value_d", "", "value_a", "value_b"]
+
+        self.assertListEqual(list(self.nwbfile.electrodes.id.data), expected_ids)
+        self.assertListEqual(list(self.nwbfile.electrodes["channel_name"].data), expected_names)
+        self.assertListEqual(list(self.nwbfile.electrodes["property"].data), expected_property_values)
+
+
+    def test_assertion_for_id_collision(self):
         """
         Add some rows to the electrode tables before using the add_electrodes function.
         In this case there is with some common ids between the manually added rows and the recorder which causes collisions.

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -180,10 +180,14 @@ class TestEcephysNwbConversions(unittest.TestCase):
                 x=recording.get_traces(return_scaled=False), y=nwb_recording.get_traces(return_scaled=False)
             )
         else:
-            # Cast channel_ids to string and do the comparisons with spikeinterface methods
+            # Spikeinterface behavior is to load the electrode table channel_name property as a channel_id
             nwb_recording = NwbRecordingExtractorSI(file_path=nwbfile_path)
+            if "channel_name" in recording.get_property_keys():
+                renamed_channel_ids = recording.get_property("channel_name")
+            else:
+                renamed_channel_ids = recording.get_channel_ids().astype("str")
             recording = recording.channel_slice(
-                channel_ids=recording.get_channel_ids(), renamed_channel_ids=recording.get_channel_ids().astype("str")
+                channel_ids=recording.get_channel_ids(), renamed_channel_ids=renamed_channel_ids
             )
 
             check_recordings_equal_si(RX1=recording, RX2=nwb_recording, return_scaled=False)


### PR DESCRIPTION
While I was working with a `spikelgx` conversion I realize that our current implementation of `add_electrodes` overwrites the property of channel name if this is available in the recording object (it always assign it to `channel_ids.astype("str")`). 

I modified the logic so this does not happen and added a new test.

I also did other two things in this PR:
* corrected a small bug that was showing up in warnings.
* Split one of the unit tests in two as it was testing two different things in one function.
* Added more descriptive names to the unittests.


