### PR TITLE
Scan image interface to use proper roiextractor

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,6 +53,7 @@ jobs:
           pip install pytest-xdist
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
+          pip instal wheel # Needed for scan image
       - name: Install nwb-conversion-tools with minimal requirements
         run: pip install .[test]
       - name: Run minimal tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
           pip install pytest-xdist
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
-          pip instal wheel # Needed for scan image
+          pip install wheel # Needed for scan image
       - name: Install nwb-conversion-tools with minimal requirements
         run: pip install .[test]
       - name: Run minimal tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Global Setup
         run: |
-          pip install -U pip
+          python -m pip install -U pip  # Official recommended way
           pip install pytest-xdist
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -24,3 +24,4 @@ tiffile==2018.10.18
 ndx-dandi-icephys>=0.4.0
 pillow==9.1.1
 pyopenephys==1.1.2
+scanimage-tiff-reader==1.4.1

--- a/src/nwb_conversion_tools/datainterfaces/ophys/scanimage/scanimageimaginginterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ophys/scanimage/scanimageimaginginterface.py
@@ -24,18 +24,6 @@ def extract_extra_metadata(file_path):
     return extra_metadata
 
 
-from PIL import Image, ExifTags
-
-
-def extract_extra_metadata2(file_path):
-    image = Image.open(file_path)
-    image_exif = image.getexif()
-    exif = {ExifTags.TAGS[k]: v for k, v in image_exif.items() if k in ExifTags.TAGS and type(v) is not bytes}
-    extra_metadata = {x.split("=")[0]: x.split("=")[1] for x in exif["ImageDescription"].split("\r") if "=" in x}
-
-    return extra_metadata
-
-
 class ScanImageImagingInterface(BaseImagingExtractorInterface):
 
     IX = ScanImageTiffImagingExtractor


### PR DESCRIPTION
Updating the `ScanImageImagingInterface` extractor to use `ScanImageTiffImagingExtractor` from roiextractors instead of `TiffImagingExtractor`.