### PR TITLE
Add kilosort data interface

### DIFF
--- a/src/nwb_conversion_tools/datainterfaces/__init__.py
+++ b/src/nwb_conversion_tools/datainterfaces/__init__.py
@@ -31,6 +31,7 @@ from .ecephys.axona.axonadatainterface import (
 )
 from .ecephys.neuralynx.neuralynxdatainterface import NeuralynxRecordingInterface
 from .ecephys.phy.phydatainterface import PhySortingInterface
+from .ecephys.kilo.kilodatainterface import KiloSortingInterface
 
 from .ophys.caiman.caimandatainterface import CaimanSegmentationInterface
 from .ophys.cnmfe.cnmfedatainterface import CnmfeSegmentationInterface
@@ -66,6 +67,7 @@ interface_list = [
     OpenEphysRecordingExtractorInterface,
     OpenEphysSortingExtractorInterface,
     PhySortingInterface,
+    KiloSortingInterface,
     AxonaRecordingExtractorInterface,
     AxonaPositionDataInterface,
     AxonaLFPDataInterface,

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/kilo/kilodatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/kilo/kilodatainterface.py
@@ -1,0 +1,26 @@
+"""Authors: Cody Baker."""
+from typing import Optional
+
+from spikeinterface.extractors import KiloSortSortingExtractor
+
+from ..basesortingextractorinterface import BaseSortingExtractorInterface
+from ....utils import FolderPathType
+
+
+class KiloSortingInterface(BaseSortingExtractorInterface):
+    """Primary data interface class for converting a KiloSortingExtractor from spikeinterface."""
+
+    SX = KiloSortSortingExtractor
+
+    def __init__(self, folder_path: FolderPathType, keep_good_only: bool = False):
+        """
+        Load and prepare sorting data for kilosort
+
+        Parameters
+        ----------
+        folder_path: str or Path
+            Path to the output Phy folder (containing the params.py)
+        keep_good_only: bool
+            If True, only Kilosort-labeled 'good' units are returned
+        """
+        super().__init__(folder_path=folder_path, keep_good_only=keep_good_only)

--- a/src/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py
+++ b/src/nwb_conversion_tools/tools/spikeinterface/spikeinterface.py
@@ -1243,7 +1243,7 @@ def _add_waveforms_to_units_table(
             """
             pass
 
-        return units_table
+    return units_table
 
 
 def write_sorting(

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -8,10 +8,13 @@ import numpy.testing as npt
 
 from parameterized import parameterized, param
 
-from spikeextractors import NwbRecordingExtractor, NwbSortingExtractor, RecordingExtractor
-from spikeinterface.extractors import NwbRecordingExtractor as NwbRecordingExtractorSI
+from spikeextractors import NwbRecordingExtractor, NwbSortingExtractor, RecordingExtractor, SortingExtractor
 from spikeextractors.testing import check_recordings_equal, check_sortings_equal
+
 from spikeinterface.core.testing import check_recordings_equal as check_recordings_equal_si
+from spikeinterface.core.testing import check_sortings_equal as check_sorting_equal_si
+from spikeinterface.extractors import NwbRecordingExtractor as NwbRecordingExtractorSI
+from spikeinterface.extractors import NwbSortingExtractor as NwbSortingExtractorSI
 
 from pynwb import NWBHDF5IO
 
@@ -24,6 +27,7 @@ from nwb_conversion_tools import (
     NeuroscopeSortingInterface,
     OpenEphysRecordingExtractorInterface,
     PhySortingInterface,
+    KiloSortingInterface,
     SpikeGadgetsRecordingInterface,
     SpikeGLXRecordingInterface,
     SpikeGLXLFPInterface,
@@ -225,6 +229,10 @@ class TestEcephysNwbConversions(unittest.TestCase):
                 interface_kwargs=dict(folder_path=str(DATA_PATH / "phy" / "phy_example_0")),
             ),
             param(
+                data_interface=KiloSortingInterface,
+                interface_kwargs=dict(folder_path=str(DATA_PATH / "phy" / "phy_example_0")),
+            ),
+            param(
                 data_interface=BlackrockSortingExtractorInterface,
                 interface_kwargs=dict(file_path=str(DATA_PATH / "blackrock" / "FileSpec2.3001.nev")),
             ),
@@ -285,8 +293,13 @@ class TestEcephysNwbConversions(unittest.TestCase):
         if sf is None:  # need to set dummy sampling frequency since no associated acquisition in file
             sf = 30000
             sorting.set_sampling_frequency(sf)
-        nwb_sorting = NwbSortingExtractor(file_path=nwbfile_path, sampling_frequency=sf)
-        check_sortings_equal(SX1=sorting, SX2=nwb_sorting)
+
+        if isinstance(sorting, SortingExtractor):
+            nwb_sorting = NwbSortingExtractor(file_path=nwbfile_path, sampling_frequency=sf)
+            check_sortings_equal(SX1=sorting, SX2=nwb_sorting)
+        else:
+            nwb_sorting = NwbSortingExtractorSI(file_path=nwbfile_path, sampling_frequency=sf)
+            check_sorting_equal_si(SX1=sorting, SX2=nwb_sorting)
 
     @parameterized.expand(
         input=[


### PR DESCRIPTION
This should close #451 

Critically, this solves a bug in the recently `_add_waveforms` (see #472) when the return statement was not properly indented. 

## How to test the behavior?
I added a gin test for this that takes into account the fact that this is an object from `spikeinterface`. 