### PR TITLE
Refactor of add_two_photon_series II

### DIFF
--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -143,7 +143,7 @@ def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=
     """
 
     if use_times:
-        warn("use times is deprecate and will be removed on or after August 1st, 2022.")
+        warn("Keyword argument 'use_times' is deprecate dand will be removed on or after August 1st, 2022.")
 
     metadata_copy = deepcopy(metadata)
     metadata_copy = dict_deep_update(get_nwb_imaging_metadata(imaging), metadata_copy)

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -79,7 +79,7 @@ def get_default_ophys_metadata():
 
 def get_nwb_imaging_metadata(imgextractor: ImagingExtractor):
     """
-    Convert metadata from the segmentation into nwb specific metadata.
+    Convert metadata from the ImagingExtractor into nwb specific metadata.
 
     Parameters
     ----------

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -267,7 +267,7 @@ def write_imaging(
         assert isinstance(nwbfile, NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
 
     if use_times:
-        warn("use times is deprecate and will be removed on or after August 1st, 2022")
+        warn("Keyword argument 'use_times' is deprecated and will be removed on or after August 1st, 2022.")
 
     # TODO on or after August 1st, 2022, remove argument and deprecation warnings
     if save_path is not None:

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -143,7 +143,7 @@ def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=
     """
 
     if use_times:
-        warn("Keyword argument 'use_times' is deprecate dand will be removed on or after August 1st, 2022.")
+        warn("Keyword argument 'use_times' is deprecated and will be removed on or after August 1st, 2022.")
 
     metadata_copy = deepcopy(metadata)
     metadata_copy = dict_deep_update(get_nwb_imaging_metadata(imaging), metadata_copy)

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -142,10 +142,8 @@ def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=
     Adds two photon series from imaging object as TwoPhotonSeries to nwbfile object.
     """
 
-
     if use_times:
         warn("use times is deprecate and will be removed on or after August 1st, 2022.")
-
 
     metadata_copy = deepcopy(metadata)
     metadata_copy = dict_deep_update(get_nwb_imaging_metadata(imaging), metadata_copy)

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -103,11 +103,7 @@ def get_nwb_imaging_metadata(imgextractor: ImagingExtractor):
                 )
             )
     # set imaging plane rate:
-    rate = (
-        np.float("NaN")
-        if imgextractor.get_sampling_frequency() is None
-        else float(imgextractor.get_sampling_frequency())
-    )
+    rate = np.nan if imgextractor.get_sampling_frequency() is None else float(imgextractor.get_sampling_frequency())
 
     # adding imaging_rate:
     metadata["Ophys"]["ImagingPlane"][0].update(imaging_rate=rate)
@@ -331,7 +327,7 @@ def get_nwb_segmentation_metadata(sgmextractor):
                 )
             )
     # set roi_response_series rate:
-    rate = np.float("NaN") if sgmextractor.get_sampling_frequency() is None else sgmextractor.get_sampling_frequency()
+    rate = np.nan if sgmextractor.get_sampling_frequency() is None else sgmextractor.get_sampling_frequency()
     for trace_name, trace_data in sgmextractor.get_traces_dict().items():
         if trace_name == "raw":
             if trace_data is not None:
@@ -518,7 +514,7 @@ def write_segmentation(
             description=f"region for Imaging plane{plane_no_loop}",
             region=list(range(segext_obj.get_num_rois())),
         )
-        rate = np.float("NaN") if segext_obj.get_sampling_frequency() is None else segext_obj.get_sampling_frequency()
+        rate = np.nan if segext_obj.get_sampling_frequency() is None else segext_obj.get_sampling_frequency()
         for i, j in roi_response_dict.items():
             data = getattr(segext_obj, f"_roi_response_{i}")
             if data is not None:

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -134,12 +134,16 @@ def add_devices(nwbfile: NWBFile, metadata: dict):
     return nwbfile
 
 
-def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10):
+def add_two_photon_series(imaging, nwbfile, metadata, buffer_size=10, use_times=False):
     """
     Auxiliary static method for nwbextractor.
 
     Adds two photon series from imaging object as TwoPhotonSeries to nwbfile object.
     """
+
+    if use_times:
+        warn("use times is deprecate and will be removed on or after August 1st, 2022.")
+
     metadata = dict_deep_update(get_nwb_imaging_metadata(imaging), metadata)
 
     # Tests if TwoPhotonSeries already exists in acquisition
@@ -224,6 +228,7 @@ def write_imaging(
     overwrite: bool = False,
     verbose: bool = True,
     buffer_size: int = 10,
+    use_times=False,
     save_path: OptionalFilePathType = None,  # TODO: to be removed
 ):
     """
@@ -257,6 +262,9 @@ def write_imaging(
     assert save_path is None or nwbfile is None, "Either pass a save_path location, or nwbfile object, but not both!"
     if nwbfile is not None:
         assert isinstance(nwbfile, NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
+
+    if use_times:
+        warn("use times is deprecate and will be removed on or after August 1st, 2022")
 
     # TODO on or after August 1st, 2022, remove argument and deprecation warnings
     if save_path is not None:

--- a/src/nwb_conversion_tools/utils/checks.py
+++ b/src/nwb_conversion_tools/utils/checks.py
@@ -10,5 +10,5 @@ def calculate_regular_series_rate(series: np.ndarray, tolerance_decimals: int = 
     rate is a scalar otherwise it is None."""
     diff_ts = np.diff(series).round(decimals=tolerance_decimals)
     uniq_diff_ts = np.unique(diff_ts)
-    rate = diff_ts[0] if len(uniq_diff_ts) == 1 else None
+    rate = 1.0 / diff_ts[0] if len(uniq_diff_ts) == 1 else None
     return rate

--- a/tests/test_internals/test_movie_interface.py
+++ b/tests/test_internals/test_movie_interface.py
@@ -247,7 +247,7 @@ class TestMovieInterface(TestCase):
             Movie=dict(starting_times=self.starting_times, timestamps=timestamps, external_mode=True)
         )
 
-        rate = np.round(timestamps[1] - timestamps[0], 9)
+        rate = 1.0 / np.round(timestamps[1] - timestamps[0], 9)
         fps = 25.0
         expected_warn_msg = (
             f"The fps={fps} from movie data is unequal to the difference in "


### PR DESCRIPTION
Small PR that is a continuation of #536 

The biggest change is the removal of `use_times` and handles this logic to`roiextractors` in the same way that we did with `spikeinterface`. 

Also, the definition of `calculate_regular_series_rate` is changed. The one in main is not calculating the rate but the period of the signal.