### PR TITLE
Metadata to handle `datetime` objects simple

### DIFF
--- a/src/nwb_conversion_tools/nwbconverter.py
+++ b/src/nwb_conversion_tools/nwbconverter.py
@@ -1,6 +1,7 @@
 """Authors: Cody Baker and Ben Dichter."""
 from jsonschema import validate
 from pathlib import Path
+import datetime
 from typing import Optional, Dict
 
 from pynwb import NWBHDF5IO, NWBFile
@@ -101,6 +102,10 @@ class NWBConverter:
 
     def validate_metadata(self, metadata: Dict[str, dict]):
         """Validate metadata against Converter metadata_schema."""
+        session_start_time = metadata.get("NWBFile", dict()).get("session_start_time", None)
+        if session_start_time and isinstance(session_start_time, datetime.datetime):
+            metadata["NWBFile"]["session_start_time"] = session_start_time.isoformat()
+
         validate(instance=metadata, schema=self.get_metadata_schema())
         if self.verbose:
             print("Metadata is valid!")

--- a/tests/test_internals/test_converter.py
+++ b/tests/test_internals/test_converter.py
@@ -37,7 +37,7 @@ def test_converter():
 
         converter = ExtensionTestNWBConverter(source_data=dict(NdxEvents=dict()))
         metadata = converter.get_metadata()
-        metadata["NWBFile"]["session_start_time"] = datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S")
+        metadata["NWBFile"]["session_start_time"] = datetime.now().astimezone()
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
 
         rmtree(test_dir)

--- a/tests/test_internals/test_interfaces.py
+++ b/tests/test_internals/test_interfaces.py
@@ -54,7 +54,7 @@ def test_tutorials():
     converter = TutorialNWBConverter(source_data=source_data)
     metadata = converter.get_metadata()
     metadata["NWBFile"]["session_description"] = "NWB Conversion Tools tutorial."
-    metadata["NWBFile"]["session_start_time"] = datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S")
+    metadata["NWBFile"]["session_start_time"] = datetime.now().astimezone()
     metadata["NWBFile"]["experimenter"] = ["My name"]
     metadata["Subject"] = dict(subject_id="Name of imaginary testing subject (required for DANDI upload)")
     conversion_options = dict(RecordingTutorial=dict(stub_test=stub_test), SortingTutorial=dict())
@@ -81,7 +81,7 @@ def test_tutorial_interfaces():
     )
     converter = TutorialNWBConverter(source_data=source_data)
     metadata = converter.get_metadata()
-    metadata["NWBFile"]["session_start_time"] = datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S")
+    metadata["NWBFile"]["session_start_time"] = datetime.now().astimezone()
     converter.run_conversion(nwbfile_path=output_file, overwrite=True, metadata=metadata)
 
 
@@ -105,7 +105,7 @@ def test_pkl_interface():
     )
     converter = SpikeInterfaceTestNWBConverter(source_data=source_data)
     metadata = converter.get_metadata()
-    metadata["NWBFile"]["session_start_time"] = datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S")
+    metadata["NWBFile"]["session_start_time"] = datetime.now().astimezone()
     converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
 
     nwb_recording = se.NwbRecordingExtractor(file_path=nwbfile_path)
@@ -141,7 +141,7 @@ class TestSortingInterface(unittest.TestCase):
         minimal_nwbfile = test_dir / "stub_temp.nwb"
         conversion_options = dict(TestSortingInterface=dict(stub_test=True))
         metadata = self.test_sorting_interface.get_metadata()
-        metadata["NWBFile"]["session_start_time"] = datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S")
+        metadata["NWBFile"]["session_start_time"] = datetime.now().astimezone()
         self.test_sorting_interface.run_conversion(
             nwbfile_path=minimal_nwbfile, metadata=metadata, conversion_options=conversion_options
         )
@@ -155,7 +155,7 @@ class TestSortingInterface(unittest.TestCase):
         test_dir = Path(mkdtemp())
         minimal_nwbfile = test_dir / "temp.nwb"
         metadata = self.test_sorting_interface.get_metadata()
-        metadata["NWBFile"]["session_start_time"] = datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S")
+        metadata["NWBFile"]["session_start_time"] = datetime.now().astimezone()
         self.test_sorting_interface.run_conversion(nwbfile_path=minimal_nwbfile, metadata=metadata)
         with NWBHDF5IO(minimal_nwbfile, "r") as io:
             nwbfile = io.read()

--- a/tests/test_internals/test_movie_interface.py
+++ b/tests/test_internals/test_movie_interface.py
@@ -62,7 +62,7 @@ class TestMovieInterface(unittest.TestCase):
 
     def get_metadata(self):
         metadata = self.nwb_converter.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S"))
+        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         return metadata
 
     def test_movie_starting_times(self):

--- a/tests/test_internals/test_tools.py
+++ b/tests/test_internals/test_tools.py
@@ -31,7 +31,7 @@ except ModuleNotFoundError:
 class TestConversionTools(TestCase):
     def test_get_module(self):
         nwbfile = make_nwbfile_from_metadata(
-            metadata=dict(NWBFile=dict(session_start_time=datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S"))),
+            metadata=dict(NWBFile=dict(session_start_time=datetime.now().astimezone())),
         )
 
         name_1 = "test_1"

--- a/tests/test_on_data/test_gin_behavior.py
+++ b/tests/test_on_data/test_gin_behavior.py
@@ -28,7 +28,7 @@ class TestMovieDataNwbConversions(unittest.TestCase):
 
     def get_metadata(self):
         metadata = self.nwb_converter.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S"))
+        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         return metadata
 
     def test_movie_starting_times(self):

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -71,7 +71,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
             if interface_kwarg in ["file_path", "folder_path"]:
                 self.assertIn(member=interface_kwarg, container=converter.data_interface_objects["TestLFP"].source_data)
         metadata = converter.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S"))
+        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
         recording = converter.data_interface_objects["TestLFP"].recording_extractor
         with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
@@ -183,7 +183,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
                     member=interface_kwarg, container=converter.data_interface_objects["TestRecording"].source_data
                 )
         metadata = converter.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S"))
+        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
         recording = converter.data_interface_objects["TestRecording"].recording_extractor
 
@@ -286,7 +286,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
                     member=interface_kwarg, container=converter.data_interface_objects["TestSorting"].source_data
                 )
         metadata = converter.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S"))
+        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
         sorting = converter.data_interface_objects["TestSorting"].sorting_extractor
         sf = sorting.get_sampling_frequency()
@@ -321,7 +321,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
 
         converter = TestConverter(source_data=dict(TestRecording=interface_kwargs))
         metadata = converter.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S"))
+        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         converter.run_conversion(
             nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata, conversion_options=conversion_options
         )
@@ -355,7 +355,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
 
         converter = TestConverter(source_data=dict(TestRecording=interface_kwargs))
         metadata = converter.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S"))
+        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         converter.run_conversion(
             nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata, conversion_options=conversion_options
         )
@@ -375,7 +375,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
             source_data=dict(TestRecording=dict(file_path=str(DATA_PATH / "neuroscope" / "test1" / "test1.dat")))
         )
         metadata = converter.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S"))
+        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         starting_time = 123.0
         converter.run_conversion(
             nwbfile_path=nwbfile_path,

--- a/tests/test_on_data/test_gin_ophys.py
+++ b/tests/test_on_data/test_gin_ophys.py
@@ -80,7 +80,7 @@ class TestOphysNwbConversions(unittest.TestCase):
 
         converter = TestConverter(source_data=dict(TestImaging=dict(interface_kwargs)))
         metadata = converter.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S"))
+        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
         imaging = converter.data_interface_objects["TestImaging"].imaging_extractor
         nwb_imaging = NwbImagingExtractor(file_path=nwbfile_path)
@@ -134,7 +134,7 @@ class TestOphysNwbConversions(unittest.TestCase):
 
         converter = TestConverter(source_data=dict(TestSegmentation=dict(interface_kwargs)))
         metadata = converter.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S"))
+        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
         segmentation = converter.data_interface_objects["TestSegmentation"].segmentation_extractor
         nwb_segmentation = NwbSegmentationExtractor(file_path=nwbfile_path)


### PR DESCRIPTION
This should close #463.

This a simpler approach compared to the one proposed in the issue. It might not generalized as well but is more specific. I will open a sister PR to discuss which one might be better. 

I removed all the `strftime` calls from datetime so now all our tests -save yaml- are running with datetime objects.