### PR TITLE
Refactor write segmentation I 

### DIFF
--- a/src/nwb_conversion_tools/tools/roiextractors/__init__.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/__init__.py
@@ -1,6 +1,7 @@
 from .roiextractors import (
     get_nwb_imaging_metadata,
     add_devices,
+    add_imaging_plane,
     add_two_photon_series,
     add_epochs,
     write_imaging,

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -143,6 +143,21 @@ def add_devices(nwbfile: NWBFile, metadata: dict) -> NWBFile:
 
 
 def _create_imaging_plane_from_metadata(nwbfile: NWBFile, imaging_plane_metadata: dict) -> ImagingPlane:
+    """
+    Private auxiliar function to create an ImagingPlane object from pynwb using the imaging_plane_metadata
+    Parameters
+    ----------
+    nwbfile : NWBFile
+        An previously defined -in memory- NWBFile.
+
+    imaging_plane_metadata : dict
+        The metadata to create the ImagingPlane object.
+
+    Returns
+    -------
+    ImagingPlane
+        The created ImagingPlane.
+    """
 
     device_name = imaging_plane_metadata["device"]
     imaging_plane_metadata["device"] = nwbfile.devices[device_name]
@@ -156,9 +171,28 @@ def _create_imaging_plane_from_metadata(nwbfile: NWBFile, imaging_plane_metadata
     return imaging_plane
 
 
-def add_imaging_plane(nwbfile: NWBFile, metadata=dict, imaging_plane_index: int = 0) -> NWBFile:
+def add_imaging_plane(nwbfile: NWBFile, metadata: dict, imaging_plane_index: int = 0) -> NWBFile:
+    """
+    Adds the imaging plane specificied by the metadata to the nwb file.
+    The imaging plane that is added is the one located in metadata["Ophys"]["ImagingPlane"][imaging_plane_index]
 
-    # Set the defaults and required infraestructure
+    Parameters
+    ----------
+    nwbfile : NWBFile
+        An previously defined -in memory- NWBFile.
+    metadata : dict
+        The metadata in the nwb conversion tools format.
+    imaging_plane_index : int, optional
+        The metadata in the nwb conversion tools format is a list of the different imaging planes to add.
+        Specificy which element of the list with this parameter, by default 0
+
+    Returns
+    -------
+    NWBFile
+        The nwbfile passed as an input with the imaging plane added.
+    """
+
+    # Set the defaults and required infrastructure
     metadata_copy = deepcopy(metadata)
     default_metadata = get_default_ophys_metadata()
     metadata_copy = dict_deep_update(default_metadata, metadata_copy, append_list=False)

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -156,7 +156,7 @@ def _create_imaging_plane_from_metadata(nwbfile: NWBFile, imaging_plane_metadata
     return imaging_plane
 
 
-def add_imaging_plane(nwbfile: NWBFile, metadata=dict, plane_index: int = 0) -> NWBFile:
+def add_imaging_plane(nwbfile: NWBFile, metadata=dict, imaging_plane_index: int = 0) -> NWBFile:
 
     # Set the defaults and required infraestructure
     metadata_copy = deepcopy(metadata)
@@ -164,7 +164,7 @@ def add_imaging_plane(nwbfile: NWBFile, metadata=dict, plane_index: int = 0) -> 
     metadata_copy = dict_deep_update(default_metadata, metadata_copy, append_list=False)
     add_devices(nwbfile=nwbfile, metadata=metadata_copy)
 
-    imaging_plane_metadata = metadata_copy["Ophys"]["ImagingPlane"][plane_index]
+    imaging_plane_metadata = metadata_copy["Ophys"]["ImagingPlane"][imaging_plane_index]
     imaging_plane_name = imaging_plane_metadata["name"]
     existing_imaging_planes = nwbfile.imaging_planes
 

--- a/tests/test_internals/test_roi_extractors_module.py
+++ b/tests/test_internals/test_roi_extractors_module.py
@@ -2,6 +2,7 @@ from tempfile import mkdtemp
 import unittest
 from pathlib import Path
 from datetime import datetime
+from copy import deepcopy
 
 import numpy as np
 
@@ -9,7 +10,7 @@ from pynwb import NWBFile, NWBHDF5IO
 from pynwb.device import Device
 from roiextractors.testing import generate_dummy_imaging_extractor
 
-from nwb_conversion_tools.tools.roiextractors import add_devices, add_two_photon_series
+from nwb_conversion_tools.tools.roiextractors import add_devices, add_imaging_plane, add_two_photon_series
 
 
 class TestAddDevices(unittest.TestCase):
@@ -141,6 +142,92 @@ class TestAddDevices(unittest.TestCase):
         assert len(devices) == 2
         assert "device_metadata" in devices
         assert "device_object" in devices
+
+
+class TestAddImagingPlane(unittest.TestCase):
+    def setUp(self):
+        self.session_start_time = datetime.now().astimezone()
+        self.nwbfile = NWBFile(
+            session_description="session_description",
+            identifier="file_id",
+            session_start_time=self.session_start_time,
+        )
+
+        self.metadata = dict(Ophys=dict())
+
+        self.device_name = "optical_device"
+        self.device_metadata = dict(name=self.device_name)
+        self.metadata["Ophys"].update(Device=[self.device_metadata])
+
+        self.optical_channel_metadata = dict(
+            name="optical_channel",
+            emission_lambda=np.nan,
+            description="description",
+        )
+
+        self.imaging_plane_name = "imaging_plane_name"
+        self.imaging_plane_description = "imaging_plane_description"
+        self.imaging_plane_metadata = dict(
+            name=self.imaging_plane_name,
+            optical_channel=[self.optical_channel_metadata],
+            description=self.imaging_plane_description,
+            device=self.device_name,
+            excitation_lambda=np.nan,
+            indicator="unknown",
+            location="unknown",
+        )
+
+        self.metadata["Ophys"].update(ImagingPlane=[self.imaging_plane_metadata])
+
+    def test_add_imaging_plane(self):
+
+        add_imaging_plane(nwbfile=self.nwbfile, metadata=self.metadata)
+
+        imaging_planes = self.nwbfile.imaging_planes
+        assert len(imaging_planes) == 1
+        assert self.imaging_plane_name in imaging_planes
+
+        imaging_plane = imaging_planes[self.imaging_plane_name]
+        assert imaging_plane.description == self.imaging_plane_description
+
+    def test_not_overwriting_imaging_plane_if_same_name(self):
+
+        add_imaging_plane(nwbfile=self.nwbfile, metadata=self.metadata)
+
+        self.imaging_plane_metadata["description"] = "modified description"
+        add_imaging_plane(nwbfile=self.nwbfile, metadata=self.metadata)
+
+        imaging_planes = self.nwbfile.imaging_planes
+        assert len(imaging_planes) == 1
+        assert self.imaging_plane_name in imaging_planes
+
+    def test_add_two_imaging_planes(self):
+
+        # Add the first imaging plane
+        first_imaging_plane_name = "first_imaging_plane_name"
+        first_imaging_plane_description = "first_imaging_plane_description"
+        self.imaging_plane_metadata["name"] = first_imaging_plane_name
+        self.imaging_plane_metadata["description"] = first_imaging_plane_description
+        add_imaging_plane(nwbfile=self.nwbfile, metadata=self.metadata)
+
+        # Add the second imaging plane
+        second_imaging_plane_name = "second_imaging_plane_name"
+        second_imaging_plane_description = "second_imaging_plane_description"
+        self.imaging_plane_metadata["name"] = second_imaging_plane_name
+        self.imaging_plane_metadata["description"] = second_imaging_plane_description
+        add_imaging_plane(nwbfile=self.nwbfile, metadata=self.metadata)
+
+        # Test expected values
+        imaging_planes = self.nwbfile.imaging_planes
+        assert len(imaging_planes) == 2
+
+        first_imaging_plane = imaging_planes[first_imaging_plane_name]
+        assert first_imaging_plane.name == first_imaging_plane_name
+        assert first_imaging_plane.description == first_imaging_plane_description
+
+        second_imaging_plane = imaging_planes[second_imaging_plane_name]
+        assert second_imaging_plane.name == second_imaging_plane_name
+        assert second_imaging_plane.description == second_imaging_plane_description
 
 
 class TestAddTwoPhotonSeries(unittest.TestCase):


### PR DESCRIPTION
This is part of a join effort with @weiglszonja to refactor `write_segmentation` in the roiextractors module. This first PR does a couple of things:
1) It refactors the previously added function called `add_imaging_plane` and adds some unit tests.
2) The `add_imaging_plane` function is then used to refactor the `write_segmentation` function with some code reduction.
3) There are some other minor refactoring in documentation (add_device function) and style here and there. 