### PR TITLE
Refactor write segmentation III (add summary images)

### DIFF
--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -17,7 +17,7 @@ opencv-python==4.5.1.48
 spikeextractors==0.9.10
 spikeinterface>=0.94.0
 neo==0.10.2
-roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@add_dummy_segmentation_extractor_without_summary_images
+roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@155efa5d0597529b5b02a8ada633d8b0452ab1d7
 pyintan==0.3.0
 pyopenephys==1.1.2
 sonpy>=1.7.1

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -17,7 +17,7 @@ opencv-python==4.5.1.48
 spikeextractors==0.9.10
 spikeinterface>=0.94.0
 neo==0.10.2
-roiextractors==0.4.17
+roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@add_dummy_segmentation_extractor_without_summary_images
 pyintan==0.3.0
 pyopenephys==1.1.2
 sonpy>=1.7.1

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -12,7 +12,7 @@ dandi==0.39.6
 spikeextractors>=0.9.10
 spikeinterface>=0.94.0
 neo>=0.9.0
-roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@add_dummy_segmentation_extractor_without_summary_images
+roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@155efa5d0597529b5b02a8ada633d8b0452ab1d7
 lxml>=4.6.5
 scipy>=1.4.1
 click  # must be unspecified version to handle platform/pyVersion

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -12,7 +12,7 @@ dandi==0.39.6
 spikeextractors>=0.9.10
 spikeinterface>=0.94.0
 neo>=0.9.0
-roiextractors==0.4.17
+roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@add_dummy_segmentation_extractor_without_summary_images
 lxml>=4.6.5
 scipy>=1.4.1
 click  # must be unspecified version to handle platform/pyVersion

--- a/src/nwb_conversion_tools/tools/roiextractors/__init__.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/__init__.py
@@ -5,5 +5,6 @@ from .roiextractors import (
     add_epochs,
     write_imaging,
     get_nwb_segmentation_metadata,
+    add_summary_images,
     write_segmentation,
 )

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -378,7 +378,7 @@ def add_summary_images(
 ) -> NWBFile:
 
     images_dict = segmentation_extractor.get_images_dict()
-    images_to_add = {image_name: image for image_name, image in images_dict.items() if image is not None}
+    images_to_add = {img_name: img for img_name, img in images_dict.items() if img is not None}
     if not images_to_add:
         return nwbfile
 
@@ -392,9 +392,9 @@ def add_summary_images(
         ophys.add(Images(images_set_name))
     image_collection = ophys.data_interfaces[images_set_name]
 
-    for image_name, img in images_to_add.items():
+    for img_name, img in images_to_add.items():
         # Note that nwb uses the conversion width x heigth (columns, rows) and roiextractors uses the transpose
-        image_collection.add_image(GrayscaleImage(name=image_name, data=img.T))
+        image_collection.add_image(GrayscaleImage(name=img_name, data=img.T))
 
     return nwbfile
 

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -564,19 +564,9 @@ def write_segmentation(
                 if trace_name not in fluorescence.roi_response_series:
                     fluorescence.create_roi_response_series(**input_kwargs)
 
-        # create Two Photon Series:
-        if "TwoPhotonSeries" not in nwbfile.acquisition:
-            warn("could not find TwoPhotonSeries, using ImagingExtractor to create an nwbfile")
-        # adding images:
-        images_dict = segext_obj.get_images_dict()
-        if any([image is not None for image in images_dict.values()]):
-            images_name = "SegmentationImages" if plane_no_loop == 0 else f"SegmentationImages_Plane{plane_no_loop}"
-            if images_name not in ophys.data_interfaces:
-                images = Images(images_name)
-                for img_name, img_no in images_dict.items():
-                    if img_no is not None:
-                        images.add_image(GrayscaleImage(name=img_name, data=img_no.T))
-                ophys.add(images)
+        # Adding summary images (mean and correlation)
+        images_set_name = "SegmentationImages" if plane_no_loop == 0 else f"SegmentationImages_Plane{plane_no_loop}"
+        add_summary_images(nwbfile=nwbfile, segmentation_extractor=segext_obj, images_set_name=images_set_name)
 
         # saving NWB file:
         if write:

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -427,8 +427,25 @@ def get_nwb_segmentation_metadata(sgmextractor):
 
 
 def add_summary_images(
-    nwbfile: NWBFile, segmentation_extractor: SegmentationExtractor, images_set_name: str
+    nwbfile: NWBFile, segmentation_extractor: SegmentationExtractor, images_set_name: str = "summary_images"
 ) -> NWBFile:
+    """
+    Adds summary images (i.e. mean and correlation) to the nwbfile using an image container object pynwb.Image
+
+    Parameters
+    ----------
+    nwbfile : NWBFile
+        An previously defined -in memory- NWBFile.
+    segmentation_extractor : SegmentationExtractor
+        A segmentation extractor object from roiextractors.
+    images_set_name : str
+        The name of the image container, "summary_images" by default.
+
+    Returns
+    -------
+    NWBFile
+        The nwbfile passed as an input with the summary images added.
+    """
 
     images_dict = segmentation_extractor.get_images_dict()
     images_to_add = {img_name: img for img_name, img in images_dict.items() if img is not None}

--- a/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
+++ b/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py
@@ -639,7 +639,6 @@ def write_segmentation(
         images_set_name = "SegmentationImages" if plane_no_loop == 0 else f"SegmentationImages_Plane{plane_no_loop}"
         add_summary_images(nwbfile=nwbfile, segmentation_extractor=segext_obj, images_set_name=images_set_name)
 
-
         # saving NWB file:
         if write:
             io.write(nwbfile)

--- a/tests/test_internals/test_roi_extractors_module.py
+++ b/tests/test_internals/test_roi_extractors_module.py
@@ -261,9 +261,7 @@ class TestAddSummaryImages(unittest.TestCase):
 
     def test_add_sumary_images(self):
 
-        segmentation_extractor = generate_dummy_segmentation_extractor(
-            num_rows=10, num_columns=15, has_summary_images=True
-        )
+        segmentation_extractor = generate_dummy_segmentation_extractor(num_rows=10, num_columns=15)
 
         images_set_name = "images_set_name"
         add_summary_images(
@@ -280,6 +278,22 @@ class TestAddSummaryImages(unittest.TestCase):
         assert expected_images_dict.keys() == extracted_images_dict.keys()
         for image_name in expected_images_dict.keys():
             np.testing.assert_almost_equal(expected_images_dict[image_name], extracted_images_dict[image_name])
+
+    def test_extractor_with_no_summary_images(self):
+
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_rows=10, num_columns=15, has_summary_images=False
+        )
+
+        images_set_name = "images_set_name"
+        self.nwbfile.create_processing_module("ophys", "contains optical physiology processed data")
+
+        add_summary_images(
+            nwbfile=self.nwbfile, segmentation_extractor=segmentation_extractor, images_set_name=images_set_name
+        )
+
+        ophys = self.nwbfile.get_processing_module("ophys")
+        assert images_set_name not in ophys.data_interfaces
 
 
 if __name__ == "__main__":

--- a/tests/test_internals/test_roi_extractors_module.py
+++ b/tests/test_internals/test_roi_extractors_module.py
@@ -10,7 +10,12 @@ from pynwb import NWBFile, NWBHDF5IO
 from pynwb.device import Device
 from roiextractors.testing import generate_dummy_imaging_extractor, generate_dummy_segmentation_extractor
 
-from nwb_conversion_tools.tools.roiextractors import add_devices, add_imaging_plane, add_two_photon_series, add_summary_images
+from nwb_conversion_tools.tools.roiextractors import (
+    add_devices,
+    add_imaging_plane,
+    add_two_photon_series,
+    add_summary_images,
+)
 
 
 class TestAddDevices(unittest.TestCase):


### PR DESCRIPTION
This is related to #601 and #602

This PR deals with refactoring the part of the `write_segmentation` function that adds the summary images (mean and correlation). I refactored this by adding an extra function whose sole purpose is to perform this addition to nwb. I also added some tests for this newly introduced function.

Also removed an unnecessary warning statement that we had.

This requires the branch in the following PR in roiextractors:
https://github.com/catalystneuro/roiextractors/pull/179

The reason being that the dummy segmentation extractor required for testing is a recent addition and the latest commit (specified in the has) also added an option for having a dummy segmentation extractor without summary images. As this runs in both our internal and data tests it is required in both requirement files