### PR TITLE
change name. The name of the sortware is "kilosort" not "kilo"

### DIFF
--- a/src/nwb_conversion_tools/datainterfaces/__init__.py
+++ b/src/nwb_conversion_tools/datainterfaces/__init__.py
@@ -31,7 +31,7 @@ from .ecephys.axona.axonadatainterface import (
 )
 from .ecephys.neuralynx.neuralynxdatainterface import NeuralynxRecordingInterface
 from .ecephys.phy.phydatainterface import PhySortingInterface
-from .ecephys.kilo.kilodatainterface import KiloSortingInterface
+from .ecephys.kilosort.kilosortdatainterface import KilosortSortingInterface
 
 from .ophys.caiman.caimandatainterface import CaimanSegmentationInterface
 from .ophys.cnmfe.cnmfedatainterface import CnmfeSegmentationInterface
@@ -69,7 +69,7 @@ interface_list = [
     OpenEphysRecordingExtractorInterface,
     OpenEphysSortingExtractorInterface,
     PhySortingInterface,
-    KiloSortingInterface,
+    KilosortSortingInterface,
     AxonaRecordingExtractorInterface,
     AxonaPositionDataInterface,
     AxonaLFPDataInterface,

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/kilosort/kilosortdatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/kilosort/kilosortdatainterface.py
@@ -7,7 +7,7 @@ from ..basesortingextractorinterface import BaseSortingExtractorInterface
 from ....utils import FolderPathType
 
 
-class KiloSortingInterface(BaseSortingExtractorInterface):
+class KilosortSortingInterface(BaseSortingExtractorInterface):
     """Primary data interface class for converting a KiloSortingExtractor from spikeinterface."""
 
     SX = KiloSortSortingExtractor

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -1,5 +1,4 @@
 import unittest
-from itertools import product
 from pathlib import Path
 from datetime import datetime
 
@@ -27,7 +26,7 @@ from nwb_conversion_tools import (
     NeuroscopeSortingInterface,
     OpenEphysRecordingExtractorInterface,
     PhySortingInterface,
-    KiloSortingInterface,
+    KilosortSortingInterface,
     SpikeGadgetsRecordingInterface,
     SpikeGLXRecordingInterface,
     SpikeGLXLFPInterface,
@@ -229,7 +228,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
                 interface_kwargs=dict(folder_path=str(DATA_PATH / "phy" / "phy_example_0")),
             ),
             param(
-                data_interface=KiloSortingInterface,
+                data_interface=KilosortSortingInterface,
                 interface_kwargs=dict(folder_path=str(DATA_PATH / "phy" / "phy_example_0")),
             ),
             param(


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

## How to test the behavior?
```
Show here how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [ ] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
