### PR TITLE
Unit test `roiextractors.py` module `add device`

### DIFF
--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -2,7 +2,6 @@
 import os
 from pathlib import Path
 from warnings import warn
-from collections import abc
 from typing import Optional
 from copy import deepcopy
 
@@ -13,6 +12,7 @@ from pynwb import NWBFile, NWBHDF5IO
 from pynwb.base import Images
 from pynwb.file import Subject
 from pynwb.image import GrayscaleImage
+from pynwb.device import Device
 from pynwb.ophys import (
     ImageSegmentation,
     Fluorescence,
@@ -122,7 +122,7 @@ def get_nwb_imaging_metadata(imgextractor: ImagingExtractor):
     return metadata
 
 
-def add_devices(nwbfile: NWBFile, metadata: dict):
+def add_devices(nwbfile: NWBFile, metadata: dict) -> NWBFile:
     """Add optical physiology devices from metadata."""
     metadata_copy = deepcopy(metadata)
     default_metadata = get_default_ophys_metadata()
@@ -130,8 +130,9 @@ def add_devices(nwbfile: NWBFile, metadata: dict):
     device_metadata = metadata_copy["Ophys"]["Device"]
 
     for device in device_metadata:
-        if "name" in device and device["name"] not in nwbfile.devices:
-            nwbfile.create_device(**device)
+        device = Device(**device) if isinstance(device, dict) else device
+        if device.name not in nwbfile.devices:
+            nwbfile.add_device(device)
 
     return nwbfile
 

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -124,10 +124,15 @@ def get_nwb_imaging_metadata(imgextractor: ImagingExtractor):
 
 def add_devices(nwbfile: NWBFile, metadata: dict):
     """Add optical physiology devices from metadata."""
-    metadata = dict_deep_update(get_default_ophys_metadata(), metadata)
-    for device in metadata.get("Ophys", dict()).get("Device", dict()):
+    metadata_copy = deepcopy(metadata)
+    default_metadata = get_default_ophys_metadata()
+    metadata_copy = dict_deep_update(default_metadata, metadata_copy, append_list=False)
+    device_metadata = metadata_copy["Ophys"]["Device"]
+
+    for device in device_metadata:
         if "name" in device and device["name"] not in nwbfile.devices:
             nwbfile.create_device(**device)
+
     return nwbfile
 
 

--- a/tests/test_internals/test_roi_extractors_module.py
+++ b/tests/test_internals/test_roi_extractors_module.py
@@ -5,13 +5,15 @@ from datetime import datetime
 import numpy as np
 
 from pynwb import NWBFile
+from pynwb.device import Device
+
 
 from nwb_conversion_tools.tools.roiextractors import add_devices
 
 
 class TestAddDevices(unittest.TestCase):
     def setUp(self):
-        self.session_start_time = datetime.now()
+        self.session_start_time = datetime.now().astimezone()
         self.nwbfile = NWBFile(
             session_description="session_description",
             identifier="file_id",

--- a/tests/test_internals/test_roi_extractors_module.py
+++ b/tests/test_internals/test_roi_extractors_module.py
@@ -113,3 +113,30 @@ class TestAddDevices(unittest.TestCase):
         devices = self.nwbfile.devices
 
         assert len(devices) == 0
+
+    def test_device_object(self):
+
+        device_name = "device_object"
+        device_object = Device(name=device_name)
+        device_list = [device_object]
+        self.metadata["Ophys"].update(Device=device_list)
+        add_devices(self.nwbfile, metadata=self.metadata)
+
+        devices = self.nwbfile.devices
+
+        assert len(devices) == 1
+        assert device_name in devices
+
+    def test_device_object_and_metadata_mix(self):
+
+        device_object = Device(name="device_object")
+        device_metadata = dict(name="device_metadata")
+        device_list = [device_object, device_metadata]
+        self.metadata["Ophys"].update(Device=device_list)
+        add_devices(self.nwbfile, metadata=self.metadata)
+
+        devices = self.nwbfile.devices
+
+        assert len(devices) == 2
+        assert "device_metadata" in devices
+        assert "device_object" in devices

--- a/tests/test_internals/test_roi_extractors_module.py
+++ b/tests/test_internals/test_roi_extractors_module.py
@@ -58,7 +58,7 @@ class TestAddDevices(unittest.TestCase):
 
         devices = self.nwbfile.devices
 
-        assert len(devices) == 1
+        assert len(devices) == 2
         assert all(device_name in devices for device_name in device_name_list)
 
     def test_add_one_device_and_then_another(self):
@@ -111,5 +111,4 @@ class TestAddDevices(unittest.TestCase):
 
         devices = self.nwbfile.devices
 
-        assert len(devices) == 1
-        assert "Microscope" in devices
+        assert len(devices) == 0

--- a/tests/test_internals/test_roi_extractors_module.py
+++ b/tests/test_internals/test_roi_extractors_module.py
@@ -1,0 +1,115 @@
+import unittest
+from pathlib import Path
+from datetime import datetime
+
+import numpy as np
+
+from pynwb import NWBFile
+from roiextractors.testing import generate_dummy_imaging_extractor
+
+from nwb_conversion_tools.tools.roiextractors import add_devices
+
+
+class TestAddDevices(unittest.TestCase):
+    def setUp(self):
+        self.session_start_time = datetime.now()
+        self.nwbfile = NWBFile(
+            session_description="session_description",
+            identifier="file_id",
+            session_start_time=self.session_start_time,
+        )
+
+        self.metadata = dict(Ophys=dict())
+
+    def test_add_device(self):
+        device_name = "new_device"
+        device_list = [dict(name=device_name)]
+        self.metadata["Ophys"].update(Device=device_list)
+        add_devices(self.nwbfile, metadata=self.metadata)
+
+        devices = self.nwbfile.devices
+
+        assert len(devices) == 1
+        assert device_name in devices
+
+    def test_add_device_with_further_metadata(self):
+
+        device_name = "new_device"
+        description = "device_description"
+        manufacturer = "manufactuer"
+
+        device_list = [dict(name=device_name, description=description, manufacturer=manufacturer)]
+        self.metadata["Ophys"].update(Device=device_list)
+        add_devices(self.nwbfile, metadata=self.metadata)
+
+        devices = self.nwbfile.devices
+        device = devices["new_device"]
+
+        assert len(devices) == 1
+        assert device.name == device_name
+        assert device.description == description
+        assert device.manufacturer == manufacturer
+
+    def test_add_two_devices(self):
+        device_name_list = ["device1", "device2"]
+        device_list = [dict(name=device_name) for device_name in device_name_list]
+        self.metadata["Ophys"].update(Device=device_list)
+        add_devices(self.nwbfile, metadata=self.metadata)
+
+        devices = self.nwbfile.devices
+
+        assert len(devices) == 1
+        assert all(device_name in devices for device_name in device_name_list)
+
+    def test_add_one_device_and_then_another(self):
+        device_name1 = "new_device"
+        device_list = [dict(name=device_name1)]
+        self.metadata["Ophys"].update(Device=device_list)
+        add_devices(self.nwbfile, metadata=self.metadata)
+
+        device_name2 = "another_device"
+        device_list = [dict(name=device_name2)]
+        self.metadata["Ophys"].update(Device=device_list)
+        add_devices(self.nwbfile, metadata=self.metadata)
+
+        devices = self.nwbfile.devices
+
+        assert len(devices) == 2
+        assert device_name1 in devices
+        assert device_name2 in devices
+
+    def test_not_overwriting_devices(self):
+        device_name1 = "same_device"
+        device_list = [dict(name=device_name1)]
+        self.metadata["Ophys"].update(Device=device_list)
+        add_devices(self.nwbfile, metadata=self.metadata)
+
+        device_name2 = "same_device"
+        device_list = [dict(name=device_name2)]
+        self.metadata["Ophys"].update(Device=device_list)
+        add_devices(self.nwbfile, metadata=self.metadata)
+
+        devices = self.nwbfile.devices
+
+        assert len(devices) == 1
+        assert device_name1 in devices
+
+    def test_add_device_defaults(self):
+
+        add_devices(self.nwbfile, metadata=self.metadata)
+
+        devices = self.nwbfile.devices
+
+        assert len(devices) == 1
+        assert "Microscope" in devices
+
+    def test_add_empty_device_list_in_metadata(self):
+
+        device_list = []
+        self.metadata["Ophys"].update(Device=device_list)
+        add_devices(self.nwbfile, metadata=self.metadata)
+
+        devices = self.nwbfile.devices
+
+        assert len(devices) == 1
+        assert "Microscope" in devices

--- a/tests/test_internals/test_roi_extractors_module.py
+++ b/tests/test_internals/test_roi_extractors_module.py
@@ -5,7 +5,6 @@ from datetime import datetime
 import numpy as np
 
 from pynwb import NWBFile
-from roiextractors.testing import generate_dummy_imaging_extractor
 
 from nwb_conversion_tools.tools.roiextractors import add_devices
 


### PR DESCRIPTION

During the current conversion (Seidemann) I am getting duplicated device metadata where specifying the actual metadata for ophys does not overwrite the defaults. This PR has two goals:
1) Add unit tests for `add_devices` in `roieextractors` 
2) Modify the function in such a way that if metadata for ophys / device is passed the defaults are not included.

