### PR TITLE
Remove incorrect statement about doc gallery

### DIFF
--- a/docs/conversion_example_gallery.rst
+++ b/docs/conversion_example_gallery.rst
@@ -21,7 +21,6 @@ Recording
 
 Sorting
 -------
-The sorters are not yet in doctest. Adding here in advance to see the structure. No need to review
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
I am removing the statement that says that the sortings are not in doctest.

