### PR TITLE
Fix group creation

### DIFF
--- a/src/nwb_conversion_tools/tools/nwb_helpers.py
+++ b/src/nwb_conversion_tools/tools/nwb_helpers.py
@@ -12,7 +12,7 @@ from ..utils import dict_deep_update
 def get_module(nwbfile: NWBFile, name: str, description: str = None):
     """Check if processing module exists. If not, create it. Then return module."""
     if name in nwbfile.processing:
-        if description is not None and nwbfile.modules[name].description != description:
+        if description is not None and nwbfile.processing[name].description != description:
             warn(
                 "Custom description given to get_module does not match existing module description! "
                 "Ignoring custom description."

--- a/src/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py
+++ b/src/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py
@@ -172,14 +172,20 @@ def add_electrode_groups(recording: SpikeInterfaceRecording, nwbfile: pynwb.NWBF
         metadata = dict()
     if "Ecephys" not in metadata:
         metadata["Ecephys"] = dict()
+    
+    if "group_name" in checked_recording.get_property_keys(): 
+        group_names = np.unique(checked_recording.get_property("group_name"))
+    else:
+        group_names = np.unique(checked_recording.get_channel_groups()).astype("str")
+    
     defaults = [
         dict(
-            name=str(group_id),
+            name=group_name,
             description="no description",
             location="unknown",
             device=[i.name for i in nwbfile.devices.values()][0],
         )
-        for group_id in np.unique(checked_recording.get_channel_groups())
+        for group_name in group_names
     ]
 
     if "ElectrodeGroup" not in metadata["Ecephys"]:
@@ -334,7 +340,6 @@ def add_electrodes(
     # If no group_names are provide use information from groups or default values
     if "group_name" in data_to_add:
         group_name_array = data_to_add["group_name"]["data"].astype("str", copy=False)
-
     else:
         if "group" in data_to_add:
             group_name_array = data_to_add["group"]["data"].astype("str", copy=False)

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -24,18 +24,18 @@ from nwb_conversion_tools.tools.spikeinterface import (
     write_recording,
     write_sorting,
     add_electrodes,
-    add_electrical_series,
 )
 from nwb_conversion_tools.tools.spikeinterface.spikeinterfacerecordingdatachunkiterator import (
     SpikeInterfaceRecordingDataChunkIterator,
 )
 from nwb_conversion_tools.utils import FilePathType
 
+testing_session_time = datetime.now().astimezone()
 
 def _create_example(seed):
     channel_ids = [0, 1, 2, 3]
     num_channels = 4
-    num_frames = 10000
+    num_frames = 1000
     num_ttls = 30
     sampling_frequency = 30000
     X = np.random.RandomState(seed=seed).normal(0, 1, (num_channels, num_frames))
@@ -121,7 +121,7 @@ class TestExtractors(unittest.TestCase):
         self.RX, self.RX2, self.RX3, self.SX, self.SX2, self.SX3, self.example_info = _create_example(seed=0)
         self.test_dir = tempfile.mkdtemp()
         self.placeholder_metadata = dict(
-            NWBFile=dict(session_start_time=datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S"))
+            NWBFile=dict(session_start_time=testing_session_time)
         )
 
     def tearDown(self):
@@ -494,10 +494,11 @@ class TestWriteElectrodes(unittest.TestCase):
         self.path1 = self.test_dir + "/test_electrodes1.nwb"
         self.path2 = self.test_dir + "/test_electrodes2.nwb"
         self.path3 = self.test_dir + "/test_electrodes3.nwb"
-        self.nwbfile1 = NWBFile("sess desc1", "file id1", datetime.now())
-        self.nwbfile2 = NWBFile("sess desc2", "file id2", datetime.now())
-        self.nwbfile3 = NWBFile("sess desc3", "file id3", datetime.now())
+        self.nwbfile1 = NWBFile("sess desc1", "file id1", testing_session_time)
+        self.nwbfile2 = NWBFile("sess desc2", "file id2", testing_session_time)
+        self.nwbfile3 = NWBFile("sess desc3", "file id3", testing_session_time)
         self.metadata_list = [dict(Ecephys={i: dict(name=i, description="desc")}) for i in ["es1", "es2"]]
+
         # change channel_ids
         id_offset = np.max(self.RX.get_channel_ids())
         self.RX2 = se.subrecordingextractor.SubRecordingExtractor(
@@ -595,7 +596,7 @@ class TestAddElectrodes(TestCase):
     def setUp(self):
         """Start with a fresh NWBFile, ElectrodeTable, and remapped BaseRecordings each time."""
         self.nwbfile = NWBFile(
-            session_description="session_description1", identifier="file_id1", session_start_time=datetime.now()
+            session_description="session_description1", identifier="file_id1", session_start_time=testing_session_time
         )
         channel_ids = self.base_recording.get_channel_ids()
         self.recording_1 = self.base_recording.channel_slice(
@@ -607,7 +608,7 @@ class TestAddElectrodes(TestCase):
 
         self.device = self.nwbfile.create_device(name="extra_device")
         self.electrode_group = self.nwbfile.create_electrode_group(
-            name="extra_group", description="description", location="location", device=self.device
+            name="0", description="description", location="location", device=self.device
         )
         self.defaults = dict(
             x=np.nan,


### PR DESCRIPTION
## Motivation
The function `add_electrode_groups` did no match the behavior of `add_electrodes` in the sense that the former used the property "group" to decide the name for group creation but the latter gave primacy / priority to the property "group_name". This PR is so they are aligned in which property is used to decide the name of the electrode groups.

Plus, I did some work for reducing some of the warnings.
1) Added a starting time to each to all of our tests.
2) Remove `nwbfile.modules` which is now deprecated. 

I also reduced the number of frames used in `test_si`. I don't think that there is any use for so many frames just for the test there. 
