### PR TITLE
Update spikeextractors version to latest

### DIFF
--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -13,7 +13,7 @@ jsonschema==3.2.0
 psutil==5.8.0
 lxml==4.6.5
 opencv-python==4.5.1.48
-spikeextractors==0.9.9
+spikeextractors==0.9.10
 spikeinterface @ git+https://github.com/Spikeinterface/spikeinterface.git@d26f991ca05c3af2fec2b4fbce8004ca9e9cd9f1
 neo==0.10.2
 roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@1d50cbeb15c317eecca73f4dcb16bca1bb1ff9f6

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -8,7 +8,7 @@ PyYAML>=5.4
 jsonschema>=3.2.0
 psutil>=5.8.0
 dandi==0.39.6  # 0.39.5 already uses schema v0.7.x
-spikeextractors>=0.9.9
+spikeextractors>=0.9.10
 spikeinterface>=0.93.0
 neo>=0.9.0
 roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@1d50cbeb15c317eecca73f4dcb16bca1bb1ff9f6


### PR DESCRIPTION
This should eliminate all the deprecation warnings. This should close #486