### PR TITLE
[Workflow]: Automatic adding of Issues/PRs to Dashboard

### DIFF
--- a/.github/workflows/add-to-dashboard.yml
+++ b/.github/workflows/add-to-dashboard.yml
@@ -10,13 +10,25 @@ on:
 
 jobs:
   issue_opened:
-    name: Add Issue or PR to Dashboard
+    name: Add Issue to Dashboard
     runs-on: ubuntu-latest
     steps:
-      - name: Add Issue or PR to Dashboard
+      - name: Add Issue to Dashboard
         uses: leonsteinhaeuser/project-beta-automations@v1.2.1
         with:
           gh_token: ${{ secrets.MY_GITHUB_TOKEN }}
           organization: catalystneuro
           project_id: 3
           resource_node_id: ${{ github.event.issue.node_id }}
+  pr_opened:
+    name: Add PR to Dashboard
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'opened')
+    steps:
+      - name: Add PR to Dashboard
+        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
+        with:
+          gh_token: ${{ secrets.MY_GITHUB_TOKEN }}
+          organization: catalystneuro
+          project_id: 3
+          resource_node_id: ${{ github.event.pull_request.node_id }}

--- a/.github/workflows/add-to-dashboard.yml
+++ b/.github/workflows/add-to-dashboard.yml
@@ -1,0 +1,22 @@
+name: Add Issue or PR to Dashboard
+
+on:
+  issues:
+    types: opened
+
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  issue_opened:
+    name: Add Issue or PR to Dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Issue or PR to Dashboard
+        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
+        with:
+          gh_token: ${{ secrets.MY_GITHUB_TOKEN }}
+          organization: catalystneuro
+          project_id: 3
+          resource_node_id: ${{ github.event.issue.node_id }}


### PR DESCRIPTION
With the new org-wide To-Do list, it would be nice to have an automatic setting feature for new Issues/PRs.

Unfortunately this isn't the kind of thing that can be set at the `ISSUE_TEMPLATE` level but instead has this lovely workflow. GitHub may eventually had implicit project-side workflows for doing this, but hey that's why it's still in Beta.