### PR TITLE
Unit test `add_two_photon_series` in the `roiextractors.py` module  

### DIFF
--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -14,9 +14,9 @@ psutil==5.8.0
 lxml==4.6.5
 opencv-python==4.5.1.48
 spikeextractors==0.9.9
-spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@12b7863684b705e3d0ae8165bb3009143c70530c
+spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@261c5f94359ce5631f2d8f19bac923ceeffb63c7
 neo==0.10.2
-roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@aff061efe00cb0f64f8b34e039adf24cf05259d6
+roiextractors @ git+https://github.com/catalystneuro/roiextractors.git
 pyintan==0.3.0
 pyopenephys==1.1.2
 sonpy>=1.7.1

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -14,7 +14,8 @@ psutil==5.8.0
 lxml==4.6.5
 opencv-python==4.5.1.48
 spikeextractors==0.9.9
-spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@261c5f94359ce5631f2d8f19bac923ceeffb63c7
+spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@12b7863684b705e3d0ae8165bb3009143c70530c
+spikeinterface @ 
 neo==0.10.2
 roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@fix_nwb_extractor_frames
 pyintan==0.3.0

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -15,7 +15,6 @@ lxml==4.6.5
 opencv-python==4.5.1.48
 spikeextractors==0.9.9
 spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@12b7863684b705e3d0ae8165bb3009143c70530c
-spikeinterface @
 neo==0.10.2
 roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@fix_nwb_extractor_frames
 pyintan==0.3.0

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -16,7 +16,7 @@ opencv-python==4.5.1.48
 spikeextractors==0.9.9
 spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@261c5f94359ce5631f2d8f19bac923ceeffb63c7
 neo==0.10.2
-roiextractors @ git+https://github.com/catalystneuro/roiextractors.git
+roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@fix_nwb_extractor_frames
 pyintan==0.3.0
 pyopenephys==1.1.2
 sonpy>=1.7.1

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -15,7 +15,7 @@ lxml==4.6.5
 opencv-python==4.5.1.48
 spikeextractors==0.9.9
 spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@12b7863684b705e3d0ae8165bb3009143c70530c
-spikeinterface @ 
+spikeinterface @
 neo==0.10.2
 roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@fix_nwb_extractor_frames
 pyintan==0.3.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -11,6 +11,6 @@ dandi==0.39.6  # 0.39.5 already uses schema v0.7.x
 spikeextractors>=0.9.9
 spikeinterface>=0.93.0
 neo>=0.9.0
-spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@261c5f94359ce5631f2d8f19bac923ceeffb63c7
+roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@fix_nwb_extractor_frames
 lxml>=4.6.5
 scipy>=1.4.1

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -11,6 +11,6 @@ dandi==0.39.6  # 0.39.5 already uses schema v0.7.x
 spikeextractors>=0.9.9
 spikeinterface>=0.93.0
 neo>=0.9.0
-roiextractors>=0.4.1
+spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@261c5f94359ce5631f2d8f19bac923ceeffb63c7
 lxml>=4.6.5
 scipy>=1.4.1

--- a/src/nwb_conversion_tools/utils/checks.py
+++ b/src/nwb_conversion_tools/utils/checks.py
@@ -4,7 +4,7 @@ from typing import Optional
 import numpy as np
 
 
-def calculate_regular_series_rate(series: np.ndarray, tolerance_decimals: int = 9) -> Optional[Real]:
+def calculate_regular_series_rate(series: np.ndarray, tolerance_decimals: int = 6) -> Optional[Real]:
     """Calculates the rate of a series as the difference between all consecutive points.
     If the difference between all time points are all the same value, then the value of
     rate is a scalar otherwise it is None."""

--- a/tests/test_internals/test_roi_extractors_module.py
+++ b/tests/test_internals/test_roi_extractors_module.py
@@ -1,14 +1,15 @@
+from tempfile import mkdtemp
 import unittest
 from pathlib import Path
 from datetime import datetime
 
 import numpy as np
 
-from pynwb import NWBFile
+from pynwb import NWBFile, NWBHDF5IO
 from pynwb.device import Device
+from roiextractors.testing import generate_dummy_imaging_extractor
 
-
-from nwb_conversion_tools.tools.roiextractors import add_devices
+from nwb_conversion_tools.tools.roiextractors import add_devices, add_two_photon_series
 
 
 class TestAddDevices(unittest.TestCase):
@@ -140,3 +141,106 @@ class TestAddDevices(unittest.TestCase):
         assert len(devices) == 2
         assert "device_metadata" in devices
         assert "device_object" in devices
+
+
+class TestAddTwoPhotonSeries(unittest.TestCase):
+    def setUp(self):
+        self.session_start_time = datetime.now().astimezone()
+        self.nwbfile = NWBFile(
+            session_description="session_description",
+            identifier="file_id",
+            session_start_time=self.session_start_time,
+        )
+        self.metadata = dict(Ophys=dict())
+
+        self.device_name = "optical_device"
+        self.device_metadata = dict(name=self.device_name)
+        self.metadata["Ophys"].update(Device=[self.device_metadata])
+
+        self.optical_channel_metadata = dict(
+            name="optical_channel",
+            emission_lambda=np.nan,
+            description="description",
+        )
+
+        self.imaging_plane_name = "imaging_plane_name"
+        self.imaging_plane_metadata = dict(
+            name=self.imaging_plane_name,
+            optical_channel=[self.optical_channel_metadata],
+            description="image_plane_description",
+            device=self.device_name,
+            excitation_lambda=np.nan,
+            indicator="unknown",
+            location="unknown",
+        )
+
+        self.metadata["Ophys"].update(ImagingPlane=[self.imaging_plane_metadata])
+
+        self.two_photon_series_name = "two_photon_series_name"
+        self.two_photon_series_metadata = dict(
+            name=self.two_photon_series_name, imaging_plane=self.imaging_plane_name, unit="unknown"
+        )
+        self.metadata["Ophys"].update(TwoPhotonSeries=[self.two_photon_series_metadata])
+
+        self.num_frames = 30
+        self.rows = 10
+        self.columns = 15
+        self.imaging_extractor = generate_dummy_imaging_extractor(self.num_frames, rows=self.rows, columns=self.columns)
+
+    def test_add_two_photon_series(self):
+
+        metadata = self.metadata
+
+        add_two_photon_series(imaging=self.imaging_extractor, nwbfile=self.nwbfile, metadata=metadata)
+
+        # Check data
+        acquisition_modules = self.nwbfile.acquisition
+        self.two_photon_series_name in acquisition_modules
+        data_in_hdfm_data_io = acquisition_modules[self.two_photon_series_name].data
+        data_chunk_iterator = data_in_hdfm_data_io.data
+        two_photon_series_extracted = np.concatenate([data_chunk.data for data_chunk in data_chunk_iterator])
+        assert two_photon_series_extracted.shape == (self.num_frames, self.rows, self.columns)
+
+        # Check device
+        devices = self.nwbfile.devices
+        assert self.device_name in devices
+        assert len(devices) == 1
+
+        # Check imaging planes
+        imaging_planes_in_file = self.nwbfile.imaging_planes
+        assert self.imaging_plane_name in imaging_planes_in_file
+        assert len(imaging_planes_in_file) == 1
+
+    def test_add_two_photon_series_roundtrip(self):
+
+        metadata = self.metadata
+
+        add_two_photon_series(imaging=self.imaging_extractor, nwbfile=self.nwbfile, metadata=metadata)
+
+        # Write the data to disk
+        nwbfile_path = Path(mkdtemp()) / "two_photon_roundtrip.nwb"
+        with NWBHDF5IO(nwbfile_path, "w") as io:
+            io.write(self.nwbfile)
+
+        with NWBHDF5IO(nwbfile_path, "r") as io:
+            read_nwbfile = io.read()
+
+            # Check data
+            acquisition_modules = read_nwbfile.acquisition
+            self.two_photon_series_name in acquisition_modules
+            two_photon_series = acquisition_modules[self.two_photon_series_name].data
+            assert two_photon_series.shape == (self.num_frames, self.rows, self.columns)
+
+            # Check device
+            devices = read_nwbfile.devices
+            assert self.device_name in devices
+            assert len(devices) == 1
+
+            # Check imaging planes
+            imaging_planes_in_file = read_nwbfile.imaging_planes
+            assert self.imaging_plane_name in imaging_planes_in_file
+            assert len(imaging_planes_in_file) == 1
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
During the current conversion (Seidemann) I am getting duplicated device metadata where specifying the actual metadata for ophys does not overwrite the defaults. This is a follow up of #543 where I corrected the same for `add_device` and this is the analgous for `add_two_photon_series`:

Add unit tests for  `add_two_photon_series` in roieextractors
Modify the function in such a way that the metadata for ophys / device is passed the defaults are not included.

EDIT: This is doing the same change as #547 as well.