### PR TITLE
Fix metadata combination of imaging and segmentation interfaces 

### DIFF
--- a/src/nwb_conversion_tools/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -44,9 +44,12 @@ class BaseImagingExtractorInterface(BaseDataInterface):
         )
 
         # Schema definition for arrays
+
+        imaging_plane_schema = get_schema_from_hdmf_class(ImagingPlane)
+        imaging_plane_schema["properties"]["optical_channel"].pop("maxItems")
         metadata_schema["properties"]["Ophys"]["properties"]["definitions"] = dict(
             Device=get_schema_from_hdmf_class(Device),
-            ImagingPlane=get_schema_from_hdmf_class(ImagingPlane),
+            ImagingPlane=imaging_plane_schema,
             TwoPhotonSeries=get_schema_from_hdmf_class(TwoPhotonSeries),
         )
 

--- a/src/nwb_conversion_tools/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -38,6 +38,8 @@ class BaseSegmentationExtractorInterface(BaseDataInterface, ABC):
 
         # Temporary fixes until centralized definition of metadata schemas
         metadata_schema["properties"]["Ophys"]["properties"]["ImagingPlane"].update(type="array")
+        metadata_schema["properties"]["Ophys"]["properties"]["TwoPhotonSeries"].update(type="array")
+
         metadata_schema["properties"]["Ophys"]["properties"]["Fluorescence"]["properties"]["roi_response_series"][
             "items"
         ]["required"] = list()
@@ -45,6 +47,7 @@ class BaseSegmentationExtractorInterface(BaseDataInterface, ABC):
         metadata_schema["properties"]["Ophys"]["properties"]["Fluorescence"]["properties"]["roi_response_series"].pop(
             "maxItems"
         )
+
         fill_defaults(metadata_schema, self.get_metadata())
         return metadata_schema
 

--- a/tests/test_on_data/test_metadata_combinations.py
+++ b/tests/test_on_data/test_metadata_combinations.py
@@ -27,7 +27,7 @@ interfaces_to_combine = ["TiffImagingInterface", "Suite2pSegmentationInterface"]
 
 
 def custom_name_func(testcase_func, param_num, param):
-    return f"{testcase_func.__name__}_{param_num}_" f"_{param.kwargs.get('case_name', '')}"
+    return f"{testcase_func.__name__}_{param_num}" f"_{param.kwargs.get('case_name', '')}"
 
 
 class TestConversionCombinations(unittest.TestCase):

--- a/tests/test_on_data/test_metadata_combinations.py
+++ b/tests/test_on_data/test_metadata_combinations.py
@@ -1,0 +1,60 @@
+import unittest
+from datetime import datetime
+
+from parameterized import parameterized, param
+
+from nwb_conversion_tools import Suite2pSegmentationInterface, TiffImagingInterface
+from nwb_conversion_tools import NWBConverter
+from .setup_paths import OPHYS_DATA_PATH
+
+
+TiffImagingInterface_source_data = dict(
+    file_path=str(OPHYS_DATA_PATH / "imaging_datasets" / "Tif" / "demoMovie.tif"), sampling_frequency=15.0
+)
+Suite2pSegmentationInterface_source_data = dict(file_path=str(OPHYS_DATA_PATH / "segmentation_datasets" / "suite2p"))
+
+interface_to_source_data_map = dict(
+    TiffImagingInterface=TiffImagingInterface_source_data,
+    Suite2pSegmentationInterface=Suite2pSegmentationInterface_source_data,
+)
+
+interface_to_class_map = dict(
+    TiffImagingInterface=TiffImagingInterface,
+    Suite2pSegmentationInterface=Suite2pSegmentationInterface,
+)
+
+interfaces_to_combine = ["TiffImagingInterface", "Suite2pSegmentationInterface"]
+
+
+def custom_name_func(testcase_func, param_num, param):
+    return f"{testcase_func.__name__}_{param_num}_" f"_{param.kwargs.get('case_name', '')}"
+
+
+class TestConversionCombinations(unittest.TestCase):
+    parameterized_list = list()
+
+    param_case = param(
+        interfaces_to_combine=["TiffImagingInterface", "Suite2pSegmentationInterface"],
+        case_name="-".join(interfaces_to_combine).replace("Interface", ""),
+    )
+    parameterized_list.append(param_case)
+
+    param_case = param(
+        interfaces_to_combine=["Suite2pSegmentationInterface", "TiffImagingInterface"],
+        case_name="-".join(interfaces_to_combine),
+    )
+    parameterized_list.append(param_case)
+
+    @parameterized.expand(input=parameterized_list, name_func=custom_name_func)
+    def test_interface_combination(self, interfaces_to_combine, case_name=""):
+        class TestConverter(NWBConverter):
+            data_interface_classes = {
+                interface: interface_to_class_map[interface] for interface in interfaces_to_combine
+            }
+
+        source_data = {interface: interface_to_source_data_map[interface] for interface in interfaces_to_combine}
+        converter = TestConverter(source_data=source_data)
+        metadata = converter.get_metadata()
+        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
+
+        converter.validate_metadata(metadata=metadata)


### PR DESCRIPTION
This is a test for #537 that I think can serve as a general boilerplate for similar combinations.  Right now I have only written the test.

Edit: The issue is now fixed and the data is aligned.