### PR TITLE
[neuralynx] Exploit metadata exposed from neo neuralynxrawio 

### DIFF
--- a/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -59,7 +59,6 @@ def get_common_metadata(extractors: list[NeuralynxRecordingExtractor]) -> dict:
     if hasattr(start_time, "__iter__") and len(start_time) == 1:
         common_header["session_start_time"] = common_header["session_start_time"][0]
 
-
     # convert version objects back to string
     if common_header.get("ApplicationVersion", None) is not None:
         common_header["ApplicationVersion"] = str(common_header["ApplicationVersion"])

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -59,12 +59,6 @@ def get_common_metadata(extractors: list[NeuralynxRecordingExtractor]) -> dict:
     if hasattr(start_time, "__iter__") and len(start_time) == 1:
         common_header["session_start_time"] = common_header["session_start_time"][0]
 
-    # remove stop time metadata if not provided as None is an invalid default value
-    stop_time = common_header.get("session_stop_time", None)
-    if stop_time is None:
-        common_header.pop("session_stop_time")
-    elif hasattr(stop_time, "__iter__") and len(stop_time) == 1:
-        common_header["session_stop_time"] = common_header["session_stop_time"][0]
 
     # convert version objects back to string
     if common_header.get("ApplicationVersion", None) is not None:

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -45,10 +45,6 @@ def get_common_metadata(extractors: typing.List[NeuralynxRecordingExtractor]) ->
         annotations = signal_info["__array_annotations__"]
         common_header = {k: annotations.get(k, None) for k in key_mapping}
 
-        # # extraction of general metadata and remapping of of keys to nwb terms
-        # general_metadata['session_start_time'] = annotations['recording_opened']
-        # general_metadata['session_id'] = annotations.get('SessionUUID', '')
-
     # mapping to nwb terms
     for neuralynx_key, nwb_key in key_mapping.items():
         common_header.setdefault(nwb_key, common_header.pop(neuralynx_key, None))

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -1,12 +1,11 @@
 """Authors: Heberto Mayorquin, Cody Baker, Ben Dichter and Julia Sprenger"""
-import warnings
 from pathlib import Path
+import typing
 from natsort import natsorted
 import json
 
 from spikeinterface.extractors import NeuralynxRecordingExtractor
 from spikeinterface.core.old_api_utils import OldToNewRecording
-from spikeinterface import BaseRecording
 
 import spikeextractors as se
 
@@ -15,7 +14,7 @@ from ....utils import FolderPathType
 from ....utils.json_schema import dict_deep_update
 
 
-def get_common_metadata(extractors: list[NeuralynxRecordingExtractor]) -> dict:
+def get_common_metadata(extractors: typing.List[NeuralynxRecordingExtractor]) -> dict:
     """
     Parse the header of one of the .ncs files to get the session start time (without
     timezone) and the session_id.

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -128,7 +128,7 @@ class NeuralynxRecordingInterface(BaseRecordingExtractorInterface):
             n_segments = first_extractor.neo_reader.segment_count(block_index=0)
             extractors.append(first_extractor)
             for i in range(1, n_segments):
-                extractors.append(NeuralynxRecordingExtractor(filename=filename, seg_index=seg_index))
+                extractors.append(NeuralynxRecordingExtractor(filename=filename, seg_index=i))
         self.recording_extractor = self.RX(extractors)
 
         gains = [extractor.get_channel_gains()[0] for extractor in extractors]

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -29,7 +29,6 @@ def get_common_metadata(extractors: list[NeuralynxRecordingExtractor]) -> dict:
     """
 
     key_mapping = {
-        "recording_closed": "session_stop_time",
         "recording_opened": "session_start_time",
         "sessionUUID": "session_id",
     }

--- a/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/nwb_conversion_tools/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -28,12 +28,14 @@ def get_common_metadata(extractors: list[NeuralynxRecordingExtractor]) -> dict:
     dict
     """
 
-    key_mapping = {'recording_closed':'session_stop_time',
-                   'recording_opened': 'session_start_time',
-                   'sessionUUID': 'session_id'}
+    key_mapping = {
+        "recording_closed": "session_stop_time",
+        "recording_opened": "session_start_time",
+        "sessionUUID": "session_id",
+    }
 
     # check if neuralynx file header objects are present and use these for consensus extraction
-    if hasattr(extractors[0].neo_reader, 'file_headers'):
+    if hasattr(extractors[0].neo_reader, "file_headers"):
         headers = [list(e.neo_reader.file_headers.values())[0] for e in extractors]
         common_keys = list(set.intersection(*[set(h.keys()) for h in headers]))
         common_header = {k: headers[0][k] for k in common_keys if all([headers[0][k] == h[k] for h in headers])}
@@ -41,8 +43,8 @@ def get_common_metadata(extractors: list[NeuralynxRecordingExtractor]) -> dict:
     # use minimal set of metadata of first recording
     else:
         neo_annotations = extractors[0].neo_reader.raw_annotations
-        signal_info = neo_annotations['blocks'][0]['segments'][0]['signals'][0]
-        annotations = signal_info['__array_annotations__']
+        signal_info = neo_annotations["blocks"][0]["segments"][0]["signals"][0]
+        annotations = signal_info["__array_annotations__"]
         common_header = {k: annotations.get(k, None) for k in key_mapping}
 
         # # extraction of general metadata and remapping of of keys to nwb terms
@@ -54,20 +56,20 @@ def get_common_metadata(extractors: list[NeuralynxRecordingExtractor]) -> dict:
         common_header.setdefault(nwb_key, common_header.pop(neuralynx_key, None))
 
     # reformat session_start_time
-    start_time = common_header['session_start_time']
-    if hasattr(start_time, '__iter__') and len(start_time) == 1:
-        common_header['session_start_time'] = common_header['session_start_time'][0]
+    start_time = common_header["session_start_time"]
+    if hasattr(start_time, "__iter__") and len(start_time) == 1:
+        common_header["session_start_time"] = common_header["session_start_time"][0]
 
     # remove stop time metadata if not provided as None is an invalid default value
-    stop_time = common_header.get('session_stop_time', None)
+    stop_time = common_header.get("session_stop_time", None)
     if stop_time is None:
-        common_header.pop('session_stop_time')
-    elif hasattr(stop_time, '__iter__') and len(stop_time) == 1:
-        common_header['session_stop_time'] = common_header['session_stop_time'][0]
+        common_header.pop("session_stop_time")
+    elif hasattr(stop_time, "__iter__") and len(stop_time) == 1:
+        common_header["session_stop_time"] = common_header["session_stop_time"][0]
 
     # convert version objects back to string
-    if common_header.get('ApplicationVersion', None) is not None:
-        common_header['ApplicationVersion'] = str(common_header['ApplicationVersion'])
+    if common_header.get("ApplicationVersion", None) is not None:
+        common_header["ApplicationVersion"] = str(common_header["ApplicationVersion"])
 
     return common_header
 
@@ -87,13 +89,13 @@ def get_filtering(extractor: NeuralynxRecordingExtractor) -> str:
 
     # extracting filter annotations
     neo_annotations = extractor.neo_reader.raw_annotations
-    signal_info = neo_annotations['blocks'][0]['segments'][0]['signals'][0]
-    signal_annotations = signal_info['__array_annotations__']
-    filter_dict = {k: v for k, v in signal_annotations.items() if k.lower().startswith('dsp')}
+    signal_info = neo_annotations["blocks"][0]["segments"][0]["signals"][0]
+    signal_annotations = signal_info["__array_annotations__"]
+    filter_dict = {k: v for k, v in signal_annotations.items() if k.lower().startswith("dsp")}
 
     # conversion to string values
     for key, value in filter_dict.items():
-        filter_dict[key] = ' '.join(value)
+        filter_dict[key] = " ".join(value)
 
     filter_info = json.dumps(filter_dict, ensure_ascii=True)
 

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -236,7 +236,9 @@ class TestEcephysNwbConversions(unittest.TestCase):
                     member=interface_kwarg, container=converter.data_interface_objects["TestRecording"].source_data
                 )
         metadata = converter.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
+        metadata["NWBFile"].update(session_start_time=metadata["NWBFile"]["session_start_time"].astimezone())
+        if 'session_stop_time' in metadata["NWBFile"]:
+            metadata["NWBFile"].update(session_stop_time=metadata["NWBFile"]['session_stop_time'].astimezone())
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
         recording = converter.data_interface_objects["TestRecording"].recording_extractor
 

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -237,8 +237,8 @@ class TestEcephysNwbConversions(unittest.TestCase):
                 )
         metadata = converter.get_metadata()
         metadata["NWBFile"].update(session_start_time=metadata["NWBFile"]["session_start_time"].astimezone())
-        if 'session_stop_time' in metadata["NWBFile"]:
-            metadata["NWBFile"].update(session_stop_time=metadata["NWBFile"]['session_stop_time'].astimezone())
+        if "session_stop_time" in metadata["NWBFile"]:
+            metadata["NWBFile"].update(session_stop_time=metadata["NWBFile"]["session_stop_time"].astimezone())
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
         recording = converter.data_interface_objects["TestRecording"].recording_extractor
 

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -237,8 +237,6 @@ class TestEcephysNwbConversions(unittest.TestCase):
                 )
         metadata = converter.get_metadata()
         metadata["NWBFile"].update(session_start_time=metadata["NWBFile"]["session_start_time"].astimezone())
-        if "session_stop_time" in metadata["NWBFile"]:
-            metadata["NWBFile"].update(session_stop_time=metadata["NWBFile"]["session_stop_time"].astimezone())
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
         recording = converter.data_interface_objects["TestRecording"].recording_extractor
 


### PR DESCRIPTION
## Motivation

The complete neuralynx files (including the headers) are parsed by the neo neuralynxio and do not need to be loaded and parsed again using an alternative approach here. This PR benefits from the changes in https://github.com/NeuralEnsemble/python-neo/pull/1137, but also works with older versions of neo.

## How to test the behavior?
```
Check the NWB metadata when loading any neuralynx dataset. The essential session start time and identifier should be the same as before.
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/catalystneuro/nwb-conversion-tools/blob/master/docs/contribute.rst) document?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/nwb-conversion-tools/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
