### PR TITLE
testing CI from fork

### DIFF
--- a/tests/test_internals/test_tools.py
+++ b/tests/test_internals/test_tools.py
@@ -32,6 +32,9 @@ try:
         LOGGED_INTO_GLOBUS = False
 except ModuleNotFoundError:
     HAVE_GLOBUS, LOGGED_INTO_GLOBUS = False, False
+
+print("here - 1")
+print(os.environ)
 HAVE_DANDI_KEY = os.getenv("DANDI_API_KEY") is not None  # "DANDI_API_KEY" in os.environ
 
 
@@ -192,6 +195,8 @@ class TestAutomaticDANDIUpload(TestCase):
         reason="You must set your DANDI_API_KEY to run this test!",
     )
     def test_automatic_dandi_upload(self):
+        print("here - 2")
+        print(os.environ)
         automatic_dandi_upload(dandiset_id="200560", nwb_folder_path=self.nwb_folder_path, staging=True)
 
 

--- a/tests/test_internals/test_tools.py
+++ b/tests/test_internals/test_tools.py
@@ -32,10 +32,8 @@ try:
         LOGGED_INTO_GLOBUS = False
 except ModuleNotFoundError:
     HAVE_GLOBUS, LOGGED_INTO_GLOBUS = False, False
-
-print("here - 1")
-print(os.environ)
-HAVE_DANDI_KEY = os.getenv("DANDI_API_KEY") is not None  # "DANDI_API_KEY" in os.environ
+DANDI_API_KEY = os.getenv("DANDI_API_KEY")
+HAVE_DANDI_KEY = DANDI_API_KEY is not None and DANDI_API_KEY != ""  # can be "" from external forks
 
 
 class TestConversionTools(TestCase):
@@ -176,6 +174,10 @@ def test_estimate_total_conversion_runtime():
     ]
 
 
+@pytest.mark.skipif(
+    not HAVE_DANDI_KEY,
+    reason="You must set your DANDI_API_KEY to run this test!",
+)
 class TestAutomaticDANDIUpload(TestCase):
     def setUp(self):
         self.tmpdir = Path(mkdtemp())
@@ -190,16 +192,14 @@ class TestAutomaticDANDIUpload(TestCase):
     def tearDown(self):
         rmtree(self.tmpdir)
 
-    @unittest.skipIf(
-        not HAVE_DANDI_KEY,
-        reason="You must set your DANDI_API_KEY to run this test!",
-    )
     def test_automatic_dandi_upload(self):
-        print("here - 2")
-        print(os.environ)
         automatic_dandi_upload(dandiset_id="200560", nwb_folder_path=self.nwb_folder_path, staging=True)
 
 
+@pytest.mark.skipif(
+    not (HAVE_GLOBUS and LOGGED_INTO_GLOBUS),
+    reason="You must have globus installed and be logged in to run this test!",
+)
 class TestGlobusTransferContent(TestCase):
     def setUp(self):
         self.tmpdir = Path(mkdtemp())  # Globus has permission issues here apparently


### PR DESCRIPTION
Trying to figure out why some of these tests that don't need to run on external forks are failing skip based on identical environment variable retrieval attempts