### PR TITLE
Allow sorting interface to run_conversion without a nwbfile II

### DIFF
--- a/src/nwb_conversion_tools/datainterfaces/ecephys/basesortingextractorinterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/basesortingextractorinterface.py
@@ -156,6 +156,7 @@ class BaseSortingExtractorInterface(BaseDataInterface, ABC):
         write_sorting(
             sorting_extractor,
             nwbfile=nwbfile,
+            metadata=metadata,
             save_path=save_path,
             overwrite=overwrite,
             property_descriptions=property_descriptions,


### PR DESCRIPTION
This is a follow-up of #505 as I failed to propagate the metadata over there (which indicates that there is some test missing).

This is required in #495 for the tests to work over there.
