### PR TITLE
Refactor of `add_two_photon_series`

### DIFF
--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -90,9 +90,9 @@ def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=
     # Tests if ElectricalSeries already exists in acquisition
     two_photon_series_metadata = metadata["Ophys"]["TwoPhotonSeries"][0]
     two_photon_series_name = two_photon_series_metadata["name"]
-    acquisition_modules = [_ for _ in nwbfile.acquisition]
+    acquisition_modules = [module for module in nwbfile.acquisition]
 
-    # Only add if module is new
+    # Only add if the two photon series if it is not present before
     if two_photon_series_name not in acquisition_modules:
 
         image_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -1,4 +1,5 @@
 """Authors: Saksham Sharda and Alessio Buccino."""
+from logging import warning
 import os
 import numpy as np
 from pathlib import Path
@@ -123,13 +124,14 @@ def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=
         if use_times:
             two_p_series_kwargs.update(timestamps=H5DataIO(timestamps, compression="gzip"))
             if "rate" in two_p_series_kwargs:
+                warn("Passed both rate and use times, rate is to be removed.")
                 del two_p_series_kwargs["rate"]
         else:
             two_p_series_kwargs.update(starting_time=timestamps[0], rate=float(imaging.get_sampling_frequency()))
 
         # Add the TwoPhotonSeries to the nwbfile
-        ophys_ts = TwoPhotonSeries(**two_p_series_kwargs)
-        nwbfile.add_acquisition(ophys_ts)
+        two_photon_series = TwoPhotonSeries(**two_p_series_kwargs)
+        nwbfile.add_acquisition(two_photon_series)
     return nwbfile
 
 
@@ -192,6 +194,7 @@ def get_nwb_imaging_metadata(imgextractor: ImagingExtractor):
         if imgextractor.get_sampling_frequency() is None
         else float(imgextractor.get_sampling_frequency())
     )
+
     # adding imaging_rate:
     metadata["Ophys"]["ImagingPlane"][0].update(imaging_rate=rate)
     # TwoPhotonSeries update:

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -106,7 +106,7 @@ def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=
 
         def data_generator(imaging):
             for i in range(imaging.get_num_frames()):
-                yield imaging.get_frames(frame_idxs=[i]).T
+                yield imaging.get_frames(frame_idxs=[i]).squeeze().T
 
         data = H5DataIO(
             DataChunkIterator(data_generator(imaging), buffer_size=buffer_size),
@@ -132,8 +132,9 @@ def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=
             )
             if "rate" in two_p_series_kwargs:
                 del two_p_series_kwargs["rate"]
-        ophys_ts = TwoPhotonSeries(**two_p_series_kwargs)
 
+        # Add the TwoPhotonSeries to the nwbfile
+        ophys_ts = TwoPhotonSeries(**two_p_series_kwargs)
         nwbfile.add_acquisition(ophys_ts)
     return nwbfile
 

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -1,11 +1,12 @@
 """Authors: Saksham Sharda and Alessio Buccino."""
-from logging import warning
 import os
-import numpy as np
 from pathlib import Path
 from warnings import warn
 from collections import abc
 from typing import Optional
+from copy import deepcopy
+
+import numpy as np
 
 from roiextractors import ImagingExtractor, SegmentationExtractor, MultiSegmentationExtractor
 from pynwb import NWBFile, NWBHDF5IO
@@ -86,10 +87,12 @@ def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=
 
     Adds two photon series from imaging object as TwoPhotonSeries to nwbfile object.
     """
-    metadata = dict_deep_update(get_nwb_imaging_metadata(imaging), metadata)
+
+    metadata_copy = deepcopy(metadata)
+    metadata_copy = dict_deep_update(get_nwb_imaging_metadata(imaging), metadata_copy)
 
     # Tests if TwoPhotonSeries already exists in acquisition
-    two_photon_series_metadata = metadata["Ophys"]["TwoPhotonSeries"][0]
+    two_photon_series_metadata = metadata_copy["Ophys"]["TwoPhotonSeries"][0]
     two_photon_series_name = two_photon_series_metadata["name"]
     acquisition_modules = [module for module in nwbfile.acquisition]
 
@@ -109,7 +112,7 @@ def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=
         two_p_series_kwargs.update(data=data)
 
         # Add the image plane
-        image_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
+        image_plane_metadata = metadata_copy["Ophys"]["ImagingPlane"][0]
         image_plane_metadata["optical_channel"] = [
             OpticalChannel(**metadata) for metadata in image_plane_metadata["optical_channel"]
         ]
@@ -132,6 +135,7 @@ def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=
         # Add the TwoPhotonSeries to the nwbfile
         two_photon_series = TwoPhotonSeries(**two_p_series_kwargs)
         nwbfile.add_acquisition(two_photon_series)
+
     return nwbfile
 
 


### PR DESCRIPTION
This follows the PR in #535 and I think will be necessary for getting the metadata correctly.

This is mostly a refactoring of the `add_two_photon_series` and as a bonus we can get rid of the function `safe_update` and use `dict_deep_update` in every instance of it.