### PR TITLE
[Bug]: add keywords to base NWB metadata schema

### DIFF
--- a/src/nwb_conversion_tools/utils/json_schema.py
+++ b/src/nwb_conversion_tools/utils/json_schema.py
@@ -262,5 +262,10 @@ def get_schema_for_NWBFile():
         },
         "stimulus_notes": {"type": "string", "description": "Notes about stimuli, such as how and where presented."},
         "lab": {"type": "string", "description": "lab where experiment was performed"},
+        "keywords": {
+            "description": "Terms to search over",
+            "type": "array",
+            "items": {"title": "keyword", "type": "string"},
+        },
     }
     return schema


### PR DESCRIPTION
Small fix I ran across when finalizing my Tingley conversion prototypes