### PR TITLE
[Feature] globus-specific size retrieval helper

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Global Setup
         run: |
           pip install -U pip
-          pip install globus-cli
           pip install pytest-xdist
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Global Setup
         run: |
           pip install -U pip
+          pip install globus-cli
           pip install pytest-xdist
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"

--- a/src/nwb_conversion_tools/tools/data_transfers.py
+++ b/src/nwb_conversion_tools/tools/data_transfers.py
@@ -9,7 +9,6 @@ try:  # pragma: no cover
     HAVE_GLOBUS = True
 except ModuleNotFoundError:
     HAVE_GLOBUS = False
-assert HAVE_GLOBUS, "You must install the globus CLI (pip install globus-cli)!"
 
 
 def get_globus_dataset_content_sizes(globus_endpoint_id: str, path: str, recursive: bool = True) -> Dict[str, int]:
@@ -18,6 +17,8 @@ def get_globus_dataset_content_sizes(globus_endpoint_id: str, path: str, recursi
 
     Returns dictionary whose keys are file names and values are sizes in bytes.
     """
+    assert HAVE_GLOBUS, "You must install the globus CLI (pip install globus-cli)!"
+
     recursive_flag = " --recursive" if recursive else ""
     contents = json.loads(os.popen(f"globus ls -Fjson {globus_endpoint_id}:{path}{recursive_flag}").read())
     files_and_sizes = {item["name"]: item["size"] for item in contents["DATA"] if item["type"] == "file"}

--- a/src/nwb_conversion_tools/tools/data_transfers.py
+++ b/src/nwb_conversion_tools/tools/data_transfers.py
@@ -1,0 +1,23 @@
+"""Collection of helper functions for assessing and performing automated data transfers."""
+import os
+import json
+from typing import Dict
+
+try:  # pragma: no cover
+    import globus_cli
+
+    HAVE_GLOBUS = True
+except ModuleNotFoundError:
+    HAVE_GLOBUS = False
+assert HAVE_GLOBUS, "You must install the globus CLI (pip install globus-cli)!"
+
+
+def get_globus_dataset_content_sizes(globus_endpoint_id: str, path: str, recursive: bool = True) -> Dict[str, int]:
+    """
+    May require external login via 'globus login' from CLI.
+
+    Returns dictionary whose keys are file names and values are sizes in bytes.
+    """
+    contents = json.loads(os.popen(f"globus ls -Fjson {globus_endpoint_id}:{path} --recursive").read())
+    files_and_sizes = {item["name"]: item["size"] for item in contents["DATA"] if item["type"] == "file"}
+    return files_and_sizes

--- a/src/nwb_conversion_tools/tools/data_transfers.py
+++ b/src/nwb_conversion_tools/tools/data_transfers.py
@@ -18,6 +18,7 @@ def get_globus_dataset_content_sizes(globus_endpoint_id: str, path: str, recursi
 
     Returns dictionary whose keys are file names and values are sizes in bytes.
     """
-    contents = json.loads(os.popen(f"globus ls -Fjson {globus_endpoint_id}:{path} --recursive").read())
+    recursive_flag = " --recursive" if recursive else ""
+    contents = json.loads(os.popen(f"globus ls -Fjson {globus_endpoint_id}:{path}{recursive_flag}").read())
     files_and_sizes = {item["name"]: item["size"] for item in contents["DATA"] if item["type"] == "file"}
     return files_and_sizes

--- a/tests/test_internals/test_tools.py
+++ b/tests/test_internals/test_tools.py
@@ -49,7 +49,7 @@ class TestConversionTools(TestCase):
 
 
 @pytest.mark.skipif(
-    not (HAVE_GLOBUS and LOGGED_INTO_GLOBUS)
+    not (HAVE_GLOBUS and LOGGED_INTO_GLOBUS),
     reason="You must have globus installed and be logged in to run this test!",
 )
 def test_get_globus_dataset_content_sizes():

--- a/tests/test_internals/test_tools.py
+++ b/tests/test_internals/test_tools.py
@@ -49,7 +49,7 @@ class TestConversionTools(TestCase):
 
 
 @pytest.mark.skipif(
-    not HAVE_GLOBUS or not LOGGED_INTO_GLOBUS,
+    not (HAVE_GLOBUS and LOGGED_INTO_GLOBUS)
     reason="You must have globus installed and be logged in to run this test!",
 )
 def test_get_globus_dataset_content_sizes():

--- a/tests/test_internals/test_tools.py
+++ b/tests/test_internals/test_tools.py
@@ -4,6 +4,7 @@ from pynwb.base import ProcessingModule
 from hdmf.testing import TestCase
 
 from nwb_conversion_tools.tools.nwb_helpers import get_module, make_nwbfile_from_metadata
+from nwb_conversion_tools.tools.data_transfers import get_globus_dataset_content_sizes
 
 
 class TestConversionTools(TestCase):
@@ -34,3 +35,28 @@ class TestConversionTools(TestCase):
             ),
         ):
             make_nwbfile_from_metadata(metadata=dict())
+
+
+def test_get_globus_dataset_content_sizes():
+    """Test is fixed to a subpath that is somewhat unlikely to change in the future."""
+    assert get_globus_dataset_content_sizes(
+        globus_endpoint_id="188a6110-96db-11eb-b7a9-f57b2d55370d",
+        path="/SenzaiY/YutaMouse41/YutaMouse41-150821/originalClu/",
+    ) == {
+        "YutaMouse41-150821.clu.1": 819862,
+        "YutaMouse41-150821.clu.2": 870498,
+        "YutaMouse41-150821.clu.3": 657938,
+        "YutaMouse41-150821.clu.4": 829761,
+        "YutaMouse41-150821.clu.5": 653502,
+        "YutaMouse41-150821.clu.6": 718752,
+        "YutaMouse41-150821.clu.7": 644541,
+        "YutaMouse41-150821.clu.8": 523422,
+        "YutaMouse41-150821.temp.clu.1": 278025,
+        "YutaMouse41-150821.temp.clu.2": 359573,
+        "YutaMouse41-150821.temp.clu.3": 219280,
+        "YutaMouse41-150821.temp.clu.4": 264388,
+        "YutaMouse41-150821.temp.clu.5": 217834,
+        "YutaMouse41-150821.temp.clu.6": 239890,
+        "YutaMouse41-150821.temp.clu.7": 214835,
+        "YutaMouse41-150821.temp.clu.8": 174434,
+    }


### PR DESCRIPTION
Here is a working minimal helper function for evaluating the size of a directory on a globus endpoint.

Our CI may take some configuring to get the test to work, but the test passes on a system with an authenticated local endpoint.


(i) Other approaches:

(a) datalad - there has been a small amount of work in the past trying to get this working (https://github.com/datalad/datalad/issues/3758) which requires git-annex compatibility with globus, leading the development of  https://github.com/CONP-PCNO/git-annex-remote-globus which looked promising, but did not work out of the box on the DANDIHub due to the `no_browser` option not propagating up to it's higher dependencies, so while it may be possible to fix this eventually, I have no clue how long or how much work it would take. Suffice to say it did not work out of the box. 

(b) Globus SDK instead of CLI: While this code pipes directly to the globus CLI for simplicity, their CLI code is all done in Python so it is possible 'in theory' to replicate their code for handling the request through the transfer client. Unfortunately for us, their approach to CLI usage is not to be a simple wrapper around a library function but rather the code within the CLI function does quite a lot to handle the API and parse output: https://github.com/globus/globus-cli/blob/f6d5e96018f3057b7e90810f438967baf8ad5a1e/src/globus_cli/commands/ls.py#L161-L218

So if we wanted to opt for a direct library usage, we would essentially have to do all that plus authentication in https://github.com/globus/globus-cli/blob/f6d5e96018f3057b7e90810f438967baf8ad5a1e/src/globus_cli/commands/ls.py#L122



(ii) Future direction:

(a) This will of course work for datasets using globus specifically, but it's my opinion that any other types of data hosting (google drive, box, and many many others) should be handled with `rclone`.

See https://rclone.org/commands/rclone_size/ for a nice, basic, machine readable size function readily offered on any rclone remote.

See https://rclone.org/ for the list of supported data hosting, which is quite a lot! Basically most sources except globus and git-annex (which datalad would then be the best choice  for specifically).

(b) Technically, datalad also says it supports rclone intermediately: https://github.com/datalad/git-remote-rclone, but have not tested this out yet. So if we wanted to use datalad as the unifying API of both globus and rclone, just be aware it may take some participation on our end to debug things, just like we often have to do with SpikeInterface.

Bonus: If curious why rclone does not support globus, see https://github.com/rclone/rclone/issues/2313.