### PR TITLE
Remove optional types in pphy sorting data interface

### DIFF
--- a/src/nwb_conversion_tools/datainterfaces/ecephys/phy/phydatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/phy/phydatainterface.py
@@ -17,8 +17,8 @@ class PhySortingInterface(BaseSortingExtractorInterface):
         self,
         folder_path: FolderPathType,
         exclude_cluster_groups: Optional[list] = None,
-        verbose: Optional[bool] = True,
-        spikeextractors_backend: Optional[bool] = False,
+        verbose: bool = True,
+        spikeextractors_backend: bool = False,
     ):
         if spikeextractors_backend:
             self.SX = se.PhySortingExtractor


### PR DESCRIPTION
By mistake I added Optional typing to some parameters that can't be None. This PR should address this by removing it. 