### PR TITLE
[Refactor] standardize LFP conversion kwargs

### DIFF
--- a/src/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -30,78 +30,37 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
 
     def run_conversion(
         self,
-        nwbfile: NWBFile,
-        metadata: dict = None,
+        nwbfile_path: OptionalFilePathType = None,
+        nwbfile: Optional[NWBFile] = None,
+        metadata: Optional[dict] = None,
+        overwrite: bool = False,
         stub_test: bool = False,
         starting_time: Optional[float] = None,
         use_times: bool = False,
-        save_path: OptionalFilePathType = None,
-        overwrite: bool = False,
-        compression: Optional[str] = "gzip",
+        compression: Optional[str] = None,
         compression_opts: Optional[int] = None,
         iterator_type: Optional[str] = None,
         iterator_opts: Optional[dict] = None,
+        save_path: OptionalFilePathType = None,  # TODO: to be removed, depreceation applied at tools level
     ):
-        """
-        Primary function for converting low-pass recording extractor data to nwb.
-
-        Parameters
-        ----------
-        nwbfile: NWBFile
-            nwb file to which the recording information is to be added
-        metadata: dict
-            metadata info for constructing the nwb file (optional).
-            Should be of the format::
-
-                metadata['Ecephys']['ElectricalSeries'] = dict(name=my_name, description=my_description)
-
-        starting_time: float (optional)
-            Sets the starting time of the ElectricalSeries to a manually set value.
-            Increments timestamps if use_times is True.
-        use_times: bool
-            If True, the times are saved to the nwb file using recording.frame_to_time(). If False (default),
-            the sampling rate is used.
-        save_path: OptionalFilePathType
-            Required if an nwbfile is not passed. Must be the path to the nwbfile
-            being appended, otherwise one is created and written.
-        overwrite: bool
-            If using save_path, whether or not to overwrite the NWBFile if it already exists.
-        stub_test: bool, optional (default False)
-            If True, will truncate the data to run the conversion faster and take up less memory.
-        compression: str (optional, defaults to "gzip")
-            Type of compression to use. Valid types are "gzip" and "lzf".
-            Set to None to disable all compression.
-        compression_opts: int (optional, defaults to 4)
-            Only applies to compression="gzip". Controls the level of the GZIP.
-        iterator_type: str (optional, defaults to 'v2')
-            The type of DataChunkIterator to use.
-            'v1' is the original DataChunkIterator of the hdmf data_utils.
-            'v2' is the locally developed RecordingExtractorDataChunkIterator, which offers full control over chunking.
-        iterator_opts: dict (optional)
-            Dictionary of options for the RecordingExtractorDataChunkIterator (iterator_type='v2').
-            Valid options are
-                buffer_gb : float (optional, defaults to 1 GB)
-                    Recommended to be as much free RAM as available). Automatically calculates suitable buffer shape.
-                chunk_mb : float (optional, defaults to 1 MB)
-                    Should be below 1 MB. Automatically calculates suitable chunk shape.
-            If manual specification of buffer_shape and chunk_shape are desired, these may be specified as well.
-        """
         if stub_test or self.subset_channels is not None:
             recording = self.subset_recording(stub_test=stub_test)
         else:
             recording = self.recording_extractor
         write_recording(
             recording=recording,
+            nwbfile_path=nwbfile_path,
             nwbfile=nwbfile,
             metadata=metadata,
+            overwrite=overwrite,
+            verbose=self.verbose,
             starting_time=starting_time,
             use_times=use_times,
             write_as="lfp",
             es_key="ElectricalSeries_lfp",
-            save_path=save_path,
-            overwrite=overwrite,
             compression=compression,
             compression_opts=compression_opts,
             iterator_type=iterator_type,
             iterator_opts=iterator_opts,
+            save_path=save_path,  # TODO: to be removed, depreceation applied at tools level
         )

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -96,7 +96,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
     def run_conversion(
         self,
         nwbfile_path: OptionalFilePathType = None,
-        nwbfile: NWBFile = None,
+        nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         overwrite: bool = False,
         stub_test: bool = False,
@@ -116,6 +116,9 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
 
         Parameters
         ----------
+        nwbfile_path: FilePathType
+            Path for where to write or load (if overwrite=False) the NWBFile.
+            If specified, this context will always write to the this location.
         nwbfile: NWBFile
             nwb file to which the recording information is to be added
         metadata: dict
@@ -123,18 +126,15 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
             Should be of the format::
 
                 metadata['Ecephys']['ElectricalSeries'] = dict(name=my_name, description=my_description)
-
+        overwrite: bool, optional
+            Whether nor not to overwrite the NWBFile if one exists at the nwbfile_path.
+        The default is False (append mode).
         starting_time: float (optional)
             Sets the starting time of the ElectricalSeries to a manually set value.
             Increments timestamps if use_times is True.
         use_times: bool
             If True, the times are saved to the nwb file using recording.frame_to_time(). If False (default),
             the sampling rate is used.
-        save_path: OptionalFilePathType
-            Required if an nwbfile is not passed. Must be the path to the nwbfile
-            being appended, otherwise one is created and written.
-        overwrite: bool
-            If using save_path, whether or not to overwrite the NWBFile if it already exists.
         stub_test: bool, optional (default False)
             If True, will truncate the data to run the conversion faster and take up less memory.
         write_as: str (optional, defaults to 'raw')

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -118,7 +118,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         ----------
         nwbfile_path: FilePathType
             Path for where to write or load (if overwrite=False) the NWBFile.
-            If specified, this context will always write to the this location.
+            If specified, this context will always write to this location.
         nwbfile: NWBFile
             nwb file to which the recording information is to be added
         metadata: dict
@@ -127,7 +127,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
 
                 metadata['Ecephys']['ElectricalSeries'] = dict(name=my_name, description=my_description)
         overwrite: bool, optional
-            Whether nor not to overwrite the NWBFile if one exists at the nwbfile_path.
+            Whether or not to overwrite the NWBFile if one exists at the nwbfile_path.
         The default is False (append mode).
         starting_time: float (optional)
             Sets the starting time of the ElectricalSeries to a manually set value.


### PR DESCRIPTION
Continuation of #516 for LFP interfaces.

Removal of docstring allows it to completely inherit the one from the parent, which is identical.