### PR TITLE
Make nwbfile argument optional in `run_conversion` for recording and sorting interfaces

### DIFF
--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,4 +1,4 @@
-dandi==0.36.0
+dandi @ git+https://github.com/dandi/dandi-cli.git@9a749401aa2dec2ba59f352205b02a3d8083b1d8  # that uses schema v0.7.x
 pynwb==2.0.0
 hdmf==3.2.1
 tqdm==4.60.0

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -21,4 +21,4 @@ pyintan==0.3.0
 pyopenephys==1.1.2
 sonpy>=1.7.1
 tiffile==2018.10.18
-nwbinspector==0.2.3
+nwbinspector==0.4.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -8,7 +8,6 @@ PyYAML>=5.4
 jsonschema>=3.2.0
 psutil>=5.8.0
 dandi @ git+https://github.com/dandi/dandi-cli.git@9a749401aa2dec2ba59f352205b02a3d8083b1d8  # that uses schema v0.7.x
-#dandischema @ git+https://github.com/dandi/dandi-schema.git@37fdbdd3cf098a087c1e8c6715e923026fe245e1  # 0.6.3
 nwbinspector>=0.2.3
 spikeextractors>=0.9.9
 spikeinterface>=0.93.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -8,7 +8,7 @@ PyYAML>=5.4
 jsonschema>=3.2.0
 psutil>=5.8.0
 dandi>=0.34.1
-dandischema @ git+https://github.com/dandi/dandi-schema.git@master  # needs to be most recent to match server
+dandischema @ git+https://github.com/dandi/dandi-schema.git@37fdbdd3cf098a087c1e8c6715e923026fe245e1  # 0.6.3
 nwbinspector>=0.2.3
 spikeextractors>=0.9.9
 spikeinterface>=0.93.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -8,6 +8,7 @@ PyYAML>=5.4
 jsonschema>=3.2.0
 psutil>=5.8.0
 dandi>=0.34.1
+dandischema>=0.7.1  # needs to be most recent
 nwbinspector>=0.2.3
 spikeextractors>=0.9.9
 spikeinterface>=0.93.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -7,8 +7,8 @@ numpy>=1.21.0
 PyYAML>=5.4
 jsonschema>=3.2.0
 psutil>=5.8.0
-dandi==0.39.4
-dandischema @ git+https://github.com/dandi/dandi-schema.git@37fdbdd3cf098a087c1e8c6715e923026fe245e1  # 0.6.3
+dandi @ git+https://github.com/dandi/dandi-cli.git@9a749401aa2dec2ba59f352205b02a3d8083b1d8  # that uses schema v0.7.x
+#dandischema @ git+https://github.com/dandi/dandi-schema.git@37fdbdd3cf098a087c1e8c6715e923026fe245e1  # 0.6.3
 nwbinspector>=0.2.3
 spikeextractors>=0.9.9
 spikeinterface>=0.93.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -8,7 +8,7 @@ PyYAML>=5.4
 jsonschema>=3.2.0
 psutil>=5.8.0
 dandi>=0.34.1
-dandischema>=0.7.1  # needs to be most recent
+dandischema @ git+https://github.com/dandi/dandi-schema.git@master  # needs to be most recent to match server
 nwbinspector>=0.2.3
 spikeextractors>=0.9.9
 spikeinterface>=0.93.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -7,7 +7,7 @@ numpy>=1.21.0
 PyYAML>=5.4
 jsonschema>=3.2.0
 psutil>=5.8.0
-dandi>=0.34.1
+dandi==0.39.4
 dandischema @ git+https://github.com/dandi/dandi-schema.git@37fdbdd3cf098a087c1e8c6715e923026fe245e1  # 0.6.3
 nwbinspector>=0.2.3
 spikeextractors>=0.9.9

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -95,7 +95,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
 
     def run_conversion(
         self,
-        nwbfile: NWBFile,
+        nwbfile: NWBFile = None,
         metadata: dict = None,
         stub_test: bool = False,
         starting_time: Optional[float] = None,


### PR DESCRIPTION
Simple change that allows recording and sorting interfaces to run without a `nwbfile` by making the argument optional.

My understanding is that @bendichter used the same pattern in the ophys module for the current fromeke conversion.