### PR TITLE
Add spikeinterface support for `NeuroscopeSortingInterface`

### DIFF
--- a/src/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -279,6 +279,7 @@ class NeuroscopeSortingInterface(BaseSortingExtractorInterface):
         exclude_shanks: Optional[list] = None,
         xml_file_path: OptionalFilePathType = None,
         verbose: bool = True,
+        spikeextractors_backend: bool = False,
         # TODO: we can enable this once
         #     a) waveforms on unit columns support conversion factor in NWB
         #     b) write_sorting utils support writing said waveforms properly to a units table

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -1,13 +1,13 @@
 """Authors: Cody Baker and Ben Dichter."""
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import spikeextractors as se
 from spikeinterface.core.old_api_utils import OldToNewRecording
 from pynwb.ecephys import ElectricalSeries
 
 from spikeinterface import BaseRecording
-from spikeinterface.extractors import NeuroScopeRecordingExtractor
+from spikeinterface.extractors import NeuroScopeRecordingExtractor, NeuroScopeSortingExtractor
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..baselfpextractorinterface import BaseLFPExtractorInterface
@@ -270,7 +270,7 @@ class NeuroscopeLFPInterface(BaseLFPExtractorInterface):
 class NeuroscopeSortingInterface(BaseSortingExtractorInterface):
     """Primary data interface class for converting a NeuroscopeSortingExtractor."""
 
-    SX = se.NeuroscopeMultiSortingExtractor
+    SX = NeuroScopeSortingExtractor
 
     def __init__(
         self,
@@ -314,8 +314,13 @@ class NeuroscopeSortingInterface(BaseSortingExtractorInterface):
             Most common value is 0.195 for an intan recording system.
             The default is None.
             Not currently in use pending updates to NWB waveforms.
+        spikeextractors_backend : Optional[bool], optional
+            False by default. When True the interface uses the old extractor from the spikextractors library instead
+            of a new spikeinterface object.
         """
         assert HAVE_LXML, INSTALL_MESSAGE
+        if spikeextractors_backend:
+            self.SX = se.NeuroscopeMultiSortingExtractor
 
         super().__init__(
             folder_path=folder_path,

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -265,13 +265,6 @@ class TestEcephysNwbConversions(unittest.TestCase):
                 )
             ),
         ),
-        param(
-            data_interface=NeuroscopeSortingInterface,
-            interface_kwargs=dict(
-                folder_path=str(DATA_PATH / "neuroscope" / "dataset_1"),
-                xml_file_path=str(DATA_PATH / "neuroscope" / "dataset_1" / "YutaMouse42-151117.xml"),
-            ),
-        ),
     ]
 
     for spikeextractors_backend in [False, True]:

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -277,6 +277,18 @@ class TestEcephysNwbConversions(unittest.TestCase):
     for spikeextractors_backend in [False, True]:
         parameterized_sorting_list.append(
             param(
+                data_interface=NeuroscopeSortingInterface,
+                interface_kwargs=dict(
+                    folder_path=str(DATA_PATH / "neuroscope" / "dataset_1"),
+                    xml_file_path=str(DATA_PATH / "neuroscope" / "dataset_1" / "YutaMouse42-151117.xml"),
+                    spikeextractors_backend=spikeextractors_backend,
+                ),
+                case_name=f"spikeextractors_backend={spikeextractors_backend}",
+            )
+        )
+
+        parameterized_sorting_list.append(
+            param(
                 data_interface=PhySortingInterface,
                 interface_kwargs=dict(
                     folder_path=str(DATA_PATH / "phy" / "phy_example_0"),


### PR DESCRIPTION
As stated in the title. Linked to https://github.com/catalystneuro/nwb-conversion-tools/issues/500.