### PR TITLE
Update default parameters for ophys

### DIFF
--- a/src/nwb_conversion_tools/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -12,6 +12,7 @@ from ...utils import (
     fill_defaults,
     get_base_schema,
     OptionalFilePathType,
+    dict_deep_update,
 )
 
 
@@ -54,7 +55,8 @@ class BaseImagingExtractorInterface(BaseDataInterface):
 
     def get_metadata(self):
         metadata = super().get_metadata()
-        metadata.update(get_nwb_imaging_metadata(self.imaging_extractor))
+        default_metadata = get_nwb_imaging_metadata(self.imaging_extractor)
+        metadata = dict_deep_update(default_metadata, metadata)
         _ = metadata.pop("NWBFile")
 
         # fix troublesome data types

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -183,16 +183,19 @@ def get_nwb_imaging_metadata(imgextractor: ImagingExtractor):
     """
     metadata = default_ophys_metadata()
     # Optical Channel name:
-    for i in range(imgextractor.get_num_channels()):
-        ch_name = imgextractor.get_channel_names()[i]
-        if i == 0:
-            metadata["Ophys"]["ImagingPlane"][0]["optical_channel"][i]["name"] = ch_name
+    channel_name_list = imgextractor.get_channel_names()
+    if channel_name_list is None:
+        channel_name_list = ["generic_name"] * imgextractor.get_num_channels()
+
+    for index, channel_name in enumerate(channel_name_list):
+        if index == 0:
+            metadata["Ophys"]["ImagingPlane"][0]["optical_channel"][index]["name"] = channel_name
         else:
             metadata["Ophys"]["ImagingPlane"][0]["optical_channel"].append(
                 dict(
-                    name=ch_name,
+                    name=channel_name,
                     emission_lambda=np.nan,
-                    description=f"{ch_name} description",
+                    description=f"{channel_name} description",
                 )
             )
     # set imaging plane rate:
@@ -205,6 +208,13 @@ def get_nwb_imaging_metadata(imgextractor: ImagingExtractor):
     metadata["Ophys"]["ImagingPlane"][0].update(imaging_rate=rate)
     # TwoPhotonSeries update:
     metadata["Ophys"]["TwoPhotonSeries"][0].update(dimension=imgextractor.get_image_size(), rate=rate)
+
+    device_name = metadata["Ophys"]["Device"][0]["name"]
+    metadata["Ophys"]["ImagingPlane"][0]["device"] = device_name
+
+    plane_name = metadata["Ophys"]["ImagingPlane"][0]["name"]
+    metadata["Ophys"]["TwoPhotonSeries"][0]["imaging_plane"] = plane_name
+
     # remove what Segmentation extractor will input:
     _ = metadata["Ophys"].pop("ImageSegmentation")
     _ = metadata["Ophys"].pop("Fluorescence")
@@ -284,7 +294,9 @@ def write_imaging(
         metadata = dict()
     if hasattr(imaging, "nwb_metadata"):
         metadata = dict_deep_update(imaging.nwb_metadata, metadata)
-    metadata = dict_deep_update(get_nwb_imaging_metadata(imaging), metadata)
+    default_metadata = get_nwb_imaging_metadata(imaging)
+    metadata = dict_deep_update(default_metadata, metadata)
+
     with make_or_load_nwbfile(
         nwbfile_path=nwbfile_path, nwbfile=nwbfile, metadata=metadata, overwrite=overwrite, verbose=verbose
     ) as nwbfile_out:

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -36,7 +36,7 @@ def safe_update(d, u):
     return d
 
 
-def default_ophys_metadata():
+def get_default_ophys_metadata():
     """Fill default metadata for optical physiology."""
     metadata = get_default_nwbfile_metadata()
     metadata.update(
@@ -82,7 +82,7 @@ def default_ophys_metadata():
 
 def add_devices(nwbfile: NWBFile, metadata: dict):
     """Add optical physiology devices from metadata."""
-    metadata = dict_deep_update(default_ophys_metadata(), metadata)
+    metadata = dict_deep_update(get_default_ophys_metadata(), metadata)
     for device in metadata.get("Ophys", dict()).get("Device", dict()):
         if "name" in device and device["name"] not in nwbfile.devices:
             nwbfile.create_device(**device)
@@ -95,7 +95,7 @@ def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=
 
     Adds two photon series from imaging object as TwoPhotonSeries to nwbfile object.
     """
-    metadata = dict_deep_update(default_ophys_metadata(), metadata)
+    metadata = dict_deep_update(get_default_ophys_metadata(), metadata)
     metadata = safe_update(metadata, get_nwb_imaging_metadata(imaging))
     # Tests if ElectricalSeries already exists in acquisition
     nwb_es_names = [ac for ac in nwbfile.acquisition]
@@ -181,7 +181,7 @@ def get_nwb_imaging_metadata(imgextractor: ImagingExtractor):
     ----------
     imgextractor: ImagingExtractor
     """
-    metadata = default_ophys_metadata()
+    metadata = get_default_ophys_metadata()
     # Optical Channel name:
     channel_name_list = imgextractor.get_channel_names()
     if channel_name_list is None:
@@ -316,7 +316,7 @@ def get_nwb_segmentation_metadata(sgmextractor):
     ----------
     sgmextractor: SegmentationExtractor
     """
-    metadata = default_ophys_metadata()
+    metadata = get_default_ophys_metadata()
     # Optical Channel name:
     for i in range(sgmextractor.get_num_channels()):
         ch_name = sgmextractor.get_channel_names()[i]

--- a/tests/test_on_data/test_gin_ophys.py
+++ b/tests/test_on_data/test_gin_ophys.py
@@ -66,18 +66,6 @@ class TestOphysNwbConversions(unittest.TestCase):
         class TestConverter(NWBConverter):
             data_interface_classes = dict(TestImaging=data_interface)
 
-            def get_metadata(self):
-                metadata = super().get_metadata()
-                # attach device to ImagingPlane lacking property
-                device_name = metadata["Ophys"]["Device"][0]["name"]
-                if "device" not in metadata["Ophys"]["ImagingPlane"][0].keys():
-                    metadata["Ophys"]["ImagingPlane"][0]["device"] = device_name
-                # attach ImagingPlane to TwoPhotonSeries lacking property
-                plane_name = metadata["Ophys"]["ImagingPlane"][0]["name"]
-                if "imaging_plane" not in metadata["Ophys"]["TwoPhotonSeries"][0].keys():
-                    metadata["Ophys"]["TwoPhotonSeries"][0]["imaging_plane"] = plane_name
-                return metadata
-
         converter = TestConverter(source_data=dict(TestImaging=dict(interface_kwargs)))
         metadata = converter.get_metadata()
         metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())

--- a/tests/test_on_data/test_metadata/test_scanimage_metadata.py
+++ b/tests/test_on_data/test_metadata/test_scanimage_metadata.py
@@ -10,8 +10,9 @@ from ..setup_paths import OPHYS_DATA_PATH
 def test_scanimage_metadata():
     scan_image_tiff_filepath = OPHYS_DATA_PATH / "imaging_datasets" / "Tif" / "sample_scanimage.tiff"
 
-    scaniamge_data_interface = ScanImageImagingInterface(scan_image_tiff_filepath)
-    assert scaniamge_data_interface.get_metadata() == {
+    scanimage_interface = ScanImageImagingInterface(scan_image_tiff_filepath)
+    metadata = scanimage_interface.get_metadata()
+    expected_metadata = {
         "Ophys": {
             "Device": [{"name": "Microscope"}],
             "ImagingPlane": [
@@ -25,6 +26,7 @@ def test_scanimage_metadata():
                         {"name": "channel_0", "emission_lambda": np.nan, "description": "no description"}
                     ],
                     "imaging_rate": 3.90625,
+                    "device": "Microscope",
                 }
             ],
             "TwoPhotonSeries": {
@@ -33,3 +35,5 @@ def test_scanimage_metadata():
         },
         "NWBFile": {"session_start_time": datetime(2017, 10, 9, 16, 57, 7, 967000)},
     }
+
+    assert metadata == expected_metadata


### PR DESCRIPTION
While working in the Seidemann conversion I have been prototyping a new ophys interface. I have noticed that there is some required metadata parameters (the device name in the imaging plane and the plane name in the TwoPhotonSeries) that our current defaults do not fill. This PR aligns the metadata behavior of `roieextractors` with the one `spikeinterface` (as libraries of `nwb-conversion-tools`) where the required metadata to run is pre-filled and updated if provided.

For some reason those were added manually in our `gin_test` so I removed them from there and that works as a test.