### PR TITLE
Fix order of TwoPhotonSeries metadata update

### DIFF
--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -96,7 +96,7 @@ def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=
     Adds two photon series from imaging object as TwoPhotonSeries to nwbfile object.
     """
     metadata = dict_deep_update(default_ophys_metadata(), metadata)
-    metadata = safe_update(metadata, get_nwb_imaging_metadata(imaging))
+    metadata = safe_update(get_nwb_imaging_metadata(imaging), metadata)
     # Tests if ElectricalSeries already exists in acquisition
     nwb_es_names = [ac for ac in nwbfile.acquisition]
     opts = metadata["Ophys"]["TwoPhotonSeries"][0]


### PR DESCRIPTION
## Motivation

This issue came up in catalystneuro/fee-lab-to-nwb#11, that adding a custom description for a `TwoPhotonSeries` gets overwritten by a default value. The order of metadata update should be reversed in this case, such that the default values should be updated with the "new" metadata values. 

## How to test the behavior?
```
Show here how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [ ] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
