### PR TITLE
Add spikeinterface support and  and gin test for `CEDRecordingInterface`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -82,6 +82,8 @@ jobs:
           datalad get -r ./blackrock/
           datalad get -r ./intan/
           datalad get -r ./spikegadgets/
+          datalad get -r ./spike2/130322-1LY.smr
+          datalad get -r ./spike2/m365_1sec.smrx
           datalad get -r ./spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/
           datalad get -r ./spikeglx/TEST_20210920_0_g0/
           datalad get -r ./phy/phy_example_0/

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/ced/ceddatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/ced/ceddatainterface.py
@@ -1,9 +1,10 @@
-"""Authors: Luiz Tauffer."""
+"""Authors: Heberto Mayorquin, Luiz Tauffer."""
+from pathlib import Path
 from platform import python_version
 from sys import platform
 from packaging import version
 
-from spikeextractors import CEDRecordingExtractor
+from spikeinterface.extractors import CedRecordingExtractor
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....utils import get_schema_from_method_signature, FilePathType
@@ -20,9 +21,10 @@ if platform == "darwin" and version.parse(python_version()) < version.parse("3.8
 
 
 class CEDRecordingInterface(BaseRecordingExtractorInterface):
-    """Primary data interface class for converting a CEDRecordingExtractor."""
+    """Primary data interface class for converting data from CED (Cambridge Electronic Design)
+    ."""
 
-    RX = CEDRecordingExtractor
+    RX = CedRecordingExtractor
 
     @classmethod
     def get_source_schema(cls):
@@ -37,6 +39,9 @@ class CEDRecordingInterface(BaseRecordingExtractorInterface):
         assert HAVE_SONPY, INSTALL_MESSAGE
         return cls.RX.get_all_channels_info(file_path=file_path)
 
-    def __init__(self, file_path: FilePathType, smrx_channel_ids: list, verbose: bool = True):
+    def __init__(self, file_path: FilePathType, verbose: bool = True):
         assert HAVE_SONPY, INSTALL_MESSAGE
-        super().__init__(file_path=file_path, smrx_channel_ids=smrx_channel_ids, verbose=verbose)
+        stream_id = None
+        if Path(file_path).suffix == ".smr":
+            stream_id = "1"
+        super().__init__(file_path=file_path, stream_id=stream_id, verbose=verbose)

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -21,6 +21,7 @@ from pynwb import NWBHDF5IO
 from nwb_conversion_tools import (
     NWBConverter,
     CellExplorerSortingInterface,
+    CEDRecordingInterface,
     IntanRecordingInterface,
     NeuralynxRecordingInterface,
     NeuroscopeRecordingInterface,
@@ -105,6 +106,10 @@ class TestEcephysNwbConversions(unittest.TestCase):
         param(
             data_interface=AxonaRecordingExtractorInterface,
             interface_kwargs=dict(file_path=str(DATA_PATH / "axona" / "axona_raw.bin")),
+        ),
+        param(
+            data_interface=CEDRecordingInterface,
+            interface_kwargs=dict(file_path=str(DATA_PATH / "spike2" / "130322-1LY.smr")),
         ),
     ]
 

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -109,6 +109,10 @@ class TestEcephysNwbConversions(unittest.TestCase):
         ),
         param(
             data_interface=CEDRecordingInterface,
+            interface_kwargs=dict(file_path=str(DATA_PATH / "spike2" / "130322-1LY.smr")),
+        ),
+        param(
+            data_interface=CEDRecordingInterface,
             interface_kwargs=dict(file_path=str(DATA_PATH / "spike2" / "m365_1sec.smrx")),
         ),
     ]

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -109,10 +109,6 @@ class TestEcephysNwbConversions(unittest.TestCase):
         ),
         param(
             data_interface=CEDRecordingInterface,
-            interface_kwargs=dict(file_path=str(DATA_PATH / "spike2" / "130322-1LY.smr")),
-        ),
-        param(
-            data_interface=CEDRecordingInterface,
             interface_kwargs=dict(file_path=str(DATA_PATH / "spike2" / "m365_1sec.smrx")),
         ),
     ]

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -111,8 +111,11 @@ class TestEcephysNwbConversions(unittest.TestCase):
             data_interface=CEDRecordingInterface,
             interface_kwargs=dict(file_path=str(DATA_PATH / "spike2" / "130322-1LY.smr")),
         ),
+        param(
+            data_interface=CEDRecordingInterface,
+            interface_kwargs=dict(file_path=str(DATA_PATH / "spike2" / "m365_1sec.smrx")),
+        ),
     ]
-
     for spikeextractors_backend in [True, False]:
         parameterized_recording_list.append(
             param(


### PR DESCRIPTION
Add spikeinterface support to `CEDRecordingInterface`. Part of #500

As discussed with @bendichter  today,  this did not have an associated gin test with `spikeextractors` so I am only adding `spikeinterface` support as it is.

I also had a problem running the old format (`.smr`) tests in my own system but spikeinterface testing suite indicates that it should be supported. I am adding it here to see if it is a problem of local dependencies exclusive to me. If not, then probably we will have to support only the new format ("smrx") for a while until we figure this out.