### PR TITLE
Refactor write segmentation II (use `add_devices`)

### DIFF
--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -596,8 +596,3 @@ def write_segmentation(
         if write:
             io.write(nwbfile)
             io.close()
-
-
-def add_summary_images(nwbfile: NWBFile, segmentation_extractor: SegmentationExtractor, metadata: dict):
-
-    pass


### PR DESCRIPTION
A continuation of #601 and chained to it:
1) Some minor modification in the add_device function so a device is not created again if it already exists.
2) Code reduction in `write_segmentation` by using the `add_device` function.
3) Eliminate code to add the subject in the `write_segmentation`
4) Make the default metadata more flat in its definition.

 