### PR TITLE
Update default conversion options instead of overwriting for run conversion

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -83,7 +83,7 @@ jobs:
         id: cache-ophys-datasets
         with:
           path: ./ophys_testing_data
-          key: ophys-datasets-040122-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
+          key: ophys-datasets-042022-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/ophys_testing_data
@@ -96,7 +96,7 @@ jobs:
         id: cache-behavior-datasets
         with:
           path: ./behavior_testing_data
-          key: behavior-datasets-040122-${{ matrix.os }}-${{ steps.behavior.outputs.HASH_behavior_DATASET }}
+          key: behavior-datasets-042022-${{ matrix.os }}-${{ steps.behavior.outputs.HASH_behavior_DATASET }}
       - name: "Force GIN: behavior download"
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -77,7 +77,7 @@ jobs:
         id: cache-ophys-datasets
         with:
           path: ./ophys_testing_data
-          key: ophys-datasets-040122-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
+          key: ophys-datasets-042022-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/ophys_testing_data
@@ -90,7 +90,7 @@ jobs:
         id: cache-behavior-datasets
         with:
           path: ./behavior_testing_data
-          key: behavior-datasets-040122-${{ matrix.os }}-${{ steps.behavior.outputs.HASH_behavior_DATASET }}
+          key: behavior-datasets-042022-${{ matrix.os }}-${{ steps.behavior.outputs.HASH_behavior_DATASET }}
       - name: "Force GIN: behavior download"
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if not gin_config_file_local.exists():
 
 setup(
     name="nwb-conversion-tools",
-    version="0.11.6",
+    version="0.11.7",
     description="Convert data from proprietary formats to NWB format.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
@@ -185,7 +185,8 @@ class MovieInterface(BaseDataInterface):
             assert len(starting_times) == len(image_series_kwargs_list_updated), (
                 f"starting times list length {len(starting_times)} must be equal to number of unique"
                 f"ImageSeries {len(image_series_kwargs_list_updated)}"
-                f"Image series as input {image_series_kwargs_list}"
+                f"Image series as input {image_series_kwargs_list} \n"
+                f"starting times = {starting_times} \n"
                 f"Image series after _check_duplicates {image_series_kwargs_list_updated}"
             )
         else:

--- a/src/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
@@ -179,7 +179,7 @@ class MovieInterface(BaseDataInterface):
                     idx = keys_set.index(image_series_kwargs["name"])
                     file_paths_list[idx].append(file_paths[n])
             return image_series_kwargs_list_unique, file_paths_list
-        
+
         image_series_kwargs_list_updated, file_paths_list = _check_duplicates(image_series_kwargs_list)
         if starting_times is not None:
             assert len(starting_times) == len(image_series_kwargs_list_updated), (

--- a/src/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
@@ -184,7 +184,7 @@ class MovieInterface(BaseDataInterface):
         if starting_times is not None:
             assert len(starting_times) == len(image_series_kwargs_list_updated), (
                 f"starting times list length {len(starting_times)} must be equal to number of unique"
-                f"ImageSeries {len(image_series_kwargs_list_updated)}"
+                f"ImageSeries {len(image_series_kwargs_list_updated)} \n"
                 f"Image series as input {image_series_kwargs_list} \n"
                 f"starting times = {starting_times} \n"
                 f"Image series after _check_duplicates {image_series_kwargs_list_updated}"

--- a/src/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
@@ -179,12 +179,14 @@ class MovieInterface(BaseDataInterface):
                     idx = keys_set.index(image_series_kwargs["name"])
                     file_paths_list[idx].append(file_paths[n])
             return image_series_kwargs_list_unique, file_paths_list
-
+        
         image_series_kwargs_list_updated, file_paths_list = _check_duplicates(image_series_kwargs_list)
         if starting_times is not None:
             assert len(starting_times) == len(image_series_kwargs_list_updated), (
                 f"starting times list length {len(starting_times)} must be equal to number of unique"
                 f"ImageSeries {len(image_series_kwargs_list_updated)}"
+                f"Image series as input {image_series_kwargs_list}"
+                f"Image series after _check_duplicates {image_series_kwargs_list_updated}"
             )
         else:
             if len(image_series_kwargs_list_updated) == 1:

--- a/src/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/behavior/movie/moviedatainterface.py
@@ -183,7 +183,8 @@ class MovieInterface(BaseDataInterface):
         image_series_kwargs_list_updated, file_paths_list = _check_duplicates(image_series_kwargs_list)
         if starting_times is not None:
             assert len(starting_times) == len(image_series_kwargs_list_updated), (
-                "starting times list length must be equal number of unique ImageSeries " "containers to write to nwb"
+                f"starting times list length {len(starting_times)} must be equal to number of unique" 
+                f"ImageSeries {len(image_series_kwargs_list_updated)}"
             )
         else:
             if len(image_series_kwargs_list_updated) == 1:

--- a/src/nwb_conversion_tools/nwbconverter.py
+++ b/src/nwb_conversion_tools/nwbconverter.py
@@ -146,10 +146,15 @@ class NWBConverter:
 
         if metadata is None:
             metadata = self.get_metadata()
-        if conversion_options is None:
-            conversion_options = self.get_conversion_options()
         self.validate_metadata(metadata=metadata)
+
+        if conversion_options is None:
+            conversion_options = dict()
+        default_conversion_options = self.get_conversion_options()
+        conversion_options = dict_deep_update(default_conversion_options, conversion_options)
+
         self.validate_conversion_options(conversion_options=conversion_options)
+
         if save_to_file:
             load_kwargs = dict(path=nwbfile_path)
             if nwbfile_path is None:

--- a/src/nwb_conversion_tools/nwbconverter.py
+++ b/src/nwb_conversion_tools/nwbconverter.py
@@ -151,9 +151,9 @@ class NWBConverter:
         if conversion_options is None:
             conversion_options = dict()
         default_conversion_options = self.get_conversion_options()
-        conversion_options = dict_deep_update(default_conversion_options, conversion_options)
+        conversion_options_to_run = dict_deep_update(default_conversion_options, conversion_options)
 
-        self.validate_conversion_options(conversion_options=conversion_options)
+        self.validate_conversion_options(conversion_options=conversion_options_to_run)
 
         if save_to_file:
             load_kwargs = dict(path=nwbfile_path)
@@ -169,7 +169,9 @@ class NWBConverter:
                 elif nwbfile is None:
                     nwbfile = make_nwbfile_from_metadata(metadata=metadata)
                 for interface_name, data_interface in self.data_interface_objects.items():
-                    data_interface.run_conversion(nwbfile, metadata, **conversion_options.get(interface_name, dict()))
+                    data_interface.run_conversion(
+                        nwbfile, metadata, **conversion_options_to_run.get(interface_name, dict())
+                    )
                 io.write(nwbfile)
             print(f"NWB file saved at {nwbfile_path}!")
         else:

--- a/src/nwb_conversion_tools/nwbconverter.py
+++ b/src/nwb_conversion_tools/nwbconverter.py
@@ -152,7 +152,6 @@ class NWBConverter:
             conversion_options = dict()
         default_conversion_options = self.get_conversion_options()
         conversion_options_to_run = dict_deep_update(default_conversion_options, conversion_options)
-
         self.validate_conversion_options(conversion_options=conversion_options_to_run)
 
         if save_to_file:

--- a/tests/test_on_data/test_gin_behavior.py
+++ b/tests/test_on_data/test_gin_behavior.py
@@ -17,11 +17,11 @@ class TestMovieDataNwbConversions(unittest.TestCase):
         """Use common recording objects and values."""
         cls.movie_files = list((BEHAVIOR_DATA_PATH / "videos" / "CFR").iterdir())
         cls.number_of_movie_files = len(cls.movie_files)
-        cls.starting_times = [float(np.random.randint(200)) for i in range(cls.number_of_movie_files)]
 
     def setUp(self):
         self.nwb_converter = self.create_movie_converter()
         self.nwbfile_path = os.path.join(self.savedir, "movie_test.nwb")
+        self.starting_times = [float(np.random.randint(200)) for i in range(self.number_of_movie_files)]
 
     def create_movie_converter(self):
         class MovieTestNWBConverter(NWBConverter):

--- a/tests/test_on_data/test_gin_behavior.py
+++ b/tests/test_on_data/test_gin_behavior.py
@@ -14,6 +14,7 @@ class TestMovieDataNwbConversions(unittest.TestCase):
 
     def setUp(self) -> None:
         self.movie_files = list((BEHAVIOR_DATA_PATH / "videos" / "CFR").iterdir())
+        self.number_of_movie_files = len(self.movie_files)
         self.nwb_converter = self.create_movie_converter()
         self.nwbfile_path = os.path.join(self.savedir, "movie_test.nwb")
 
@@ -30,7 +31,7 @@ class TestMovieDataNwbConversions(unittest.TestCase):
         return metadata
 
     def test_movie_starting_times(self):
-        starting_times = [float(np.random.randint(200)) for i in range(len(self.movie_files))]
+        starting_times = [float(np.random.randint(200)) for i in range(self.number_of_movie_files)]
         conversion_opts = dict(Movie=dict(starting_times=starting_times, external_mode=False))
         self.nwb_converter.run_conversion(
             nwbfile_path=self.nwbfile_path,
@@ -81,7 +82,7 @@ class TestMovieDataNwbConversions(unittest.TestCase):
             assert mod[movie_interface_name].starting_time == 0.0
 
     def test_movie_custom_module(self):
-        starting_times = [float(np.random.randint(200)) for i in range(len(self.movie_files))]
+        starting_times = [float(np.random.randint(200)) for i in range(self.number_of_movie_files)]
         module_name = "TestModule"
         module_description = "This is a test module."
         conversion_opts = dict(
@@ -104,7 +105,7 @@ class TestMovieDataNwbConversions(unittest.TestCase):
             assert module_description == nwbfile.processing[module_name].description
 
     def test_movie_chunking(self):
-        starting_times = [float(np.random.randint(200)) for i in range(len(self.movie_files))]
+        starting_times = [float(np.random.randint(200)) for i in range(self.number_of_movie_files)]
         conv_ops = dict(
             Movie=dict(external_mode=False, stub_test=True, starting_times=starting_times, chunk_data=False)
         )
@@ -121,7 +122,7 @@ class TestMovieDataNwbConversions(unittest.TestCase):
                 assert mod[movie_interface_name].data.chunks is not None  # TODO retrive storage_layout of hdf5 dataset
 
     def test_movie_external_mode(self):
-        starting_times = [float(np.random.randint(200)) for i in range(len(self.movie_files))]
+        starting_times = [float(np.random.randint(200)) for i in range(self.number_of_movie_files)]
         conversion_opts = dict(Movie=dict(starting_times=starting_times, external_mode=True))
         self.nwb_converter.run_conversion(
             nwbfile_path=self.nwbfile_path,
@@ -170,7 +171,7 @@ class TestMovieDataNwbConversions(unittest.TestCase):
             )
 
     def test_movie_stub(self):
-        starting_times = [float(np.random.randint(200)) for i in range(len(self.movie_files))]
+        starting_times = [float(np.random.randint(200)) for i in range(self.number_of_movie_files)]
         conversion_opts = dict(Movie=dict(starting_times=starting_times, external_mode=False, stub_test=True))
         self.nwb_converter.run_conversion(
             nwbfile_path=self.nwbfile_path,

--- a/tests/test_on_data/test_gin_behavior.py
+++ b/tests/test_on_data/test_gin_behavior.py
@@ -12,9 +12,14 @@ from .setup_paths import OUTPUT_PATH, BEHAVIOR_DATA_PATH
 class TestMovieDataNwbConversions(unittest.TestCase):
     savedir = OUTPUT_PATH
 
-    def setUp(self) -> None:
-        self.movie_files = list((BEHAVIOR_DATA_PATH / "videos" / "CFR").iterdir())
-        self.number_of_movie_files = len(self.movie_files)
+    @classmethod
+    def setUpClass(cls):
+        """Use common recording objects and values."""
+        cls.movie_files = list((BEHAVIOR_DATA_PATH / "videos" / "CFR").iterdir())
+        cls.number_of_movie_files = len(cls.movie_files)
+        cls.starting_times = [float(np.random.randint(200)) for i in range(cls.number_of_movie_files)]
+
+    def setUp(self):
         self.nwb_converter = self.create_movie_converter()
         self.nwbfile_path = os.path.join(self.savedir, "movie_test.nwb")
 
@@ -31,7 +36,7 @@ class TestMovieDataNwbConversions(unittest.TestCase):
         return metadata
 
     def test_movie_starting_times(self):
-        starting_times = [float(np.random.randint(200)) for i in range(self.number_of_movie_files)]
+        starting_times = self.starting_times
         conversion_opts = dict(Movie=dict(starting_times=starting_times, external_mode=False))
         self.nwb_converter.run_conversion(
             nwbfile_path=self.nwbfile_path,
@@ -82,7 +87,7 @@ class TestMovieDataNwbConversions(unittest.TestCase):
             assert mod[movie_interface_name].starting_time == 0.0
 
     def test_movie_custom_module(self):
-        starting_times = [float(np.random.randint(200)) for i in range(self.number_of_movie_files)]
+        starting_times = self.starting_times
         module_name = "TestModule"
         module_description = "This is a test module."
         conversion_opts = dict(
@@ -105,7 +110,7 @@ class TestMovieDataNwbConversions(unittest.TestCase):
             assert module_description == nwbfile.processing[module_name].description
 
     def test_movie_chunking(self):
-        starting_times = [float(np.random.randint(200)) for i in range(self.number_of_movie_files)]
+        starting_times = self.starting_times
         conv_ops = dict(
             Movie=dict(external_mode=False, stub_test=True, starting_times=starting_times, chunk_data=False)
         )
@@ -122,7 +127,7 @@ class TestMovieDataNwbConversions(unittest.TestCase):
                 assert mod[movie_interface_name].data.chunks is not None  # TODO retrive storage_layout of hdf5 dataset
 
     def test_movie_external_mode(self):
-        starting_times = [float(np.random.randint(200)) for i in range(self.number_of_movie_files)]
+        starting_times = self.starting_times
         conversion_opts = dict(Movie=dict(starting_times=starting_times, external_mode=True))
         self.nwb_converter.run_conversion(
             nwbfile_path=self.nwbfile_path,
@@ -171,7 +176,7 @@ class TestMovieDataNwbConversions(unittest.TestCase):
             )
 
     def test_movie_stub(self):
-        starting_times = [float(np.random.randint(200)) for i in range(self.number_of_movie_files)]
+        starting_times = self.starting_times
         conversion_opts = dict(Movie=dict(starting_times=starting_times, external_mode=False, stub_test=True))
         self.nwb_converter.run_conversion(
             nwbfile_path=self.nwbfile_path,


### PR DESCRIPTION
## Motivation
Right now, when we run a conversion (with `NwbConverter` class) and we pass some `conversion_options` this overrides all of them:

https://github.com/catalystneuro/nwb-conversion-tools/blob/673410a79402b31a919e0e13e2bf7ed84732d15c/src/nwb_conversion_tools/nwbconverter.py#L149-L150

The current PR solves this by using `dict_deep_update` so the defaults conversion options defined at the interface level are respected at run time.

This PR is a follow up of #465 where we are using the `get_conversion_options` to hard code how and where the recording extractor data should be written. 

Currently, we only define `get_conversion_options` for spikeglx and in our `TutorialRecordingExtractor` but if we want to use this option further we will need something like this. 