### PR TITLE
Add spikeinterface support to intan

### DIFF
--- a/src/nwb_conversion_tools/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/intan/intandatainterface.py
@@ -1,7 +1,10 @@
-"""Authors: Cody Baker and Ben Dichter."""
+"""Authors: Heberto Mayorquin, Cody Baker and Ben Dichter."""
 from pathlib import Path
+from typing import Optional
 
 from spikeinterface.core.old_api_utils import OldToNewRecording
+from spikeinterface import BaseRecording
+from spikeinterface.extractors import IntanRecordingExtractor
 
 import spikeextractors as se
 from pynwb.ecephys import ElectricalSeries
@@ -15,7 +18,7 @@ try:
     HAVE_PYINTAN = True
 except ImportError:
     HAVE_PYINTAN = False
-INSTALL_MESSAGE = "Please install pyintan to use this extractor!"
+INSTALL_MESSAGE = "Please install pyintan (https://pypi.org/project/pyintan/) to use this extractor!"
 
 
 def extract_electrode_metadata_with_pyintan(file_path):
@@ -45,17 +48,48 @@ def extract_electrode_metadata_with_pyintan(file_path):
     return electrodes_metadata
 
 
+def extract_electrode_metadata(recording_extractor: BaseRecording):
+
+    channel_name_array = recording_extractor.get_property("channel_name")
+
+    group_names = [channel.split("-")[0] for channel in channel_name_array]
+    unique_group_names = set(group_names)
+    group_electrode_numbers = [int(channel.split("-")[1]) for channel in channel_name_array]
+    custom_names = list()
+
+    electrodes_metadata = dict(
+        group_names=group_names,
+        unique_group_names=unique_group_names,
+        group_electrode_numbers=group_electrode_numbers,
+        custom_names=custom_names,
+    )
+
+    return electrodes_metadata
+
+
 class IntanRecordingInterface(BaseRecordingExtractorInterface):
     """Primary data interface class for converting a IntanRecordingExtractor."""
 
-    RX = se.IntanRecordingExtractor
+    RX = IntanRecordingExtractor
 
-    def __init__(self, file_path: FilePathType, verbose: bool = True):
-        assert HAVE_PYINTAN, INSTALL_MESSAGE
-        super().__init__(file_path=file_path, verbose=verbose)
+    def __init__(
+        self,
+        file_path: FilePathType,
+        stream_id: Optional[str] = "0",
+        spikeextractors_backend: Optional[bool] = False,
+        verbose: Optional[bool] = True,
+    ):
 
-        electrodes_metadata = extract_electrode_metadata_with_pyintan(file_path)
-        self.recording_extractor = OldToNewRecording(oldapi_recording_extractor=self.recording_extractor)
+        if spikeextractors_backend:
+            assert HAVE_PYINTAN, INSTALL_MESSAGE
+            self.RX = se.IntanRecordingExtractor
+            super().__init__(file_path=file_path, verbose=verbose)
+            self.recording_extractor = OldToNewRecording(oldapi_recording_extractor=self.recording_extractor)
+            electrodes_metadata = extract_electrode_metadata_with_pyintan(file_path)
+        else:
+            self.stream_id = stream_id
+            super().__init__(file_path=file_path, stream_id=self.stream_id, verbose=verbose)
+            electrodes_metadata = extract_electrode_metadata(recording_extractor=self.recording_extractor)
 
         group_names = electrodes_metadata["group_names"]
         group_electrode_numbers = electrodes_metadata["group_electrode_numbers"]

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -1,6 +1,7 @@
 import unittest
 from pathlib import Path
 from datetime import datetime
+import itertools
 
 import numpy as np
 import numpy.testing as npt
@@ -111,12 +112,15 @@ class TestEcephysNwbConversions(unittest.TestCase):
         ),
     ]
 
-    for suffix in ["rhd", "rhs"]:
+    for suffix, spikeextractors_backend in itertools.product(["rhd", "rhs"], [True, False]):
         parameterized_recording_list.append(
             param(
                 data_interface=IntanRecordingInterface,
-                interface_kwargs=dict(file_path=str(DATA_PATH / "intan" / f"intan_{suffix}_test_1.{suffix}")),
-                case_name=suffix,
+                interface_kwargs=dict(
+                    file_path=str(DATA_PATH / "intan" / f"intan_{suffix}_test_1.{suffix}"),
+                    spikeextractors_backend=spikeextractors_backend,
+                ),
+                case_name=f"{suffix}, spikeextractors_backend={spikeextractors_backend}",
             )
         )
     for file_name, num_channels in zip(["20210225_em8_minirec2_ac", "W122_06_09_2019_1_fromSD"], [512, 128]):


### PR DESCRIPTION
Adding `spikeinterface` support to `IntanRecordingInterface`. This should be done after #558 
 